### PR TITLE
Tweaked symlinks so unpacked paths point to correct locations

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -243,16 +243,16 @@ func generateInitRamfs(conf *generatorConfig) error {
 // appendCompatibilitySymlinks appends symlinks for compatibility with older firmware that loads extra files from non-standard locations
 func appendCompatibilitySymlinks(img *Image) error {
 	symlinks := []struct{ src, target string }{
-		{"/lib", "/usr/lib"},
-		{"/usr/local/lib", "/usr/lib"},
-		{"/usr/sbin", "/usr/bin"},
-		{"/bin", "/usr/bin"},
-		{"/sbin", "/usr/bin"},
-		{"/usr/local/bin", "/usr/bin"},
-		{"/usr/local/sbin", "/usr/bin"},
-		{"/var/run", "/run"},
-		{"/usr/lib64", "/usr/lib"},
-		{"/lib64", "/usr/lib"},
+		{"/lib", "usr/lib"},
+		{"/usr/local/lib", "usr/lib"},
+		{"/usr/sbin", "usr/bin"},
+		{"/bin", "usr/bin"},
+		{"/sbin", "usr/bin"},
+		{"/usr/local/bin", "usr/bin"},
+		{"/usr/local/sbin", "usr/bin"},
+		{"/var/run", "run"},
+		{"/usr/lib64", "usr/lib"},
+		{"/lib64", "usr/lib"},
 	}
 
 	for _, l := range symlinks {


### PR DESCRIPTION
Currently, in the `generator` test suite, I have several tests failing, including ` TestExtraFiles`, ` TestEnableVirtualConsole`, `TestEnableVirtualConsoleWithoutLocaleConf`. This seems to be because the symlinks are currently set up to point to the root directory. Whilst this is fine when used in practice as an initramfs, it means that when unpacked, it points to the root directory of the host machine (which is not the intended effect). Removing the leading slash makes the test suite pass, and the resulting image remains bootable.