### PR TITLE
packaging: Add kernel-install hook for booster

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -61,6 +61,7 @@ package() {
   install -Dp -m755 init/init "$pkgdir/usr/lib/booster/init"
   install -Dp -m755 packaging/arch/regenerate_images "$pkgdir/usr/lib/booster/regenerate_images"
   install -Dp -m755 packaging/arch/regenerate_uki "$pkgdir/usr/lib/booster/regenerate_uki"
+  install -Dp -m755 packaging/common/50-booster.install "$pkgdir/usr/lib/kernel/install.d/50-booster.install"
 
   install -Dp -m644 packaging/arch/90-booster-install.hook "$pkgdir/usr/share/libalpm/hooks/90-booster-install.hook"
   install -Dp -m755 packaging/arch/booster-install "$pkgdir/usr/share/libalpm/scripts/booster-install"

--- a/packaging/centos/booster.spec
+++ b/packaging/centos/booster.spec
@@ -66,6 +66,7 @@ touch $RPM_BUILD_ROOT/etc/booster.yaml
 %{__install} -Dp -m755 packaging/centos/booster-remove "$RPM_BUILD_ROOT/usr/share/yum-plugins/post-actions/scripts/booster-remove"
 %{__install} -Dp -m755 packaging/centos/booster-install-pre.action "$RPM_BUILD_ROOT/etc/yum/pre-actions/booster-pre.action"
 %{__install} -Dp -m755 packaging/centos/booster-install-post.action "$RPM_BUILD_ROOT/etc/yum/post-actions/booster-post.action"
+%{__install} -Dp -m755 packaging/common/50-booster.install "$RPM_BUILD_ROOT/usr/lib/kernel/install.d/50-booster.install"
 
 %files
 /etc/booster.yaml

--- a/packaging/common/50-booster.install
+++ b/packaging/common/50-booster.install
@@ -1,0 +1,31 @@
+#!/usr/bin/bash -e
+
+COMMAND="${1:?}"
+KERNEL_VERSION="${2:?}"
+BOOT_DIR="$3"
+KERNEL_IMAGE="$4"
+
+# If the initrd was provide don the command line, we shouldn't generate our own
+# If the supplied image is a UKI, we don't need to create an initrd
+if [[ "$COMMAND" != "add" || "$#" -gt 4  || "$KERNEL_INSTALL_IMAGE_TYPE" = "uki" ]]; then
+    exit 0
+fi
+
+# Only create an initrd if we are the configured initrd generator
+if [[ "$KERNEL_INSTALL_INITRD_GENERATOR" != "booster" ]]; then
+    exit 0
+fi
+
+existing_image="$KERNEL_IMAGE%/*}/initrd"
+output_path="$KERNEL_INSTALL_STAGING_AREA/initrd"
+if [[ -f "$existing_image" ]]; then
+    # we found an initrd at the same place as the kernel
+    # use this and don't generate a new one
+    [[ "$KERNEL_INSTALL_VERBOSE" == 1 ]] && printf "Thres is an initrd image at the same place as the kernel, skipping generating a new one"
+    cp --reflink=auto --no-preserve=ownership "$existing_image" "$output_path"
+    chmod 0600 "$KERNEL_INSTALL_STAGING_AREA/$IMAGE"
+    exit 0
+fi
+
+
+booster build --force --kernel-version "$KERNEL_VERSION" "$output_path" || exit 1


### PR DESCRIPTION
This allows booster to be used as the initrd_generator with kernel-install (1).