### PR TITLE
Support rootfstype=virtiofs

### DIFF
--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -172,7 +172,9 @@ func getNextParam(params string, index int) (string, string, int) {
 func parseParams(params string) error {
 	var luksOptions []string
 
-	var key, value string
+	var key, value, rootValue string
+	var rootErr error
+
 	i := 0
 
 	for i < len(params) {
@@ -212,7 +214,9 @@ func parseParams(params string) error {
 			var err error
 			cmdRoot, err = parseDeviceRef(value)
 			if err != nil {
-				return fmt.Errorf("root=%s: %v", value, err)
+				// in case of failure, do not error out yet, save the root value for remote identifier logic later
+				rootValue = value
+				rootErr = err
 			}
 		case "rd.modules_force_load":
 			if value == "" {
@@ -328,6 +332,20 @@ func parseParams(params string) error {
 				mod, param := key[:dot], key[dot+1:]
 				mod = normalizeModuleName(mod)
 				moduleParams[mod] = append(moduleParams[mod], param+"="+value)
+			}
+		}
+	}
+
+	if cmdRoot == nil { // we haven't parsed root successfully yet, either with missing root=, or it was probably remote
+		if len(rootValue) == 0 { // missing root=, do not consider this an error, nop
+
+		} else if len(rootFsType) == 0 { // has root=, but missing rootfstype=, bail out with earlier rootErr
+			return fmt.Errorf("root=%s: %v", rootValue, rootErr)
+		} else { // has both root= and rootfstype=, definitely remote
+			var err error
+			cmdRoot, err = parseRemoteRef(rootValue, rootFsType)
+			if err != nil {
+				return fmt.Errorf("root(remote)=%s: %v", rootValue, err)
 			}
 		}
 	}

--- a/init/deviceref.go
+++ b/init/deviceref.go
@@ -22,6 +22,7 @@ const (
 	refFsLabel
 	refHwPath
 	refWwID
+	refRemote // either a virtiofs or nfs (remote) target, either case non-local
 )
 
 // The are many ways a user can specify root partition (using name, fs uuid, fs label, gpt attribute, ...).
@@ -262,4 +263,13 @@ func parseDeviceRef(param string) (*deviceRef, error) {
 	}
 
 	return nil, fmt.Errorf("unable to parse the device reference")
+}
+
+func parseRemoteRef(remote string, fsType string) (*deviceRef, error) {
+	switch fsType {
+	case "virtiofs":
+		return &deviceRef{refRemote, remote}, nil
+	default:
+		return nil, fmt.Errorf("remote root reference of type %v not supported, currently only virtiofs is supported", fsType)
+	}
 }

--- a/init/main.go
+++ b/init/main.go
@@ -551,6 +551,20 @@ func fsck(dev string) error {
 	return nil
 }
 
+func mountRootFsChecked(dev, fstype string) error {
+	rootMountFlags, options := mountFlags()
+	info("mounting %s->%s, fs=%s, flags=0x%x, options=%s", dev, newRoot, fstype, rootMountFlags, options)
+	if err := mount(dev, newRoot, fstype, rootMountFlags, options); err != nil {
+		// Note that this mounting function might be called multiple times
+		// e.g. in case of multiple devices needed to assemble the root array, see https://github.com/anatol/booster/issues/194
+		// It will try to mount it until mount() is successful.
+		return err
+	}
+
+	rootMounted.Done()
+	return nil
+}
+
 func mountRootFs(dev, fstype string) error {
 	// some fs have module names that differs from the fs name itself
 	fstypeModules := map[string]string{
@@ -580,17 +594,7 @@ func mountRootFs(dev, fstype string) error {
 		return err
 	}
 
-	rootMountFlags, options := mountFlags()
-	info("mounting %s->%s, fs=%s, flags=0x%x, options=%s", dev, newRoot, fstype, rootMountFlags, options)
-	if err := mount(dev, newRoot, fstype, rootMountFlags, options); err != nil {
-		// Note that this mounting function might be called multiple times
-		// e.g. in case of multiple devices needed to assemble the root array, see https://github.com/anatol/booster/issues/194
-		// It will try to mount it until mount() is successful.
-		return err
-	}
-
-	rootMounted.Done()
-	return nil
+	return mountRootFsChecked(dev, fstype)
 }
 
 // Wait until all devices of a multiple-device filesystem are scanned and registered within the kernel module
@@ -1095,6 +1099,7 @@ func boost() error {
 
 	go func() { check(scanSysModaliases()) }()
 	go func() { check(scanSysBlock()) }()
+	go func() { check(mountRemoteRoot()) }()
 
 	if config.EnableZfs {
 		if err := mountZfsRoot(); err != nil {
@@ -1208,6 +1213,36 @@ func loadZfsKey(encryptionRoot string) error {
 		}
 		return nil
 	}
+}
+
+// While this looks generic but currently only virtiofs is supported
+func mountRemoteRoot() error {
+	if cmdRoot.format != refRemote {
+		// return early if root is non-remote
+		return nil
+	}
+
+	if rootFsType != "virtiofs" {
+		return fmt.Errorf("unsupported remote fs type %s, we should not be here", rootFsType)
+	}
+
+	// Arch Linux official kernels selects virtiofs as built-in, ALARM has it as module, load regardless just in case
+	virtiofsWg := loadModules("virtiofs")
+	virtiofsWg.Wait()
+
+	rootMountingMutex.Lock()
+	defer rootMountingMutex.Unlock()
+
+	// hack: some "remote" fs becomes available so fast that udevQuitLoop wouldn't even be initialized here (mainly virtiofs)
+	// wait for udevQuitLoop to become ready so we don't break cleanup() in which udevQuitLoop needs to be closed
+	for {
+		if udevQuitLoop != nil {
+			break
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	return mountRootFsChecked(cmdRoot.data.(string), rootFsType)
 }
 
 var config InitConfig

--- a/tests/virtiofs_test.go
+++ b/tests/virtiofs_test.go
@@ -1,0 +1,47 @@
+package tests
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Most of the command (params) come from https://virtio-fs.gitlab.io/howto-qemu.html
+func TestVirtiofs(t *testing.T) {
+	const pathVirtiofsd string = "/usr/lib/virtiofsd"
+	require.True(t, fileExists(pathVirtiofsd))
+
+	// Use the whole assets/ folder as root so we do not need a dedicated folder
+	virtiofsd := exec.Command(pathVirtiofsd, "--socket-path=/tmp/vhostqemu", "-o", "source=assets/", "-o", "cache=always")
+
+	require.NoError(t, virtiofsd.Start())
+
+	go func() {
+		virtiofsd.Wait()
+	}()
+
+	defer func() {
+		if virtiofsd.Process != nil {
+			virtiofsd.Process.Kill()
+		}
+	}()
+	vm, err := buildVmInstance(t, Opts{
+		// The init binary is already there, just use it
+		kernelArgs: []string{"rootfstype=virtiofs", "root=root", "init=/init"},
+		// The params come from the "Running with virtiofs" section at https://virtio-fs.gitlab.io/howto-qemu.html
+		params: []string{
+			// to create the communications socket
+			"-chardev", "socket,id=char0,path=/tmp/vhostqemu",
+			// instantiate the device
+			"-device", "vhost-user-fs-pci,queue-size=1024,chardev=char0,tag=root",
+			// force use of memory sharable with virtiofsd
+			// NOTE: the 8G param must be set explicitly here; when updating utils.go/buildVmInstance, it shall also be updated!
+			"-object", "memory-backend-file,id=mem,size=8G,mem-path=/dev/shm,share=on", "-numa", "node,memdev=mem",
+		},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}


### PR DESCRIPTION
This adds support to boot with virtiofs as rootfs, the behaviour stays in-line with `mkinitcpio` and `dracut`, in that `rootfstype=virtiofs` must be specified explicitly to distinguish it from other "virtual" roots (e.g. virtio-9p, nfs, etc), e.g.

`rootfstype=virtiofs root=root`

(Of course this only adds support of virtiofs)

---

virtiofs is a nice host-passthrough "fs" with which a virtual machine can use the host fs almost directly, saving the overhead of "guest fs -> guest disk -> host file -> host fs"  hassle, a virtiofs root is especially useful when access to files in guest root fs from host directly is needed, e.g. when doing frequent debugging, or vice versa.

E.g. with the following snippet in corresponding libvirt-qemu config:
```
<filesystem type='mount' accessmode='passthrough'>
    <driver type='virtiofs'/>
    <source dir='/var/lib/libvirt/filesystems/root.arch-x64-testing'/>
    <target dir='root'/>
    <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
</filesystem>
```

And an Arch system installed in archiso with the following steps:
```
mount -t virtiofs root /mnt
pacstrap /mnt ......
```

With optionally the following fstab:
```
root / virtiofs rw 0 0
```

The guest os can be booted with the following libvirt-qemu snippet:
```
<os>
    <type arch='x86_64' machine='pc-q35-10.0'>hvm</type>
    <kernel>/var/lib/libvirt/filesystems/root.arch-x64-testing/boot/vmlinuz-linux</kernel>
    <initrd>/var/lib/libvirt/filesystems/root.arch-x64-testing/boot/booster-linux.img</initrd>
    <cmdline>rootfstype=virtiofs root=root</cmdline>
    <boot dev='hd'/>
    <bootmenu enable='no'/>
</os>
```

Booting is successful with this patchset:
```
[root@archout ~]# dmesg | grep virtio | grep root
[    0.000000] Command line: console=ttyS0,115200n8 rootfstype=virtiofs root=root booster.log=console,debug
[    0.120364] Kernel command line: console=ttyS0,115200n8 rootfstype=virtiofs root=root booster.log=console,debug
[    0.667763] virtiofs virtio1: discovered new tag: root
[    1.132546] booster: mounting root->/booster.root, fs=virtiofs, flags=0x0, options=
[root@archout ~]# mount | grep root
root on / type virtiofs (rw,relatime)
```
