### PR TITLE
Forward arguments set by the kernel cmdline to the init system

### DIFF
--- a/init/main.go
+++ b/init/main.go
@@ -666,6 +666,11 @@ func switchRoot() error {
 	}
 
 	initArgs := []string{initBinary}
+        // Kernel can pass their arguments to the init program that we should then forward to actual system init
+        if(len(os.Args) > 1) {
+                initArgs = append(initArgs, os.Args[1:]...)
+        }
+
 	isSystemdInit, err := isSystemd(initBinary)
 	if err != nil {
 		return err


### PR DESCRIPTION
Kernel can pass arguments to the init script if it encounters a [double dash ](https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html) that should then be forwarded to the actual init system (at least that's the behavior on in other init scripts, such as ones generated by mkinitcpio).

Fixes #266 