### PR TITLE
generator: Fix creation of target directory

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -263,7 +263,7 @@ func appendCompatibilitySymlinks(img *Image) error {
 	for _, l := range symlinks {
 		// Ensure that target always exist which may not be the
 		// case if we only install files from /lib or /bin.
-		targetDir := filepath.Dir(filepath.Join(filepath.Dir(l.src), l.target))
+		targetDir := filepath.Join(filepath.Dir(l.src), l.target)
 		if err := img.AppendDirEntry(targetDir); err != nil {
 			return err
 		}


### PR DESCRIPTION
This attempts to fix a regression introduced in commit e13aa77e49aef93cc1370a269785b471758cb546 since this commit the `usr/lib` target directroy is not created if the host system does not ship any files in `usr/lib` (e.g. Alpine). This causes initramfs images generated on such systems to not be bootable as `lib` is a symlink to the non-existent `usr/lib` then.

The problem is the current implementation:

```Go
filepath.Dir(filepath.Join(filepath.Dir(l.src), l.target))
```

would return `/usr` for `{"/lib", "usr/lib"}` and hence `/usr/lib` was never created.

I believe this was intended to be:

```Go
filepath.Join(filepath.Dir(l.src), l.target)
```

This commit changes this accordingly and fixes booting Booster 0.10 images on Alpine.

---

See also: #134