### PR TITLE
Add support for encrypted ZFS datasets.

### DIFF
--- a/init/main.go
+++ b/init/main.go
@@ -901,12 +901,34 @@ func mountZfsRoot() error {
 	flags, options := mountFlags()
 	options = strings.Join([]string{"zfsutil", options}, ",")
 	for _, ds := range strings.Split(strings.TrimSpace(string(datasets)), "\n") {
-		val, err := exec.Command("zfs", "get", "-H", "-o", "value", "mountpoint", ds).Output()
+		encryptionRoot, err := getZfsPropertyValue("encryptionroot", ds)
 		if err != nil {
 			return unwrapExitError(err)
 		}
-
-		mt := strings.TrimSpace(string(val))
+		if encryptionRoot != "-" {
+			keyStatus, err := getZfsPropertyValue("keystatus", encryptionRoot)
+			if err != nil {
+				return unwrapExitError(err)
+			}
+			if keyStatus == "unavailable" {
+				keyLocation, err := getZfsPropertyValue("keylocation", encryptionRoot)
+				if err != nil {
+					return unwrapExitError(err)
+				}
+				if keyLocation == "prompt" {
+					err := loadZfsKey(encryptionRoot)
+					if err != nil {
+						return unwrapExitError(err)
+					}
+				} else {
+					warning("unable to load key for ZFS dataset %s", encryptionRoot)
+				}
+			}
+		}
+		mt, err := getZfsPropertyValue("mountpoint", ds)
+		if err != nil {
+			return unwrapExitError(err)
+		}
 		switch mt {
 		case "none":
 			continue
@@ -922,6 +944,32 @@ func mountZfsRoot() error {
 	rootMounted.Done()
 
 	return nil
+}
+
+func getZfsPropertyValue(property, dataset string) (string, error) {
+	val, err := exec.Command("zfs", "get", "-H", "-o", "value", property, dataset).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(val)), err
+}
+
+func loadZfsKey(encryptionRoot string) error {
+	for {
+		zfsLoadKey := exec.Command("zfs", "load-key", encryptionRoot)
+		zfsLoadKey.Stdin = os.Stdin
+		zfsLoadKey.Stdout = os.Stdout
+		zfsLoadKey.Stderr = os.Stderr
+		err := zfsLoadKey.Run()
+		if err != nil {
+			warning("running `zfs load-key`: %v", err)
+			if _, ok := err.(*exec.ExitError); ok {
+				continue
+			}
+			return err
+		}
+		return nil
+	}
 }
 
 var config InitConfig

--- a/init/main.go
+++ b/init/main.go
@@ -911,17 +911,9 @@ func mountZfsRoot() error {
 				return unwrapExitError(err)
 			}
 			if keyStatus == "unavailable" {
-				keyLocation, err := getZfsPropertyValue("keylocation", encryptionRoot)
+				err := loadZfsKey(encryptionRoot)
 				if err != nil {
 					return unwrapExitError(err)
-				}
-				if keyLocation == "prompt" {
-					err := loadZfsKey(encryptionRoot)
-					if err != nil {
-						return unwrapExitError(err)
-					}
-				} else {
-					warning("unable to load key for ZFS dataset %s", encryptionRoot)
 				}
 			}
 		}

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -40,6 +40,7 @@ var assetGenerators = map[string]assetGenerator{
 	"systemd-recovery.img":      {"systemd_recovery.sh", []string{"LUKS_UUID=62020168-58b9-4095-a3d0-176403353d20", "FS_UUID=b0cfeb48-c1e2-459d-a327-4d611804ac24", "LUKS_PASSWORD=2211"}},
 	"swap.raw":                  {"swap.sh", nil},
 	"zfs.img":                   {"zfs.sh", nil},
+	"zfs_encrypted.img":         {"zfs.sh", []string{"ZFS_PASSPHRASE=encrypted"}},
 
 	// non-images
 	"tpm2/tpm2-00.permall.pristine": {"swtpm.sh", nil},

--- a/tests/generators/zfs.sh
+++ b/tests/generators/zfs.sh
@@ -12,7 +12,7 @@ quit() {
 
 truncate --size 100M "${OUTPUT}"
 lodev=$(sudo losetup -f -P --show "${OUTPUT}")
-sudo gdisk "${lodev}" <<< "o
+sudo gdisk "${lodev}" <<<"o
 y
 n
 
@@ -32,7 +32,11 @@ y
 dir=$(mktemp -d)
 sleep 2 # wait till udev creates /dev/disk/by-partuuid/ link
 sudo modprobe zfs
-sudo zpool create testpool /dev/disk/by-partuuid/308eb65b-292a-49ca-9cf1-f739b338a77e
+if [ "${ZFS_PASSPHRASE}" != "" ]; then
+  echo -e "${ZFS_PASSPHRASE}\n${ZFS_PASSPHRASE}" | sudo zpool create -O encryption=on -O keylocation=prompt -O keyformat=passphrase testpool /dev/disk/by-partuuid/308eb65b-292a-49ca-9cf1-f739b338a77e
+else
+  sudo zpool create testpool /dev/disk/by-partuuid/308eb65b-292a-49ca-9cf1-f739b338a77e
+fi
 sudo zfs create -o mountpoint=/ testpool/root
 sudo mount -t zfs -o zfsutil testpool/root "${dir}"
 sudo chown "${USER}" "${dir}"

--- a/tests/zfs_test.go
+++ b/tests/zfs_test.go
@@ -18,3 +18,19 @@ func TestZfs(t *testing.T) {
 
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
 }
+
+func TestUnlockEncryptedZfs(t *testing.T) {
+	vm, err := buildVmInstance(t, Opts{
+		enableZfs:     true,
+		zfsCachePath:  "assets/zfs/zpool.cache",
+		disk:          "assets/zfs_encrypted.img",
+		kernelVersion: "6.6.28-1-lts",
+		kernelArgs:    []string{"zfs=testpool/root"},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for 'testpool':"))
+	require.NoError(t, vm.ConsoleWrite("encrypted\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}

--- a/tests/zfs_test.go
+++ b/tests/zfs_test.go
@@ -21,11 +21,10 @@ func TestZfs(t *testing.T) {
 
 func TestUnlockEncryptedZfs(t *testing.T) {
 	vm, err := buildVmInstance(t, Opts{
-		enableZfs:     true,
-		zfsCachePath:  "assets/zfs/zpool.cache",
-		disk:          "assets/zfs_encrypted.img",
-		kernelVersion: "6.6.28-1-lts",
-		kernelArgs:    []string{"zfs=testpool/root"},
+		enableZfs:    true,
+		zfsCachePath: "assets/zfs/zpool.cache",
+		disk:         "assets/zfs_encrypted.img",
+		kernelArgs:   []string{"zfs=testpool/root"},
 	})
 	require.NoError(t, err)
 	defer vm.Shutdown()


### PR DESCRIPTION
Here is a minimal implementation of support for encrypted ZFS datasets, calling `zfs load-key` for each encrypted root.