### PR TITLE
image: add workaround to deal with libraries located in /lib

### DIFF
--- a/generator/image.go
+++ b/generator/image.go
@@ -338,9 +338,18 @@ func (img *Image) AppendElfDependencies(ef *elf.File) error {
 		libs = append(libs, interp)
 	}
 
-	for _, p := range libs {
-		if !filepath.IsAbs(p) {
-			p = filepath.Join("/usr/lib", p)
+	for _, lib := range libs {
+		var p string
+		if filepath.IsAbs(lib) {
+			p = lib
+		} else {
+			p = filepath.Join("/usr/lib", lib)
+
+			// XXX: Workaround to support libraries located in /lib.
+			_, err := os.Open(p)
+			if os.IsNotExist(err) {
+				p = filepath.Join("/lib", lib)
+			}
 		}
 		err := img.AppendFile(p)
 		if err != nil {


### PR DESCRIPTION
While creating a booster package for Alpine Linux, I noticed that
booster assumes unconditionally that shared libraries are located in
/usr/lib. Contrary to Arch Linux, Alpine uses both /usr/lib and /lib.
For example, the shared library for our musl libc is located in /lib.

This patch adds a workaround which checks /lib (in addition to /usr/lib)
for shared libraries, if the library wasn't found in the latter. A proper
solution would probably be not hardcoding any library directories at all
but this should be fine for now until the comment in `AppendElfDependencies`
is addressed:

https://github.com/anatol/booster/blob/82f015198b46c08f4216152044487760260edbd7/generator/image.go#L324-L325