### PR TITLE
generator: lookup executable paths using exec.LookPath

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -256,6 +256,11 @@ func (img *Image) appendExtraFiles(binaries []string) error {
 			if err != nil {
 				return err
 			}
+
+			if err := img.AppendFileTo(f, "/usr/bin"); err != nil {
+				return err
+			}
+			continue
 		}
 
 		if err := img.AppendFile(f); err != nil {


### PR DESCRIPTION
This fixes an issues I discovered on Alpine when attempting to use Booster's vconsole feature as the setfont executable is located in /usr/sbin on Alpine and hence the binary was not found successfully by the primitive lookup implementation previously provided by Booster. I think there should be no downside to using [`exec.Lookup`](https://pkg.go.dev/os/exec@go1.18#LookPath) hence proposing this for upstream inclusion. While at it, I also made use of [`filepath.IsAbs`](https://pkg.go.dev/path/filepath#IsAbs).

<!--
For example, to ensure that busybox is always added as `/bin/busybox` even if it originates in `/sbin/busybox` on the host:

https://github.com/anatol/booster/blob/edeff4c705d5f2b3a02162bed74626b70754ca63/init/main.go#L790-L796
-->