### PR TITLE
Add debian lib64 path to elfLibDir

### DIFF
--- a/generator/image.go
+++ b/generator/image.go
@@ -314,7 +314,7 @@ func elfSectionContent(s *elf.Section) (string, error) {
 	return string(b[:bytes.IndexByte(b, '\x00')]), nil
 }
 
-var elfLibDir = []string{"/usr/lib", "/lib", "/usr/lib64"}
+var elfLibDir = []string{"/usr/lib", "/lib", "/usr/lib64", "/usr/lib/x86_64-linux-gnu"}
 
 // for a given library (e.g. libc.so.6) finds absolute path to the library file
 func elfPath(lib string) string {


### PR DESCRIPTION
Hi,

I've recently been trying to packaging booster for my debian/ubuntu based distro and we ran into an issue with the elfLibDir not having the path debian uses. This PR fixes that.