### PR TITLE
Bugfix: close device file descriptors in wwid

### DIFF
--- a/init/wwid.go
+++ b/init/wwid.go
@@ -27,6 +27,7 @@ func wwid(device string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+		defer n.Close()
 
 		c, nss, err := n.Identify()
 		if err != nil {
@@ -56,6 +57,7 @@ func wwid(device string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+		defer dev.Close()
 
 		switch dev.Type() {
 		case "sata":


### PR DESCRIPTION
File descriptors to block devices (like /dev/sda) currently remain open and are inherited down the userspace process tree through PID 1. For example, on my machine the LVM command `vgchange` issues this warning during system initialization:

```
File descriptor 6 (/dev/sda) leaked on vgchange invocation.
```

This change closes the file descriptors properly, eliminating those warnings from the boot messages.