### PR TITLE
Handle zstd compressed firmware

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -331,6 +331,7 @@ func findFwFile(fw string) (string, error) {
 	supportedFwExt := []string{
 		"",
 		".xz", // since linux v5.3
+		".zst", // since linux v5.19
 	}
 
 	fwBasePath := firmwareDir + fw

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -330,7 +330,7 @@ func lookupPath(binary string) (string, error) {
 func findFwFile(fw string) (string, error) {
 	supportedFwExt := []string{
 		"",
-		".xz", // https://archlinux.org/news/linux-firmware-202201190c6a7b3-2-requires-kernel-53-and-package-splitting/
+		".xz", // since linux v5.3
 	}
 
 	fwBasePath := firmwareDir + fw


### PR DESCRIPTION
Nothing special here - just another extension to handle. While we're here, mentioning the kernel version which landed support is more beneficial to when it was by distribution X or Y - the project is aiming at multiple distributions after all.

Closes: https://github.com/anatol/booster/issues/224