### PR TITLE
init: wait for usbhid drivers for fido2 unlocking

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -206,15 +206,6 @@ func generateInitRamfs(conf *generatorConfig) error {
 		}
 	}
 
-	// force load usbhid and hid_sensor_hub modules when unlocking encrypted LUKS2 volumes with fido2 tokens/devices
-	for _, file := range conf.extraFiles {
-		if file == "fido2-assert" {
-			conf.modulesForceLoad = append(conf.modulesForceLoad, "usbhid", "hid_sensor_hub")
-
-			break
-		}
-	}
-
 	if err := kmod.resolveDependencies(); err != nil {
 		return err
 	}

--- a/init/luks.go
+++ b/init/luks.go
@@ -90,6 +90,9 @@ func recoverClevisPassword(t luks.Token, luksVersion int) ([]byte, error) {
 }
 
 func recoverFido2Password(devName string, credential string, salt string, relyingParty string, pinRequired bool, userPresenceRequired bool, userVerificationRequired bool) ([]byte, error) {
+	usbHidDriverWg.Wait()
+	hidGenericWg.Wait()
+
 	ueventContent, err := os.ReadFile("/sys/class/hidraw/" + devName + "/device/uevent")
 	if err != nil {
 		return nil, fmt.Errorf("unable to read uevent file for %s", devName)

--- a/init/luks.go
+++ b/init/luks.go
@@ -90,7 +90,6 @@ func recoverClevisPassword(t luks.Token, luksVersion int) ([]byte, error) {
 }
 
 func recoverFido2Password(devName string, credential string, salt string, relyingParty string, pinRequired bool, userPresenceRequired bool, userVerificationRequired bool) ([]byte, error) {
-	usbHidDriverWg.Wait()
 	hidGenericWg.Wait()
 
 	ueventContent, err := os.ReadFile("/sys/class/hidraw/" + devName + "/device/uevent")

--- a/init/luks.go
+++ b/init/luks.go
@@ -90,7 +90,7 @@ func recoverClevisPassword(t luks.Token, luksVersion int) ([]byte, error) {
 }
 
 func recoverFido2Password(devName string, credential string, salt string, relyingParty string, pinRequired bool, userPresenceRequired bool, userVerificationRequired bool) ([]byte, error) {
-	hidGenericWg.Wait()
+	usbhidWg.Wait()
 
 	ueventContent, err := os.ReadFile("/sys/class/hidraw/" + devName + "/device/uevent")
 	if err != nil {

--- a/init/udev.go
+++ b/init/udev.go
@@ -68,17 +68,14 @@ var (
 	// Wait() will return after the TPM is ready.
 	// Only works after we start listening for udev events.
 	tpmReady       sync.Once
-	usbHidDriver   sync.Once
 	hidGeneric     sync.Once
 	tpmReadyWg     sync.WaitGroup
-	usbHidDriverWg sync.WaitGroup
 	hidGenericWg   sync.WaitGroup
 )
 
 func udevListener() error {
 	// Initialize tpmReadyWg
 	tpmReadyWg.Add(1)
-	usbHidDriverWg.Add(1)
 	hidGenericWg.Add(1)
 
 	udevConn = new(netlink.UEventConn)
@@ -127,19 +124,12 @@ func handleUdevEvent(ev netlink.UEvent) {
 		go func() { hidrawDevices <- ev.Env["DEVNAME"] }()
 	} else if ev.Env["SUBSYSTEM"] == "tpmrm" && ev.Action == "add" {
 		go handleTpmReadyUevent(ev)
-	} else if ev.Env["SUBSYSTEM"] == "drivers" && ev.Action == "add" && ev.KObj == "/bus/usb/drivers/usbhid" {
-		go handleHidUevent(ev)
 	} 
 }
 
 func handleHidGenericUevent(ev netlink.UEvent) {
 	info(ev.Env["DRIVER"] + " uevent: device: %s", ev.Env["DEVPATH"])
 	hidGeneric.Do(hidGenericWg.Done)
-}
-
-func handleHidUevent(ev netlink.UEvent) {
-	info(ev.Env["SUBSYSTEM"] + " uevent: drivers loaded: %s", ev.Env["DEVPATH"])
-	usbHidDriver.Do(usbHidDriverWg.Done)
 }
 
 func handleTpmReadyUevent(ev netlink.UEvent) {

--- a/init/udev.go
+++ b/init/udev.go
@@ -116,7 +116,7 @@ func handleUdevEvent(ev netlink.UEvent) {
 	if modalias, ok := ev.Env["MODALIAS"]; ok {
 		go func() { check(loadModalias(normalizeModuleName(modalias))) }()
 		// bind actions associated with the hid-generic driver have an alias
-		if ev.Env["DRIVER"] == "hid-generic" && ev.Action == "bind" {
+		if ev.Env["DRIVER"] == "usbhid" && ev.Action == "bind" {
 			go handleHidGenericUevent(ev)
 		}
 	} else if ev.Env["SUBSYSTEM"] == "block" {

--- a/init/udev.go
+++ b/init/udev.go
@@ -112,7 +112,7 @@ func handleUdevEvent(ev netlink.UEvent) {
 
 	if modalias, ok := ev.Env["MODALIAS"]; ok {
 		go func() { check(loadModalias(normalizeModuleName(modalias))) }()
-		// bind actions associated with the hid-generic driver have an alias
+		// bind actions associated with the usbhid driver have an alias
 		if ev.Env["DRIVER"] == "usbhid" && ev.Action == "bind" {
 			go handleUsbHidUevent(ev)
 		}

--- a/init/udev.go
+++ b/init/udev.go
@@ -128,7 +128,9 @@ func handleUdevEvent(ev netlink.UEvent) {
 }
 
 func handleUsbHidUevent(ev netlink.UEvent) {
-	info(ev.Env["DRIVER"]+" uevent: device: %s", ev.Env["DEVPATH"])
+	// `PRODUCT` is associated with the usb device, and can be used to id the fido2 token
+	// it's the concat of `idVendor`, `idProduct`, and `bcdDevice` when a kernel usb event occurs
+	info(ev.Env["DRIVER"]+" uevent: product: %s", ev.Env["PRODUCT"])
 	usbhid.Do(usbhidWg.Done)
 }
 

--- a/init/udev.go
+++ b/init/udev.go
@@ -115,6 +115,10 @@ func handleUdevEvent(ev netlink.UEvent) {
 
 	if modalias, ok := ev.Env["MODALIAS"]; ok {
 		go func() { check(loadModalias(normalizeModuleName(modalias))) }()
+		// bind actions associated with the hid-generic driver have an alias
+		if ev.Env["DRIVER"] == "hid-generic" && ev.Action == "bind" {
+			go handleHidGenericUevent(ev)
+		}
 	} else if ev.Env["SUBSYSTEM"] == "block" {
 		go func() { check(handleBlockDeviceUevent(ev)) }()
 	} else if ev.Env["SUBSYSTEM"] == "net" {
@@ -126,10 +130,6 @@ func handleUdevEvent(ev netlink.UEvent) {
 	} else if ev.Env["SUBSYSTEM"] == "drivers" && ev.Action == "add" && ev.KObj == "/bus/usb/drivers/usbhid" {
 		go handleHidUevent(ev)
 	} 
-
-	if ev.Env["DRIVER"] == "hid-generic" && ev.Action == "bind" {
-		go handleHidGenericUevent(ev)
-	}
 }
 
 func handleHidGenericUevent(ev netlink.UEvent) {


### PR DESCRIPTION
Accomplishes the same effect as https://github.com/anatol/booster/commit/1b655775edd015b0aa584a30f79c5d25ef8d5489 but instead of forcibly loading the `usbhid` and `hid_sensor_hub` modules, specific events are listened and waited for, namely, the `hid-generic` and the `usbhid` drivers. 

It appears booster is being too fast, and doesn't wait long enough for the  built in `hid-generic` driver to target the hidraw devices plugged via usb. As a result, errors occur for uevents when attempting to recover the fido2 password from hidraw devices.

This way unlocking encrypted partitions with fido2 keys is possible by only specifying `fido2-assert` in booster.yaml, but without the workarounds of generating a universal image and loading the `hid_sensor_hub`.
