### PR TITLE
generator: Convert constants pointing to directory to variables

### DIFF
--- a/generator/console.go
+++ b/generator/console.go
@@ -14,7 +14,7 @@ import (
 )
 
 // path to console fonts, adjust it to your distro (e.g. Fedora uses /usr/lib/kbd/consolefonts path for it)
-const consolefontsDir = "/usr/share/kbd/consolefonts/"
+var consolefontsDir = "/usr/share/kbd/consolefonts/"
 
 func (img *Image) enableVirtualConsole(vConsolePath, localePath string) (*VirtualConsole, error) {
 	debug("enabling virtual console")

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -58,7 +58,7 @@ const (
 	netStatic
 )
 
-const (
+var (
 	imageModulesDir = "/usr/lib/modules/"
 	firmwareDir     = "/usr/lib/firmware/"
 )


### PR DESCRIPTION
This allows modifying their value via the `-X` flag provided by `go tool link`. This eases packaging of Booster as distributions which use different paths for these directories don't need to patch Booster but instead can set these variables using:

	go build --ldflags="-X main.consolefontsDir=/foo/bar/…"