### PR TITLE
add noLogging level

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -124,7 +124,9 @@ Some parts of booster boot functionality can be modified with kernel boot parame
  * `zfs=$pool/$dataset` specifies what ZFS dataset needs to be used for root partition. This option is only used if ZFS config option is enabled. If ZFS filesystem is enabled then `root=` boot param is ignored.
  * `booster.log` configures booster init logging. It accepts a comma separated list of following values:
 
-   One of the level values (from more verbose to less verbose) - `debug`, `info`, `warning`, `error`. If the level is not specified then `info` used by default.
+   One of the level values (from more verbose to less verbose) - `debug`, `info`, `warning`, `error` or `null`.
+   The last level of `null` disables any logging, so *⚠️use it only if know what you are doing⚠️*.
+   If the level is not specified then `info` used by default.
 
    `console` - print booster init logs to console.
 
@@ -194,7 +196,7 @@ This allows for booting directly through the firmware (UEFI) as well as authenti
 
 To generate UKIs in Booster, please install the systemd UKI generator (systemd-ukify) from your distribution's package manager and use `/usr/lib/booster/regenerate_uki`.
 It is a convenience script that performs the same type of image regeneration as if you installed `booster` with your package manager, then passes the result to systemd's UKI generator (ukify) as input.
-The script only passes a subset of boot components, namely the system's microcode(s), initrd, os-release file, boot splash image and kernel. Kernel command-line entries of the UKI are inherited from `/etc/booster.yaml`. 
+The script only passes a subset of boot components, namely the system's microcode(s), initrd, os-release file, boot splash image and kernel. Kernel command-line entries of the UKI are inherited from `/etc/booster.yaml`.
 
 Please note that to boot the UKI by default, it may be necessary to configure your system's boot loader configuration file(s) accordingly.
 

--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -176,6 +176,8 @@ func parseParams(params string) error {
 					verbosityLevel = levelError
 				case "console":
 					printToConsole = true
+				case "null":
+					verbosityLevel = noLogging
 				default:
 					warning("unknown booster.log key: %s", p)
 				}

--- a/init/logging.go
+++ b/init/logging.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	// TOTHINK rename to debug/info/warning
+	noLogging  = iota - 1
 	levelError = iota
 	levelWarning
 	levelInfo


### PR DESCRIPTION
I had a specific problem which logs `mount(/dev/nvme0n1p5): no such file or directory` just after bootloader. I used systemd's ukify to add a splash image. I also use ` quiet loglevel=3 rd.udev.log_level=3 splash` to ensure no message can be put.

The only message that passes through is from booster. This logging simply destroys the splash image. :<

I'm sure this error is meaningless, as I've checked after boot for any mount errors and didn't find any.

This patch should ideally disable any logging from booster.

Incase there are others that experience the same thing and are ok with no logging, I think this patch justifies them.