### PR TITLE
generator: normalize both module and pattern names from modules.alias

### DIFF
--- a/generator/kmod.go
+++ b/generator/kmod.go
@@ -250,6 +250,12 @@ func (k *Kmod) readKernelAliases() error {
 		}
 		pattern := line[:idx]
 		module := line[idx+1:]
+
+		// As per modprobe.d(5), - and _ can be used
+		// interchangeably in both module and alias names.
+		pattern = normalizeModuleName(pattern)
+		module = normalizeModuleName(module)
+
 		k.aliases = append(k.aliases, alias{pattern, module})
 	}
 
@@ -704,7 +710,7 @@ func readDeviceAliases() (set, error) {
 		if err != nil {
 			return err
 		}
-		al := strings.TrimSpace(string(b))
+		al := normalizeModuleName(strings.TrimSpace(string(b)))
 		if al == "" {
 			return nil
 		}

--- a/init/udev.go
+++ b/init/udev.go
@@ -109,7 +109,7 @@ func handleUdevEvent(ev netlink.UEvent) {
 	debug("udev event %+v", ev)
 
 	if modalias, ok := ev.Env["MODALIAS"]; ok {
-		go func() { check(loadModalias(modalias)) }()
+		go func() { check(loadModalias(normalizeModuleName(modalias))) }()
 	} else if ev.Env["SUBSYSTEM"] == "block" {
 		go func() { check(handleBlockDeviceUevent(ev)) }()
 	} else if ev.Env["SUBSYSTEM"] == "net" {


### PR DESCRIPTION
From `modprobe.d(5)`:

> Note that module and alias names (like other module names) can have - or _ in them: both are interchangeable throughout all the module commands as underscore conversion happens automatically.

For this reason, we need to make sure that everywhere where module or pattern names are compared that this comparison is always performed on a normalized string. This commit adds several normalizations for module and pattern names that were previously not performed.

Fixes #185