### PR TITLE
Strip .smp_locks .rela.smp_locks from ELF

### DIFF
--- a/generator/image.go
+++ b/generator/image.go
@@ -136,7 +136,7 @@ func stripElf(name string, in []byte, stripAll bool) ([]byte, error) {
 	}
 	_ = t.Close()
 
-	args := []string{"-R", ".note.*", "-R", ".comment", "-R", ".go.buildinfo", "-R", ".gosymtab", "-R", "*__bug_table", "-R", "*orc_unwind*", "-R", ".BTF"}
+	args := []string{"-R", ".note.*", "-R", ".comment", "-R", ".go.buildinfo", "-R", ".gosymtab", "-R", "*__bug_table", "-R", "*orc_unwind*", "-R", ".BTF", "-R", "*smp_locks"}
 	if stripAll {
 		args = append(args, "--strip-all")
 	} else {


### PR DESCRIPTION
They seems related to Big Kernel Lock which is no longer exists.
closes #70