### PR TITLE
Deduplicated check in TestExtraFiles

### DIFF
--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -419,7 +419,7 @@ func TestExtraFiles(t *testing.T) {
 	files := []string{"e", "q", "z"}
 	d := t.TempDir()
 	for _, f := range files {
-		require.NoError(t, os.WriteFile(d+"/"+f, []byte{}, 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(d, f), []byte{}, 0o644))
 	}
 
 	opts := options{
@@ -429,10 +429,10 @@ func TestExtraFiles(t *testing.T) {
 	createTestInitRamfs(t, &opts)
 
 	for _, f := range []string{"/usr/bin/true", "/usr/bin/false"} {
-		checkFileExistence(t, opts.workDir+"/image.unpacked"+f)
+		checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked", f))
 	}
 
-	checkDirListing(t, opts.workDir+"/image.unpacked/"+d, files...)
+	checkDirListing(t, filepath.Join(opts.workDir, "/image.unpacked/", d), files...)
 }
 
 func TestInvalidExtraFiles(t *testing.T) {

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -429,13 +429,9 @@ func TestExtraFiles(t *testing.T) {
 	createTestInitRamfs(t, &opts)
 
 	for _, f := range []string{"/usr/bin/true", "/usr/bin/false"} {
-		_, err := os.Stat(opts.workDir + "/image.unpacked" + f)
-		require.NoError(t, err)
-
+		checkFileExistence(t, opts.workDir+"/image.unpacked"+f)
 	}
 
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/bin/true")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/bin/false")
 	checkDirListing(t, opts.workDir+"/image.unpacked/"+d, files...)
 }
 


### PR DESCRIPTION
In `TestExtraFiles` in `generator_test.go`, a `stat` check was being performed twice --- once inside the `for` loop and then again afterwards with calls to `checkFileExistence`. Have deleted the latter checks and converted the check inside the `for` loop to a call to `checkFIleExistence`. Also converted string concatenation of paths to calls to `filepath.Join`.