### PR TITLE
ISSUE-37: Allow luks unlocking via keyfile specified in kernel parameters with rd.luks.key

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -114,6 +114,7 @@ Some parts of booster boot functionality can be modified with kernel boot parame
  * `rootflags=$OPTIONS` mount options for the root filesystem, e.g. rootflags=user_xattr,nobarrier. In partition autodiscovery mode GPT attribute 60 ("read-only") is taken into account.
  * `rd.luks.uuid=$UUID` UUID of the LUKS partition where the root partition is enclosed. booster will try to unlock this LUKS device.
  * `rd.luks.name=$UUID=$NAME` similar to rd.luks.uuid parameter but also specifies the name used for the LUKS device opening.
+ * `rd.luks.key=$UUID=$PATH` absolute path to a keyfile in the initrd/initramfs which can be unsed to unlock the device identified by UUID, if this file does not exist or fails to unlock it will fall back to a password request.
  * `rd.luks.options=opt1,opt2` a comma-separated list of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`.
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
  * `resume=$deviceref` device reference to suspend-to-disk device.

--- a/init/main.go
+++ b/init/main.go
@@ -36,7 +36,7 @@ var (
 
 	initBinary = "/sbin/init" // path to init binary inside the user's chroot
 
-	luksMappings []luksMapping // list of LUKS devices that booster unlocked during boot process
+	luksMappings []*luksMapping // list of LUKS devices that booster unlocked during boot process
 
 	rootAutodiscoveryMode       bool
 	rootAutodiscoveryMountFlags uintptr // autodiscovery mode uses GPT attribute to configure mount flags


### PR DESCRIPTION
For #37: Add support to allow unlocking a luks volume by keyfile, reworked the luks mappings a little to allow more complex patterns of parsing parameters and building mappings.

This slightly tweaks creating luksMapping lists so they can occur multiple times in the kernel parameter list and it just updates the relevant properties for each mapping (to allow extending even further if desired).

- updated luksMapping type to hold a keyfile
- add a luksMapping findOrCreate function in luks.go, either finds the existing mapping by UUID or adds one
- update the rd.luks.uuid and rd.luks.name in cmdline.go to make use of findOrCreate 
- adds rd.luks.key with the format UUID=keyfile which should point to a file in initramfs containing the password
- adds recoverKeyfilePassword go routine which attempts to read the password from the keyfile and unlock the device, falling back to running the requestKeyboardPassword option if that fails
- update luksOpen to call recoverKeyfilePassword if a keyfile is defined on the mapping

Putting this forward more as an idea for the approach, not sure how good or bad the specific way I implemented it is.