### PR TITLE
Changed modules directory from /usr/lib/modules to /lib/modules

### DIFF
--- a/init/module.go
+++ b/init/module.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const imageModulesDir = "/usr/lib/modules"
+const imageModulesDir = "/lib/modules"
 
 var (
 	loadedModules    = make(map[string]bool)


### PR DESCRIPTION
In the Linux kernel, the default modules directory is `/lib/modules` rather than `/usr/lib/modules`. The reason the current code works on many distros, such as Arch Linux, Fedora and Debian, is that these distribution have merged the members `/usr` directory with their root equivalents ([Arch merge](https://archlinux.org/news/the-lib-directory-becomes-a-symlink/); [Fedora merge](url); [Debian merge](https://wiki.debian.org/UsrMerge)). However, not all distros have performed this merge (like Gentoo), and the [FHS](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html) still regards them as separate.

This proposed commit will preserve current behaviours on systems with a `usrmerge` hierarchy (as the symlink will just be followed); will now act correctly on systems without a `usrmerge`  and where `usr` does not sit on a separate partition; and will open up the possibility of extending support to those systems without a `usrmerge` and with separate `usr` partitions.

Further reading if interested: [1](https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/), [2](https://freedesktop.org/wiki/Software/systemd/separate-usr-is-broken/), [3](https://lwn.net/Articles/890219/).