### PR TITLE
generator: re-use imageModulesDir constant

### DIFF
--- a/generator/config.go
+++ b/generator/config.go
@@ -133,7 +133,7 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 	if opts.BuildCommand.ModulesDirectory != "" {
 		conf.modulesDir = opts.BuildCommand.ModulesDirectory
 	} else {
-		conf.modulesDir = path.Join("/usr/lib/modules", conf.kernelVersion)
+		conf.modulesDir = path.Join(imageModulesDir, conf.kernelVersion)
 	}
 	conf.debug = opts.Verbose
 	conf.readDeviceAliases = readDeviceAliases


### PR DESCRIPTION
At Alpine Linux, Linux Kernel files are also located in /lib instead
of /usr/lib. For this reason, I patch the constants in config.go
accordingly for the Alpine Linux booster package. However, while working
on this I noticed that config.go does not re-use the imageModulesDir
constant. I think it makes sense to re-use it to not hardcode the path
twice.