### PR TITLE
ukify: Use --microcode instead of --initrd

### DIFF
--- a/packaging/arch/regenerate_uki
+++ b/packaging/arch/regenerate_uki
@@ -15,7 +15,7 @@ create_uki() {
   microcodes=$(find /boot -name '*-ucode.img' -type f -printf "/boot/%f " | tr -d ' ')
 
   booster build --force --kernel-version "${kernel##/usr/lib/modules/}" "$initrd"
-  ukify --initrd="$microcodes" --initrd="$initrd" --linux="${kernel}/vmlinuz" --os-release="@${osrel}" --splash="$splash" --output="${esp}/booster-${pkgbase}.efi" build
+  ukify --microcode="$microcodes" --initrd="$initrd" --linux="${kernel}/vmlinuz" --os-release="@${osrel}" --splash="$splash" --output="${esp}/booster-${pkgbase}.efi" build
   install -Dm644 "${kernel}/vmlinuz" "/boot/vmlinuz-${pkgbase}"
 }
 


### PR DESCRIPTION
Cosmetic. systemd [added](https://github.com/systemd/systemd/commit/d380337dc5141eeb3c25071c6fcd9337aa814b62) the [--microcode](https://man.archlinux.org/man/ukify.1#%5BUKI%5D_section) option. This is probably the same as putting the ucode img as the 1st initrd.