### PR TITLE
Add binutils to optdeps for strip

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -15,6 +15,7 @@ optdepends=(
   'yubikey-personalization: for clevis Yubikey challenge-response support'
   'libfido2: for systemd-enroll with FIDO2'
   'systemd-ukify: for generating UKIs'
+  'binutils: to strip kernel modules'
 )
 backup=(etc/booster.yaml)
 provides=(booster initramfs)


### PR DESCRIPTION
Add **binutils** to optdeps of PKGBUILD.
It is needed to stripping kernel modules.
Related: https://gitlab.archlinux.org/archlinux/packaging/packages/booster/-/issues/1