### PR TITLE
Changed kernel modules/firmware directories from /usr/lib/ to /lib/; also tidied Arch packaging scripts in the process

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -43,7 +43,7 @@ Booster advantages:
  * `universal` is a boolean flag that tells booster to generate a universal image. By default booster generates a host-specific image that includes kernel modules used at the current host. For example if the host does not have a TPM2 chip then tpm modules are ignored. Universal image includes many kernel modules and tools that might be needed at a broad range of hardware configurations.
 
  * `modules` is a comma-separated list of extra modules to add to or remove from the generated image.
-    One can use a module name or a path relative to the modules dir (/usr/lib/modules/$KERNEL_VERSION).
+    One can use a module name or a path relative to the modules dir (`/lib/modules/$KERNEL_VERSION`).
     The compression algorithm suffix (e.g. ".xz", ".gz) can be omitted from the module filename.
     If the element starts with a minus sign (`-`) then it means "do not add it to the image", otherwise modules are added.
     If the path ends with a slash symbol (/) then it is considered a directory and all modules from this directory need to be added recursively.
@@ -171,9 +171,9 @@ If the element starts with minus sign `-` then it removes given modules from the
 If the element is a module name then this module is added/removed. Note that by convention a kernel module name can be computed from its filename by replacing all dashes to underscore, e.g.
 For the module `hid-apple.ko.gz` name will be `hid_apple`.
 
-If the element is a path to the module file relative to `/usr/lib/modules/$KERNEL_VERSION` then the module is added/removed. Note that the compression algorithm suffix can be omitted from the module filename.
+If the element is a path to the module file relative to `/lib/modules/$KERNEL_VERSION` then the module is added/removed. Note that the compression algorithm suffix can be omitted from the module filename.
 
-If the element ends with the slash symbol `/` then this element is considered a directory relative to `/usr/lib/modules/$KERNEL_VERSION`.
+If the element ends with the slash symbol `/` then this element is considered a directory relative to `/lib/modules/$KERNEL_VERSION`.
 Booster goes over this directory recursively and adds/removes the modules to the image. Minus sign can be used with the directories.
 
 Star symbol `*` is a shortcut for "all modules", it can be used to add all modules or remove all modules from the image.

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -62,8 +62,8 @@ const (
 )
 
 var (
-	imageModulesDir = "/usr/lib/modules/"
-	firmwareDir     = "/usr/lib/firmware/"
+	imageModulesDir = "/lib/modules/"
+	firmwareDir     = "/lib/firmware/"
 )
 
 // This is default modules list checked by booster. It either specifies a name of the module

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -324,9 +324,9 @@ func TestUniversalMode(t *testing.T) {
 	require.Equal(t, "matestkernel", cfg.Kernel)
 
 	// all except kernel/testfoo.ko need to be in the image
-	checkDirListing(t, opts.workDir+"/image.unpacked/usr/lib/modules/", "foo.ko", "cbc.ko", "virtio_scsi.ko", "booster.alias")
+	checkDirListing(t, filepath.Join(opts.workDir, "/image.unpacked/lib/modules/"), "foo.ko", "cbc.ko", "virtio_scsi.ko", "booster.alias")
 
-	aliasesFile, err := os.ReadFile(opts.workDir + "/image.unpacked/usr/lib/modules/booster.alias")
+	aliasesFile, err := os.ReadFile(filepath.Join(opts.workDir, "/image.unpacked/lib/modules/booster.alias"))
 	require.NoError(t, err)
 
 	expectedAliases := `pci:v*d*sv*sd*bc0Csc03i30* cbc
@@ -335,9 +335,9 @@ cpu:type:x86,ven*fam*mod*:feature:*0081* cbc
 `
 	require.Equal(t, expectedAliases, string(aliasesFile))
 
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/whiteheat.fw.xz")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/usbdux_firmware.bin.xz")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/rtw88/rtw8723d_fw.bin.xz")
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/whiteheat.fw.xz"))
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/usbdux_firmware.bin.xz"))
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/rtw88/rtw8723d_fw.bin.xz"))
 }
 
 func TestSoftDependencies(t *testing.T) {
@@ -352,7 +352,7 @@ func TestSoftDependencies(t *testing.T) {
 	createTestInitRamfs(t, &opts)
 
 	// all except kernel/testfoo.ko need to be in the image
-	checkDirListing(t, opts.workDir+"/image.unpacked/usr/lib/modules/", "foo.ko", "a.ko", "b.ko", "c.ko", "d.ko", "booster.alias")
+	checkDirListing(t, filepath.Join(opts.workDir, "/image.unpacked/lib/modules/"), "foo.ko", "a.ko", "b.ko", "c.ko", "d.ko", "booster.alias")
 }
 
 func TestComplexPatterns(t *testing.T) {
@@ -367,7 +367,7 @@ func TestComplexPatterns(t *testing.T) {
 	createTestInitRamfs(t, &opts)
 
 	// all except kernel/testfoo.ko need to be in the image
-	checkDirListing(t, opts.workDir+"/image.unpacked/usr/lib/modules/", "booster.alias", "k4.ko", "k5.ko", "k7_1.ko")
+	checkDirListing(t, filepath.Join(opts.workDir, "/image.unpacked/lib/modules/"), "booster.alias", "k4.ko", "k5.ko", "k7_1.ko")
 }
 
 func TestHostMode(t *testing.T) {
@@ -394,9 +394,9 @@ func TestHostMode(t *testing.T) {
 	createTestInitRamfs(t, &opts)
 
 	// all except kernel/testfoo.ko need to be in the image
-	checkDirListing(t, opts.workDir+"/image.unpacked/usr/lib/modules/", "cbc.ko", "virtio_scsi.ko", "booster.alias")
+	checkDirListing(t, filepath.Join(opts.workDir, "/image.unpacked/lib/modules/"), "cbc.ko", "virtio_scsi.ko", "booster.alias")
 
-	aliasesFile, err := os.ReadFile(opts.workDir + "/image.unpacked/usr/lib/modules/booster.alias")
+	aliasesFile, err := os.ReadFile(filepath.Join(opts.workDir, "/image.unpacked/lib/modules/booster.alias"))
 	require.NoError(t, err)
 
 	expectedAliases := `cpu:type:x86,ven*fam*mod*:feature:*0081* cbc
@@ -410,9 +410,9 @@ pci:v*d*sv*sd*bc0Csc03i30* cbc`
 
 	require.Equal(t, expectedAliases, sortedAliases)
 
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/whiteheat.fw.xz")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/usbdux_firmware.bin.xz")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/rtw88/rtw8723d_fw.bin.xz")
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/whiteheat.fw.xz"))
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/usbdux_firmware.bin.xz"))
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/rtw88/rtw8723d_fw.bin.xz"))
 }
 
 func TestExtraFiles(t *testing.T) {
@@ -454,19 +454,19 @@ func TestCompressedModules(t *testing.T) {
 	}
 	createTestInitRamfs(t, &opts)
 
-	checkDirListing(t, opts.workDir+"/image.unpacked/usr/lib/modules/", "plain.ko", "zst.ko", "xz.ko", "lz4.ko", "gz.ko", "booster.alias")
+	checkDirListing(t, filepath.Join(opts.workDir, "/image.unpacked/lib/modules/"), "plain.ko", "zst.ko", "xz.ko", "lz4.ko", "gz.ko", "booster.alias")
 	checkFilesEqual(t,
 		"assets/test_module.ko",
-		opts.workDir+"/image.unpacked/usr/lib/modules/plain.ko",
-		opts.workDir+"/image.unpacked/usr/lib/modules/zst.ko",
-		opts.workDir+"/image.unpacked/usr/lib/modules/xz.ko",
-		opts.workDir+"/image.unpacked/usr/lib/modules/lz4.ko",
-		opts.workDir+"/image.unpacked/usr/lib/modules/gz.ko",
+		filepath.Join(opts.workDir, "/image.unpacked/lib/modules/plain.ko"),
+		filepath.Join(opts.workDir, "/image.unpacked/lib/modules/zst.ko"),
+		filepath.Join(opts.workDir, "/image.unpacked/lib/modules/xz.ko"),
+		filepath.Join(opts.workDir, "/image.unpacked/lib/modules/lz4.ko"),
+		filepath.Join(opts.workDir, "/image.unpacked/lib/modules/gz.ko"),
 	)
 
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/whiteheat.fw.xz")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/usbdux_firmware.bin.xz")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/rtw88/rtw8723d_fw.bin.xz")
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/whiteheat.fw.xz"))
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/usbdux_firmware.bin.xz"))
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/rtw88/rtw8723d_fw.bin.xz"))
 }
 
 func TestModuleNameAliases(t *testing.T) {
@@ -477,12 +477,12 @@ func TestModuleNameAliases(t *testing.T) {
 	}
 	createTestInitRamfs(t, &opts)
 
-	checkDirListing(t, opts.workDir+"/image.unpacked/usr/lib/modules/", "zst.ko", "xz.ko", "gz.ko", "booster.alias")
+	checkDirListing(t, filepath.Join(opts.workDir, "/image.unpacked/lib/modules/"), "zst.ko", "xz.ko", "gz.ko", "booster.alias")
 	checkFilesEqual(t,
 		"assets/test_module.ko",
-		opts.workDir+"/image.unpacked/usr/lib/modules/zst.ko",
-		opts.workDir+"/image.unpacked/usr/lib/modules/xz.ko",
-		opts.workDir+"/image.unpacked/usr/lib/modules/gz.ko",
+		filepath.Join(opts.workDir, "/image.unpacked/lib/modules/zst.ko"),
+		filepath.Join(opts.workDir, "/image.unpacked/lib/modules/xz.ko"),
+		filepath.Join(opts.workDir, "/image.unpacked/lib/modules/gz.ko"),
 	)
 }
 
@@ -495,9 +495,9 @@ func TestStripBinaries(t *testing.T) {
 	}
 	createTestInitRamfs(t, &opts)
 
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/whiteheat.fw.xz")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/usbdux_firmware.bin.xz")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/rtw88/rtw8723d_fw.bin.xz")
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/whiteheat.fw.xz"))
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/usbdux_firmware.bin.xz"))
+	checkFileExistence(t, filepath.Join(opts.workDir, "/image.unpacked/lib/firmware/rtw88/rtw8723d_fw.bin.xz"))
 }
 
 func TestEnableVirtualConsole(t *testing.T) {

--- a/generator/kmod.go
+++ b/generator/kmod.go
@@ -25,7 +25,7 @@ type alias struct {
 type Kmod struct {
 	universal         bool // if false - include modules for current host only
 	kernelVersion     string
-	hostModulesDir    string // host path to modules e.g. /usr/lib/modules/5.9.9-arch1-1, note that image path is always /usr/lib/modules
+	hostModulesDir    string // host path to modules e.g. /lib/modules/5.9.9-arch1-1, note that image path is always /lib/modules
 	nameToPathMapping *Bimap // kernel module name to path (relative to modulesDir)
 	builtinModules    set
 	requiredModules   set                 // set of modules that we need to be added to the image

--- a/generator/kmod_test.go
+++ b/generator/kmod_test.go
@@ -28,7 +28,7 @@ func TestModuleNames(t *testing.T) {
 	conf := &generatorConfig{
 		universal:           true,
 		kernelVersion:       ver,
-		modulesDir:          "/usr/lib/modules/" + ver,
+		modulesDir:          filepath.Join("/lib/modules/", ver),
 		readHostModules:     readHostModules,
 		readDeviceAliases:   readDeviceAliases,
 		readModprobeOptions: readModprobeOptions,
@@ -164,7 +164,7 @@ func TestReadBuiltinModinfo(t *testing.T) {
 	ver, err := readKernelVersion()
 	require.NoError(t, err)
 
-	fws, err := readBuiltinModinfo("/usr/lib/modules/"+ver, "file")
+	fws, err := readBuiltinModinfo(filepath.Join("/lib/modules/", ver), "file")
 	require.NoError(t, err)
 
 	_ = fws

--- a/generator/main.go
+++ b/generator/main.go
@@ -20,7 +20,7 @@ var opts struct {
 		InitBinary       string `long:"init-binary" default:"/usr/lib/booster/init" description:"Booster 'init' binary location"`
 		Compression      string `long:"compression" choice:"zstd" choice:"gzip" choice:"xz" choice:"lz4" choice:"none" description:"Output file compression"`
 		KernelVersion    string `long:"kernel-version" description:"Linux kernel version to generate initramfs for"`
-		ModulesDirectory string `long:"modules-dir" description:"Directory with kernel modules, if not set then /usr/lib/modules/$kernel-version is used"`
+		ModulesDirectory string `long:"modules-dir" description:"Directory with kernel modules, if not set then /lib/modules/$kernel-version is used"`
 		ConfigFile       string `long:"config" default:"/etc/booster.yaml" description:"Configuration file path"`
 		Universal        bool   `long:"universal" description:"Add wide range of modules/tools to allow this image boot at different machines"`
 		Strip            bool   `long:"strip" description:"Strip ELF files (binaries, shared libraries and kernel modules) before adding it to the image"`

--- a/init/module.go
+++ b/init/module.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const imageModulesDir = "/usr/lib/modules"
+const imageModulesDir = "/lib/modules"
 
 var (
 	loadedModules    = make(map[string]bool)

--- a/packaging/arch/booster-install
+++ b/packaging/arch/booster-install
@@ -4,30 +4,30 @@ kernels=()
 all=0
 
 while read -r line; do
-    # line is like usr/lib/modules/5.8.2-arch1-1/vmlinuz
-    if [[ "${line}" != usr/lib/modules/* ]]; then
-        # triggers when it's a change to usr/lib/booster/*
-        all=1
-        break
-    fi
+  # line is like usr/lib/modules/5.8.2-arch1-1/vmlinuz
+  if [[ ${line} != usr/lib/modules/* ]]; then
+    # triggers when it's a change to usr/lib/booster/*
+    all=1
+    break
+  fi
 
-    kernels+=("/${line%/vmlinuz}")
+  kernels+=("/${line%/vmlinuz}")
 done
 
 if [ "${all}" -eq "1" ]; then
-    # find out all installed kernels
-    kernels=($(ls -d /usr/lib/modules/*))
+  # find out all installed kernels
+  mapfile -d '' kernels < <(find /lib/modules -maxdepth 1 -type d ! -name "modules" -print0)
 fi
 
 for kernel in "${kernels[@]}"; do
-    if ! pacman -Qqo "${kernel}/pkgbase" > /dev/null 2>&1; then
-        # if pkgbase does not belong to any package then skip this kernel
-        continue
-    fi
-    read -r pkgbase < "${kernel}/pkgbase"
+  if ! pacman -Qqo "${kernel}/pkgbase" > /dev/null 2>&1; then
+    # if pkgbase does not belong to any package then skip this kernel
+    continue
+  fi
+  read -r pkgbase < "${kernel}/pkgbase"
 
-    booster build --force --kernel-version ${kernel##/usr/lib/modules/} /boot/booster-${pkgbase}.img &
-    install -Dm644 "${kernel}/vmlinuz" "/boot/vmlinuz-${pkgbase}"
+  booster build --force --kernel-version "$(basename "${kernel}")" "/boot/booster-${pkgbase}.img" &
+  install -Dm644 "${kernel}/vmlinuz" "/boot/vmlinuz-${pkgbase}"
 done
 
 wait

--- a/packaging/arch/booster-remove
+++ b/packaging/arch/booster-remove
@@ -4,27 +4,27 @@ kernels=()
 all=0
 
 while read -r line; do
-    # line is like usr/lib/modules/5.8.2-arch1-1/vmlinuz
-    if [[ "${line}" != usr/lib/modules/* ]]; then
-        # triggers when it's a change to usr/lib/booster/*
-        all=1
-        break
-    fi
+  # line is like usr/lib/modules/5.8.2-arch1-1/vmlinuz
+  if [[ ${line} != usr/lib/modules/* ]]; then
+    # triggers when it's a change to usr/lib/booster/*
+    all=1
+    break
+  fi
 
-    kernels+=("/${line%/vmlinuz}")
+  kernels+=("/${line%/vmlinuz}")
 done
 
 if [ "${all}" -eq "1" ]; then
-    # find out all installed kernels
-    kernels=($(ls -d /usr/lib/modules/*))
+  # find out all installed kernels
+  mapfile -d '' kernels < <(find /lib/modules -maxdepth 1 -type d ! -name "modules" -print0)
 fi
 
 for kernel in "${kernels[@]}"; do
-    if ! pacman -Qqo "${kernel}/pkgbase" > /dev/null 2>&1; then
-        # if pkgbase does not belong to any package then skip this kernel
-        continue
-    fi
-    read -r pkgbase < "${kernel}/pkgbase"
+  if ! pacman -Qqo "${kernel}/pkgbase" > /dev/null 2>&1; then
+    # if pkgbase does not belong to any package then skip this kernel
+    continue
+  fi
+  read -r pkgbase < "${kernel}/pkgbase"
 
-    rm /boot/booster-${pkgbase}.img
+  rm "/boot/booster-${pkgbase}.img"
 done

--- a/packaging/arch/regenerate_images
+++ b/packaging/arch/regenerate_images
@@ -1,17 +1,17 @@
 #!/bin/bash -e
 
 # find out all installed kernels
-kernels=($(ls -d /usr/lib/modules/*))
+mapfile -d '' kernels < <(find /lib/modules -maxdepth 1 -type d ! -name "modules" -print0)
 
 for kernel in "${kernels[@]}"; do
-    if ! pacman -Qqo "${kernel}/pkgbase" > /dev/null 2>&1; then
-        # if pkgbase does not belong to any package then skip this kernel
-        continue
-    fi
-    read -r pkgbase < "${kernel}/pkgbase"
+  if ! pacman -Qqo "${kernel}/pkgbase" > /dev/null 2>&1; then
+    # if pkgbase does not belong to any package then skip this kernel
+    continue
+  fi
+  read -r pkgbase < "${kernel}/pkgbase"
 
-    booster build --force --kernel-version ${kernel##/usr/lib/modules/} /boot/booster-${pkgbase}.img &
-    install -Dm644 "${kernel}/vmlinuz" "/boot/vmlinuz-${pkgbase}"
+  booster build --force --kernel-version "$(basename "${kernel}")" "/boot/booster-${pkgbase}.img" &
+  install -Dm644 "${kernel}/vmlinuz" "/boot/vmlinuz-${pkgbase}"
 done
 
 wait

--- a/tests/generators/voidlinux.sh
+++ b/tests/generators/voidlinux.sh
@@ -23,7 +23,7 @@ sudo mv 60:ae:0c:d6:f0:95:17:80:bc:93:46:7a:89:af:a3:2d.plist "${mount}/var/db/x
 
 sudo xbps-install -y -R https://alpha.de.repo.voidlinux.org/current -c /var/cache/xbps -r "${mount}" -Su base-system linux
 
-modulesdir="${mount}/usr/lib/modules"
+modulesdir="${mount}/lib/modules"
 # Makes the fairly reasonable assumption that the "|" character will never appear in a kernel version
 kernelver=$(find "${modulesdir}" -maxdepth 1 -type d ! -name "modules" -print 0 | xargs -0 stat -c "%Y|%n" | sort -r | cut -d "|" -f 2 | xargs basename)
 printf '%s' "${kernelver}" > assets/voidlinux/vmlinuz-version

--- a/tests/util.go
+++ b/tests/util.go
@@ -22,7 +22,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const kernelsDir = "/usr/lib/modules"
+const kernelsDir = "/lib/modules"
 
 var (
 	binariesDir    string // working dir shared between all tests


### PR DESCRIPTION
In the Linux kernel, the default modules directory is `/lib/modules` rather than `/usr/lib/modules`. The reason the current code works on many distros, such as Arch Linux, Fedora and Debian, is because these distribution have merged the members of the `/usr` directory with their root equivalents ([Arch merge](https://archlinux.org/news/the-lib-directory-becomes-a-symlink/); [Fedora merge](https://github.com/anatol/booster/pull/url); [Debian merge](https://wiki.debian.org/UsrMerge)). However, not all distros have performed this merge (like Gentoo), and the [FHS](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html) still regards them as separate.

This proposed commit will preserve current behaviours on systems with a usrmerge hierarchy (as the symlink will just be followed); will now act correctly on systems without a usrmerge and where usr does not sit on a separate partition; and will open up the possibility of extending support to those systems without a usrmerge and with separate usr partitions. All tests remain passing on my Arch Linux system, and have gone from none of them passing to (almost) all of them passing on my Gentoo system.

Further reading if interested: [1](https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/), [2](https://freedesktop.org/wiki/Software/systemd/separate-usr-is-broken/), [3](https://lwn.net/Articles/890219/).