### PR TITLE
Parse quoted UUID from cmdline

### DIFF
--- a/init/uuid_test.go
+++ b/init/uuid_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseUUIDFromRoot(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		cmdroot      string
+		expectedUUID string
+	}{
+		{
+			name:         "quoted uuid",
+			cmdroot:      "UUID=\"0d7b09a9-8928-4451-8037-21f7a329fed8\"",
+			expectedUUID: "0d7b09a9-8928-4451-8037-21f7a329fed8",
+		},
+		{
+			name:         "non-quoted uuid",
+			cmdroot:      "UUID=\"0d7b09a9-8928-4451-8037-21f7a329fed8\"",
+			expectedUUID: "0d7b09a9-8928-4451-8037-21f7a329fed8",
+		},
+		{
+			name:         "malformed uuid",
+			cmdroot:      "UUID=\"0d7b09a9-8928-4451-8037-21f7a329fed\"",
+			expectedUUID: "",
+		},
+		{
+			name:         "extra quoted uuid",
+			cmdroot:      "UUID=\"\"0d7b09a9-8928-4451-8037-21f7a329fed8\"\"",
+			expectedUUID: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, uuidParseTest(testCase.cmdroot, testCase.expectedUUID))
+	}
+}
+
+func uuidParseTest(cmdroot, expectedUUID string) func(t *testing.T) {
+	return func(t *testing.T) {
+		uuid := parseUUIDFromCmdRoot(cmdroot)
+		if uuid != expectedUUID {
+			t.Fatalf("expected uuid to be %s, but saw %s", expectedUUID, uuid)
+		}
+	}
+}


### PR DESCRIPTION
This pull requests attempts to partially remedy #6 

This change adds a `parseUUIDFromCmdRoot` function that parses the cmdroot UUID field and a set of tests for the logic
The change adds a regex for the UUID that allows a set of quotes around the UUID field to optionally be added. The regular expression expects a UUID in the [canonical format](https://en.wikipedia.org/wiki/Universally_unique_identifier#Format), 8-4-4-4-12. 

Since I don't have `root=UUID=""` filesystem using lux, I haven't been able to end-to-end test this on my machine, but happy to try to get a vm setup to attempt this if we think that's best.

Happy to make any changes wanted here if it seems this could be helpful.