### PR TITLE
basic resume support

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -75,7 +75,8 @@ Some parts of booster boot functionality can be modified with kernel boot parame
  * `rd.luks.name=$UUID=$NAME` similar to rd.luks.uuid parameter but also specifies the name used for the LUKS device opening.
  * `rd.luks.options=opt1,opt2` a comma-separated lists of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`.
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
- * `booster.debug=1` enable booster debug output. It is printed to console at the boot time. This feature might be useful to debug booster issues.
+* `resume={$PATH|UUID=$UUID|LABEL=$LABEL}` suspend-to-disk device. Like `root`, can be specified as a path to the block device, fs UUID, or a fs label.
+* `booster.debug=1` enable booster debug output. It is printed to console at the boot time. This feature might be useful to debug booster issues.
  * `quiet` option is opposite of `booster.debug` and reduces verbosity of the tool. It hides boot-time booster warnings. This option is ignored if `booster.debug` is set.
 
 ## DEBUGGING

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -75,8 +75,8 @@ Some parts of booster boot functionality can be modified with kernel boot parame
  * `rd.luks.name=$UUID=$NAME` similar to rd.luks.uuid parameter but also specifies the name used for the LUKS device opening.
  * `rd.luks.options=opt1,opt2` a comma-separated lists of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`.
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
-* `resume={$PATH|UUID=$UUID|LABEL=$LABEL}` suspend-to-disk device. Like `root`, can be specified as a path to the block device, fs UUID, or a fs label.
-* `booster.debug=1` enable booster debug output. It is printed to console at the boot time. This feature might be useful to debug booster issues.
+ * `resume={$PATH|UUID=$UUID|LABEL=$LABEL}` suspend-to-disk device. Like `root`, can be specified as a path to the block device, fs UUID, or a fs label.
+ * `booster.debug=1` enable booster debug output. It is printed to console at the boot time. This feature might be useful to debug booster issues.
  * `quiet` option is opposite of `booster.debug` and reduces verbosity of the tool. It hides boot-time booster warnings. This option is ignored if `booster.debug` is set.
 
 ## DEBUGGING


### PR DESCRIPTION
This adds basic support for parsing the resume kernel parameter and setting `/sys/power/resume` appropriately. It works for me, but I haven't tested all combinations of argument formats yet (e.g. a LABEL device selector) -- I wanted to get this PR in front of people early because it kinda feels like a general refactor of `devAdd` might be in order if this approach I'm taking is what we want.

Couple notes;
* I chose to add the resume handling to the `devAdd` handler, because that's also where luks handling that similarly needs to lookup devices lives. I'm not sure if this is the best approach -- seems like we could maybe do the resume handling after we've mounted the root volume, and just no-op if the device hasn't been added by that point?
* If doing this logic in the `devAdd` handler makes sense, it's currently a bit unwieldy because there are a few return points from the function, and currently it seems like we'd have to call the `resume` handler at each point. I'd love to discuss ways to refactor the function if necessary.
