### PR TITLE
ISSUE-73: Improved parser for cmdline parameters

### DIFF
--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -123,6 +123,7 @@ func getNextParam(params string, index int) (string, string, int) {
 			if (!keyComplete && len(key) > 0) || (keyComplete && len(value) > 0) {
 				// error, this quote is inside real characters
 				// we are going to recover as best we can, just copy the quote and hope for the best
+				warning("while parsing cmdline parameter unexpected \" found at %d, input may be malformed, attempting to proceed", index+i)
 				copyRune(r)
 				continue
 			}
@@ -160,6 +161,7 @@ func parseParams(params string) error {
 		switch key {
 		case "":
 			// probably trailing whitespace, just ignore it
+			warning("attempting to parse a parameter returned a blank key, cmdline may be malformed somewhere around %d", i)
 		case "booster.log":
 			for _, p := range strings.Split(value, ",") {
 				switch p {

--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -60,16 +60,15 @@ func getNextParam(params string, index int) (string, string, int) {
 	var inQuote = false     // indicates if we are within quotes
 	var escaping = false    // indicates if we read an escape character "\"
 	var copyMode = false    // indicates if we are copying runes yet (leading whitespace trim)
-	var key = ""
-	var value = ""
+	var key, value strings.Builder
 
 	// copy a given rune into the key or value, update copy mode if not set
 	var copyRune = func(r rune) {
 		copyMode = true
 		if !keyComplete {
-			key += string(r)
+			key.WriteRune(r)
 		} else {
-			value += string(r)
+			value.WriteRune(r)
 		}
 	}
 
@@ -97,7 +96,7 @@ func getNextParam(params string, index int) (string, string, int) {
 			// whitespace/null is end of a parse sequence if not in quotes
 			if !inQuote {
 				// return what we collected and give them the next rune to pass back
-				return key, value, index + i + 1
+				return key.String(), value.String(), index + i + 1
 			}
 
 			// if we are in quotes we just copy it through
@@ -112,7 +111,7 @@ func getNextParam(params string, index int) (string, string, int) {
 
 				// if we have parsed a key already this ends our parse too, otherwise continue as normal
 				if keyComplete {
-					return key, value, index + i + 1
+					return key.String(), value.String(), index + i + 1
 				}
 
 				continue
@@ -120,7 +119,7 @@ func getNextParam(params string, index int) (string, string, int) {
 
 			// if we are parsing a key, and it isn't empty, then something has gone wrong
 			// same for value
-			if (!keyComplete && len(key) > 0) || (keyComplete && len(value) > 0) {
+			if (!keyComplete && key.Len() > 0) || (keyComplete && value.Len() > 0) {
 				// error, this quote is inside real characters
 				// we are going to recover as best we can, just copy the quote and hope for the best
 				warning("while parsing cmdline parameter unexpected \" found at %d, input may be malformed, attempting to proceed", index+i)
@@ -145,7 +144,7 @@ func getNextParam(params string, index int) (string, string, int) {
 	}
 
 	// if we hit here return whatever we collected
-	return key, value, len(params)
+	return key.String(), value.String(), len(params)
 }
 
 func parseParams(params string) error {

--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -49,20 +49,94 @@ func parseCmdline() error {
 	return nil
 }
 
+// obtain the next key / value param from a params string starting at a given index
+// will return the key and value and the next offset to send for the next call
+// note that quotes will be removed after this step and new strings are returned
+// can handle "param=true", param="true", param=true, param="tr ue", "param=tr ue"
+//            "param=tr\"ue", "param=tr\nue", param=test=true, param="test=true"
+//            param1=true\nparam2=false
+func getNextParam(params string, index int) (string, string, int) {
+	var keyComplete = false // indicates if we are reading the key or value
+	var inQuote = false     // indicates if we are within quotes
+	var escaping = false    // indicates if we read an escape character "\"
+	var copyMode = false    // indicates if we are copying runes yet (leading whitespace trim)
+	var key = ""
+	var value = ""
+
+	// copy a given rune into the key or value, update copy mode if not set
+	var copyRune = func(r rune) {
+		copyMode = true
+		if !keyComplete {
+			key += string(r)
+		} else {
+			value += string(r)
+		}
+	}
+
+	// walk through each rune
+	for i, r := range params[index:] {
+		// if we are in escape mode just copy the next rune and move on
+		if copyMode && escaping {
+			copyRune(r)
+			escaping = false
+			continue
+		}
+
+		switch r {
+		case '\000', '\n', '\r', '\t', ' ':
+			// if we haven't seen any non-whitespace yet just continue
+			if !copyMode {
+				continue
+			}
+
+			// whitespace/null is end of a parse sequence if not in quotes
+			if !inQuote {
+				// return what we collected and give them the next rune to pass back
+				return key, value, index + i + 1
+			}
+
+			// if we are in quotes we just copy it through
+			copyRune(r)
+		case '\\':
+			// escaping something, update flag and move on
+			escaping = true
+		case '"':
+			// we changed quote mode
+			inQuote = !inQuote
+			// also now in copy mode if we were not already
+			copyMode = true
+		case '=':
+			// this separates key=value, but only while in key mode
+			if !keyComplete {
+				// done reading key, do nothing with the rune
+				keyComplete = true
+			} else {
+				// outside key mode just copy it through (value can have = in it)
+				copyRune(r)
+			}
+		default:
+			// anything else just copy and move on
+			copyRune(r)
+		}
+	}
+
+	// if we hit here return whatever we collected
+	return key, value, len(params)
+}
+
 func parseParams(params string) error {
 	var luksOptions []string
 
-	for _, part := range strings.Split(params, " ") {
-		var key, value string
-		// separate key/value based on the first = character;
-		// there may be multiple (e.g. in rd.luks.name)
-		if idx := strings.IndexByte(part, '='); idx > -1 {
-			key, value = part[:idx], part[idx+1:]
-		} else {
-			key = part
-		}
+	var key, value string
+	var i = 0
+
+	for i < len(params) {
+		// read the next param to examine and update for next round
+		key, value, i = getNextParam(params, i)
 
 		switch key {
+		case "":
+			// probably trailing whitespace, just ignore it
 		case "booster.log":
 			for _, p := range strings.Split(value, ",") {
 				switch p {

--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -83,6 +83,11 @@ func getNextParam(params string, index int) (string, string, int) {
 		}
 
 		switch r {
+		case '\\':
+			// now in copy mode if we were not already
+			copyMode = true
+			// escaping something, update flag and move on
+			escaping = true
 		case 0, '\n', '\r', '\t', ' ':
 			// if we haven't seen any non-whitespace yet just continue
 			if !copyMode {
@@ -97,9 +102,6 @@ func getNextParam(params string, index int) (string, string, int) {
 
 			// if we are in quotes we just copy it through
 			copyRune(r)
-		case '\\':
-			// escaping something, update flag and move on
-			escaping = true
 		case '"':
 			// now in copy mode if we were not already
 			copyMode = true

--- a/init/cmdline_test.go
+++ b/init/cmdline_test.go
@@ -86,12 +86,16 @@ func TestGetNextParam(t *testing.T) {
 		test{"param17=\"te\"st0\"", "param17", "te", 12},
 		// param18"=test0
 		test{"param18\"=test0", "param18\"", "test0", 14},
-		// =test0
-		test{"=test0", "", "test0", 6},
 		// param19=te\nst0
 		test{"param19=te\nst0", "param19", "te", 11},
 		// param20=test0\r
 		test{"param20=test0\r", "param20", "test0", 14},
+		// =test0 // This is a worst case bad junk input, it will return empty key
+		test{"=test0", "", "test0", 6},
+		// param21="test0 param22="test1" // This is a worst case bad junk input, it will mangle 21 and swallow 22
+		test{"param21=\"test0 param22=\"test1\"", "param21", "test0 param22=", 24},
+		// param23="test0 param24=test1 // This is a worst case bad junk input, it will mangle 23 and swallow 24
+		test{"param23=\"test0 param24=test1", "param23", "test0 param24=test1", 28},
 	}
 
 	for _, test := range tests {

--- a/init/cmdline_test.go
+++ b/init/cmdline_test.go
@@ -50,6 +50,8 @@ func TestGetNextParam(t *testing.T) {
 	}
 
 	var tests = []test{
+		// \param00=test0 // an odd case, but we will allow it
+		test{"\\param00=test0", "param00", "test0", 14},
 		// param01=test0
 		test{"param01=test0", "param01", "test0", 13},
 		// "param02=test0"

--- a/init/cmdline_test.go
+++ b/init/cmdline_test.go
@@ -51,53 +51,53 @@ func TestGetNextParam(t *testing.T) {
 
 	var tests = []test{
 		// \param00=test0 // an odd case, but we will allow it
-		test{"\\param00=test0", "param00", "test0", 14},
+		{"\\param00=test0", "param00", "test0", 14},
 		// param01=test0
-		test{"param01=test0", "param01", "test0", 13},
+		{"param01=test0", "param01", "test0", 13},
 		// "param02=test0"
-		test{"\"param02=test0\"", "param02", "test0", 15},
+		{"\"param02=test0\"", "param02", "test0", 15},
 		// param03="test0"
-		test{"param03=\"test0\"", "param03", "test0", 15},
+		{"param03=\"test0\"", "param03", "test0", 15},
 		// '   param04=test0   '
-		test{"   param04=test0   ", "param04", "test0", 17},
+		{"   param04=test0   ", "param04", "test0", 17},
 		// param05=te\0st
-		test{"param05=te\000st0", "param05", "te", 11},
+		{"param05=te\000st0", "param05", "te", 11},
 		// [tab]param06=test0[tab]
-		test{"\tparam06=test0\t", "param06", "test0", 15},
+		{"\tparam06=test0\t", "param06", "test0", 15},
 		// param07=te"st0
-		test{"param07=te\"st0", "param07", "te\"st0", 14},
+		{"param07=te\"st0", "param07", "te\"st0", 14},
 		// par"am08=test0
-		test{"par\"am08=test0", "par\"am08", "test0", 14},
+		{"par\"am08=test0", "par\"am08", "test0", 14},
 		// param09=test1=test2
-		test{"param09=test1=test2", "param09", "test1=test2", 19},
+		{"param09=test1=test2", "param09", "test1=test2", 19},
 		// param10=\"test1=test2\"
-		test{"param10=\"test1=test2\"", "param10", "test1=test2", 21},
+		{"param10=\"test1=test2\"", "param10", "test1=test2", 21},
 		// param11
-		test{"param11", "param11", "", 7},
+		{"param11", "param11", "", 7},
 		// "param12"
-		test{"\"param12\"", "param12", "", 9},
+		{"\"param12\"", "param12", "", 9},
 		// param13=
-		test{"param13=", "param13", "", 8},
+		{"param13=", "param13", "", 8},
 		// param14=te\ st0
-		test{"param14=te\\ st0", "param14", "te st0", 15},
+		{"param14=te\\ st0", "param14", "te st0", 15},
 		// param15="te\"st0"
-		test{"param15=\"te\\\"st0\"", "param15", "te\"st0", 17},
+		{"param15=\"te\\\"st0\"", "param15", "te\"st0", 17},
 		// param16=te"st0
-		test{"param16=te\"st0", "param16", "te\"st0", 14},
+		{"param16=te\"st0", "param16", "te\"st0", 14},
 		// param17="te"st0"
-		test{"param17=\"te\"st0\"", "param17", "te", 12},
+		{"param17=\"te\"st0\"", "param17", "te", 12},
 		// param18"=test0
-		test{"param18\"=test0", "param18\"", "test0", 14},
+		{"param18\"=test0", "param18\"", "test0", 14},
 		// param19=te\nst0
-		test{"param19=te\nst0", "param19", "te", 11},
+		{"param19=te\nst0", "param19", "te", 11},
 		// param20=test0\r
-		test{"param20=test0\r", "param20", "test0", 14},
+		{"param20=test0\r", "param20", "test0", 14},
 		// =test0 // This is a worst case bad junk input, it will return empty key
-		test{"=test0", "", "test0", 6},
+		{"=test0", "", "test0", 6},
 		// param21="test0 param22="test1" // This is a worst case bad junk input, it will mangle 21 and swallow 22
-		test{"param21=\"test0 param22=\"test1\"", "param21", "test0 param22=", 24},
+		{"param21=\"test0 param22=\"test1\"", "param21", "test0 param22=", 24},
 		// param23="test0 param24=test1 // This is a worst case bad junk input, it will mangle 23 and swallow 24
-		test{"param23=\"test0 param24=test1", "param23", "test0 param24=test1", 28},
+		{"param23=\"test0 param24=test1", "param23", "test0 param24=test1", 28},
 	}
 
 	for _, test := range tests {

--- a/init/deviceref.go
+++ b/init/deviceref.go
@@ -182,7 +182,7 @@ func parseDeviceRef(param string) (*deviceRef, error) {
 	if strings.HasPrefix(param, "UUID=") {
 		uuid := strings.TrimPrefix(param, "UUID=")
 
-		u, err := parseUUID(stripQuotes(uuid))
+		u, err := parseUUID(uuid)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse UUID parameter %s: %v", param, err)
 		}
@@ -190,7 +190,7 @@ func parseDeviceRef(param string) (*deviceRef, error) {
 	}
 	if strings.HasPrefix(param, "/dev/disk/by-uuid/") {
 		uuid := strings.TrimPrefix(param, "/dev/disk/by-uuid/")
-		u, err := parseUUID(stripQuotes(uuid))
+		u, err := parseUUID(uuid)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse UUID parameter %s: %v", param, err)
 		}
@@ -214,13 +214,13 @@ func parseDeviceRef(param string) (*deviceRef, error) {
 			if err != nil {
 				return nil, fmt.Errorf("unable to parse PARTNROFF= value %s", param)
 			}
-			u, err := parseUUID(stripQuotes(uuid))
+			u, err := parseUUID(uuid)
 			if err != nil {
 				return nil, fmt.Errorf("unable to parse UUID parameter %s: %v", param, err)
 			}
 			return &deviceRef{refGptUUIDPartoff, gptPartoffData{u, partnoff}}, nil
 		} else {
-			u, err := parseUUID(stripQuotes(uuid))
+			u, err := parseUUID(uuid)
 			if err != nil {
 				return nil, fmt.Errorf("unable to parse UUID parameter %s: %v", param, err)
 			}
@@ -229,7 +229,7 @@ func parseDeviceRef(param string) (*deviceRef, error) {
 	}
 	if strings.HasPrefix(param, "/dev/disk/by-partuuid/") {
 		uuid := strings.TrimPrefix(param, "/dev/disk/by-partuuid/")
-		u, err := parseUUID(stripQuotes(uuid))
+		u, err := parseUUID(uuid)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse UUID parameter %s: %v", param, err)
 		}

--- a/init/util.go
+++ b/init/util.go
@@ -85,16 +85,6 @@ func (uuid UUID) toString() string {
 	}
 }
 
-// stripQuotes removes leading and trailing quote symbols if they wrap the given sentence
-func stripQuotes(in string) string {
-	l := len(in)
-	if in[0] == '"' && in[l-1] == '"' {
-		return in[1 : l-1]
-	}
-
-	return in
-}
-
 func getKernelVersion() (string, error) {
 	var uts unix.Utsname
 	if err := unix.Uname(&uts); err != nil {

--- a/init/util_test.go
+++ b/init/util_test.go
@@ -72,21 +72,6 @@ func TestFormatUUID(t *testing.T) {
 	require.Equal(t, expected, uuid.toString())
 }
 
-func TestStripQuotes(t *testing.T) {
-	check := func(in, out string) {
-		str := stripQuotes(in)
-		require.Equal(t, out, str)
-	}
-
-	check("Hello", "Hello")
-	check("He\"llo", "He\"llo")
-	check("Hell o", "Hell o")
-	check("\"Hello", "\"Hello")
-	check("Hello\"", "Hello\"")
-	check("\"Hello\"", "Hello")
-	check("\"\"He   llo\"", "\"He   llo")
-}
-
 func TestDeviceNo(t *testing.T) {
 	dir, err := os.ReadDir("/sys/block")
 	require.NoError(t, err)


### PR DESCRIPTION
For #73 - Adding a more advanced parser to allow handling more complex cmdline parameters. This is based more on a 1 rune parse state machine style design, it iterates over each rune and makes a decision on what to do, copy/exit/change modes. Tried to leave enough comments to make it less confusing.

- This can split apart on any whitespace (null bytes, newlines, carriage returns,tabs, spaces)
- Quotes are handled and stripped from the strings
- Escaping quotes (or other chars) will copy them through
- Keys can't have an =, but values can get = chars in
- Whitespace is generally cleaned up

The design is around a single key/value enumeration approach, so it can be called until everything is processed. It handles some bad conditions ok, other things it might choke on. Worst case it outputs a bad chunk of data as the final result if the input is horribly out of spec/mangled. It generates new strings for each key/value it reads, using += assembly so not the best, but its a one shot deal so shouldn't be a huge deal.

I did not clean up some of the other code that could probably be removed by using this (such as the strip quotes in luks uuid, I believe this will allow that to be avoided as the quotes are removed through this.

I used the following string as test:
```
"    key=value   param=test=true param=\"test=true\"   test=tr\\\000ue double=equals=true \"param=tr ue\" \"param=yes\" param2=\"also yes\" quotes=\"escaped\\\"ooh\" ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS KEYBOARDTYPE=pc KEYTABLE=us\nLANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16\nrd_LVM_LV=VolGroup/lv_root rd_NO_DM rhgb quiet selinux=0"
```

Results: [ next token start, 'key parsed', 'value parsed' ]
```
        14      'key' = 'value'
        32      'param' = 'test=true'
        50      'param' = 'test=true'
        64      'test' = 'true'
        83      'double' = 'equals=true'
        97      'param' = 'tr ue'
        109     'param' = 'yes'
        127     'param2' = 'also yes'
        149     'quotes' = 'escaped"ooh'
        152     'ro' = ''
        186     'root' = '/dev/mapper/VolGroup-lv_root'
        197     'rd_NO_LUKS' = ''
        213     'KEYBOARDTYPE' = 'pc'
        225     'KEYTABLE' = 'us'
        242     'LANG' = 'en_US.UTF-8'
        251     'rd_NO_MD' = ''
        278     'rd_LVM_LV' = 'VolGroup/lv_swap'
        304     'SYSFONT' = 'latarcyrheb-sun16'
        340     'rd_NO_DM' = ''VolGroup/lv_root'
        345     'rhgb' = ''
        351     'quiet' = ''
        360     'selinux' = '0'
```