### PR TITLE
Fix parsing errors when quotes are inside values

### DIFF
--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -60,11 +60,13 @@ func getNextParam(params string, index int) (string, string, int) {
 	inQuote := false     // indicates if we are within quotes
 	escaping := false    // indicates if we read an escape character "\"
 	copyMode := false    // indicates if we are copying runes yet (leading whitespace trim)
+	var lastRune rune
 	var key, value strings.Builder
 
 	// copy a given rune into the key or value, update copy mode if not set
 	copyRune := func(r rune) {
 		copyMode = true
+		lastRune = r
 		if !keyComplete {
 			key.WriteRune(r)
 		} else {
@@ -119,7 +121,7 @@ func getNextParam(params string, index int) (string, string, int) {
 
 			// if we are parsing a key, and it isn't empty, then something has gone wrong
 			// same for value
-			if (!keyComplete && key.Len() > 0) || (keyComplete && value.Len() > 0) {
+			if (!keyComplete && key.Len() > 0) || (keyComplete && value.Len() > 0 && lastRune != '=') {
 				// error, this quote is inside real characters
 				// we are going to recover as best we can, just copy the quote and hope for the best
 				warning("while parsing cmdline parameter unexpected \" found at %d, input may be malformed, attempting to proceed", index+i)

--- a/init/cmdline_test.go
+++ b/init/cmdline_test.go
@@ -50,63 +50,100 @@ func TestGetNextParam(t *testing.T) {
 	}
 
 	tests := []test{
-		// \param00=test0 // an odd case, but we will allow it
-		{"\\param00=test0", "param00", "test0", 14},
-		// param01=test0
-		{"param01=test0", "param01", "test0", 13},
-		// "param02=test0"
-		{"\"param02=test0\"", "param02", "test0", 15},
-		// param03="test0"
-		{"param03=\"test0\"", "param03", "test0", 15},
-		// '   param04=test0   '
-		{"   param04=test0   ", "param04", "test0", 17},
-		// param05=te\0st
-		{"param05=te\000st0", "param05", "te", 11},
-		// [tab]param06=test0[tab]
-		{"\tparam06=test0\t", "param06", "test0", 15},
-		// param07=te"st0
-		{"param07=te\"st0", "param07", "te\"st0", 14},
-		// par"am08=test0
-		{"par\"am08=test0", "par\"am08", "test0", 14},
-		// param09=test1=test2
-		{"param09=test1=test2", "param09", "test1=test2", 19},
-		// param10=\"test1=test2\"
-		{"param10=\"test1=test2\"", "param10", "test1=test2", 21},
+		// \param00=test00 // an odd case, but we will allow it
+		{"\\param00=test00", "param00", "test00", 15},
+		// param01=test01
+		{"param01=test01", "param01", "test01", 14},
+		// "param02=test02"
+		{"\"param02=test02\"", "param02", "test02", 16},
+		// param03="test03"
+		{"param03=\"test03\"", "param03", "test03", 16},
+		// '   param04=test04   '
+		{"   param04=test04   ", "param04", "test04", 18},
+		// param05=te\0st05
+		{"param05=te\000st05", "param05", "te", 11},
+		// [tab]param06=test06[tab]
+		{"\tparam06=test06\t", "param06", "test06", 16},
+		// param07=te"st07
+		{"param07=te\"st07", "param07", "te\"st07", 15},
+		// par"am08=test08
+		{"par\"am08=test08", "par\"am08", "test08", 15},
+		// param09=test09=test10
+		{"param09=test09=test10", "param09", "test09=test10", 21},
+		// param10=\"test11=test12\"
+		{"param10=\"test11=test12\"", "param10", "test11=test12", 23},
 		// param11
 		{"param11", "param11", "", 7},
 		// "param12"
 		{"\"param12\"", "param12", "", 9},
 		// param13=
 		{"param13=", "param13", "", 8},
-		// param14=te\ st0
-		{"param14=te\\ st0", "param14", "te st0", 15},
-		// param15="te\"st0"
-		{"param15=\"te\\\"st0\"", "param15", "te\"st0", 17},
-		// param16=te"st0
-		{"param16=te\"st0", "param16", "te\"st0", 14},
-		// param17="te"st0"
-		{"param17=\"te\"st0\"", "param17", "te", 12},
-		// param18"=test0
-		{"param18\"=test0", "param18\"", "test0", 14},
-		// param19=te\nst0
-		{"param19=te\nst0", "param19", "te", 11},
-		// param20=test0\r
-		{"param20=test0\r", "param20", "test0", 14},
-		// =test0 // This is a worst case bad junk input, it will return empty key
-		{"=test0", "", "test0", 6},
-		// param21="test0 param22="test1" // This is a worst case bad junk input, it will mangle 21 and swallow 22
-		{"param21=\"test0 param22=\"test1\"", "param21", "test0 param22=", 24},
-		// param23="test0 param24=test1 // This is a worst case bad junk input, it will mangle 23 and swallow 24
-		{"param23=\"test0 param24=test1", "param23", "test0 param24=test1", 28},
+		// param14=te\ st14
+		{"param14=te\\ st14", "param14", "te st14", 16},
+		// param15="te\"st15"
+		{"param15=\"te\\\"st15\"", "param15", "te\"st15", 18},
+		// param16=te"st16
+		{"param16=te\"st16", "param16", "te\"st16", 15},
+		// param17="te"st17"
+		{"param17=\"te\"st17\"", "param17", "te", 12},
+		// param18"=test18
+		{"param18\"=test18", "param18\"", "test18", 15},
+		// param19=te\nst19
+		{"param19=te\nst19", "param19", "te", 11},
+		// param20=test20\r
+		{"param20=test20\r", "param20", "test20", 15},
+		// =test21 // This is a worst case bad junk input, it will return empty key
+		{"=test21", "", "test21", 7},
+		// param22="test22 param23="test23" // This is a worst case bad junk input, it will mangle 22 and swallow 23
+		{"param22=\"test22 param23=\"test23\"", "param22", "test22 param23=", 25},
+		// param24="test24 param25=test25 // This is a worst case bad junk input, it will mangle 24 and swallow 25
+		{"param24=\"test24 param25=test25", "param24", "test24 param25=test25", 30},
 	}
 
 	for _, test := range tests {
 		var k, v string
 		var i int
 
+		t.Log("Testing ", test.input, "\n")
 		k, v, i = getNextParam(test.input, 0)
 		require.Equal(t, test.outKey, k)
 		require.Equal(t, test.outValue, v)
 		require.Equal(t, test.outIndex, i)
+	}
+}
+
+func TestGetNextParamMulti(t *testing.T) {
+	type testOutput struct {
+		outKey   string
+		outValue string
+		outIndex int
+	}
+
+	type multiTest struct {
+		input  string
+		output []testOutput
+	}
+
+	tests := []multiTest{
+		{
+			"rd.luks.uuid=\"639b8fdd-36ba-443e-be3e-e5b335935502\" root=UUID=\"7bbf9363-eb42-4476-8c1c-9f1f4d091385\"",
+			[]testOutput{
+				{"rd.luks.uuid", "639b8fdd-36ba-443e-be3e-e5b335935502", 51},
+				{"root", "UUID=7bbf9363-eb42-4476-8c1c-9f1f4d091385", 100},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		var k, v string
+		i := 0
+
+		t.Log("Testing ", test.input)
+		for _, output := range test.output {
+			k, v, i = getNextParam(test.input, i)
+			require.Equal(t, output.outKey, k)
+			require.Equal(t, output.outValue, v)
+			require.Equal(t, output.outIndex, i)
+		}
 	}
 }


### PR DESCRIPTION
For: https://github.com/anatol/booster/issues/73#issuecomment-1210899737

The parser is missing an edge case for quotes within values, which could be technically valid. This allows those conditions to pass successfully while keeping everything cleaned up as before. This is a very minimal modification to account for the condition. 

For now the error condition is reduced to allow quotes if they follow an equals sign. This allows the test case to work, but would still catch more unusual edge cases. If more conditions that need to allow quotes within sub-strings are needed the restriction on the quotes in values side can be removed to allow a better behavioral handle.

- Fixing parsing error that happens when quotes are deeper into values in key=value checks. IE: `key=UUID="test"`
- Update tests to account for coving the extra cases.
- Updated test cases to have better combinations to make looking for test failures easier
- Added an extra test for multi-parameter testing and validation, specifically putting in the failing luks test for now