### PR TITLE
crypttab: add /etc/crypttab.initramfs support with keyfile, tries, nofail options

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -119,7 +119,9 @@ Some parts of booster boot functionality can be modified with kernel boot parame
  * `rd.luks.uuid=$UUID` UUID of the LUKS partition where the root partition is enclosed. booster will try to unlock this LUKS device.
  * `rd.luks.name=$UUID=$NAME` similar to rd.luks.uuid parameter but also specifies the name used for the LUKS device opening.
  * `rd.luks.key=$UUID=$PATH` absolute path to a keyfile in the initrd/initramfs which can be used to unlock the device identified by UUID, if this file does not exist or fails to unlock it will fall back to a password request.
- * `rd.luks.options=opt1,opt2` a comma-separated list of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`.
+ * `rd.luks.options=opt1,opt2` a comma-separated list of LUKS options. Supported dm-crypt flags are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`.
+    Token device options are also supported: `fido2-device=auto` defers the keyboard passphrase prompt until FIDO2 unlock fails or times out; `tpm2-device=auto` does the same for TPM2 tokens.
+    The optional `token-timeout=DURATION` controls how long to wait for the token before falling back to keyboard (default 30s when a token option is set; bare integers are treated as seconds; `token-timeout=0` waits forever).
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
  * `rd.modules_force_load` a comma-separated list of extra kernel modules which should be force loaded.
  * `resume=$deviceref` device reference to suspend-to-disk device.

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -124,6 +124,9 @@ Some parts of booster boot functionality can be modified with kernel boot parame
     The optional `token-timeout=DURATION` controls how long to wait for the token before falling back to keyboard (default 30s when a token option is set; bare integers are treated as seconds; `token-timeout=0` waits forever).
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
  * `rd.modules_force_load` a comma-separated list of extra kernel modules which should be force loaded.
+
+As an alternative to `rd.luks.*` parameters, LUKS volumes can be configured via `/etc/crypttab.initramfs` on the host (see **crypttab(5)**).  If the file exists it is automatically bundled as `/etc/crypttab` inside the initramfs.  Booster supports `fido2-device=`, `tpm2-device=`, `token-timeout=`, `key-slot=`, `header=`, `discard`, and the other standard dm-crypt flags.  Kernel cmdline parameters take precedence over crypttab entries.
+
  * `resume=$deviceref` device reference to suspend-to-disk device.
  * `zfs=$pool/$dataset` specifies what ZFS dataset needs to be used for root partition. This option is only used if ZFS config option is enabled. If ZFS filesystem is enabled then `root=` boot param is ignored.
  * `booster.log` configures booster init logging. It accepts a comma separated list of following values:

--- a/generator/config.go
+++ b/generator/config.go
@@ -140,6 +140,7 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 	} else {
 		conf.modulesDir = filepath.Join(imageModulesDir, conf.kernelVersion)
 	}
+	conf.crypttabFile = opts.BuildCommand.CrypttabFile
 	conf.debug = opts.Verbose
 	conf.readDeviceAliases = readDeviceAliases
 	conf.readHostModules = readHostModules

--- a/generator/crypttab.go
+++ b/generator/crypttab.go
@@ -7,6 +7,18 @@ import (
 	"strings"
 )
 
+// isKeyfileOnDevice reports whether kf is a keyfile-on-device specifier of the
+// form "/path:UUID=xxx", "/path:LABEL=xxx", etc.
+func isKeyfileOnDevice(kf string) bool {
+	idx := strings.Index(kf, ":")
+	if idx < 0 {
+		return false
+	}
+	r := kf[idx+1:]
+	return strings.HasPrefix(r, "UUID=") || strings.HasPrefix(r, "LABEL=") ||
+		strings.HasPrefix(r, "PARTUUID=") || strings.HasPrefix(r, "PARTLABEL=")
+}
+
 // appendCrypttab bundles /etc/crypttab.initramfs (if present on the host) into
 // the image as /etc/crypttab, and pre-bundles any referenced keyfiles or
 // detached LUKS headers.  Silently skips if the file does not exist — opting in
@@ -62,10 +74,10 @@ func (img *Image) appendCrypttabFrom(hostPath string) error {
 		}
 
 		// bundle keyfile if it is an absolute path (not none/-)
-		// TODO: keyfile of the form "/path:UUID=..." means the key is on a separate
-		// device — requires mounting that device at early boot (issue #26).
 		if keyfile != "" && keyfile != "none" && keyfile != "-" && filepath.IsAbs(keyfile) {
-			if err := img.AppendFile(keyfile); err != nil {
+			if isKeyfileOnDevice(keyfile) {
+				// key lives on a separate runtime device — nothing to bundle
+			} else if err := img.AppendFile(keyfile); err != nil {
 				return fmt.Errorf("crypttab.initramfs: keyfile %s: %v", keyfile, err)
 			}
 		}

--- a/generator/crypttab.go
+++ b/generator/crypttab.go
@@ -62,6 +62,8 @@ func (img *Image) appendCrypttabFrom(hostPath string) error {
 		}
 
 		// bundle keyfile if it is an absolute path (not none/-)
+		// TODO: keyfile of the form "/path:UUID=..." means the key is on a separate
+		// device — requires mounting that device at early boot (issue #26).
 		if keyfile != "" && keyfile != "none" && keyfile != "-" && filepath.IsAbs(keyfile) {
 			if err := img.AppendFile(keyfile); err != nil {
 				return fmt.Errorf("crypttab.initramfs: keyfile %s: %v", keyfile, err)

--- a/generator/crypttab.go
+++ b/generator/crypttab.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// appendCrypttab bundles /etc/crypttab.initramfs (if present on the host) into
+// the image as /etc/crypttab, and pre-bundles any referenced keyfiles or
+// detached LUKS headers.  Silently skips if the file does not exist — opting in
+// is as simple as creating the file.
+func (img *Image) appendCrypttab() error {
+	return img.appendCrypttabFrom("/etc/crypttab.initramfs")
+}
+
+// appendCrypttabFrom is the testable implementation; hostPath can be overridden in tests.
+func (img *Image) appendCrypttabFrom(hostPath string) error {
+	content, err := os.ReadFile(hostPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := img.AppendContent("/etc/crypttab", 0o600, content); err != nil {
+		return err
+	}
+
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		var keyfile, optStr string
+		if len(fields) >= 3 {
+			keyfile = fields[2]
+		}
+		if len(fields) >= 4 {
+			optStr = fields[3]
+		}
+
+		// skip entries that won't be processed at boot
+		noauto := false
+		for _, opt := range strings.Split(optStr, ",") {
+			opt = strings.TrimSpace(opt)
+			if opt == "noauto" || opt == "swap" || opt == "tmp" || opt == "plain" || opt == "bitlk" || opt == "tcrypt" {
+				noauto = true
+				break
+			}
+		}
+		if noauto {
+			continue
+		}
+
+		// bundle keyfile if it is an absolute path (not none/-)
+		if keyfile != "" && keyfile != "none" && keyfile != "-" && filepath.IsAbs(keyfile) {
+			if err := img.AppendFile(keyfile); err != nil {
+				return fmt.Errorf("crypttab.initramfs: keyfile %s: %v", keyfile, err)
+			}
+		}
+
+		// bundle detached header if header=PATH is in options
+		for _, opt := range strings.Split(optStr, ",") {
+			opt = strings.TrimSpace(opt)
+			if strings.HasPrefix(opt, "header=") {
+				headerPath := strings.TrimPrefix(opt, "header=")
+				if !filepath.IsAbs(headerPath) {
+					return fmt.Errorf("crypttab.initramfs: header= path must be absolute: %s", headerPath)
+				}
+				if err := img.AppendFile(headerPath); err != nil {
+					return fmt.Errorf("crypttab.initramfs: header %s: %v", headerPath, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/generator/crypttab_test.go
+++ b/generator/crypttab_test.go
@@ -116,6 +116,51 @@ func TestAppendCrypttabHeaderRelativePathError(t *testing.T) {
 	require.Error(t, img.appendCrypttabFrom(crypttab))
 }
 
+func TestIsKeyfileOnDeviceUUID(t *testing.T) {
+	require.True(t, isKeyfileOnDevice("/keyfile:UUID=f1e2d3c4-b5a6-4789-8abc-def123456789"))
+}
+
+func TestIsKeyfileOnDeviceLabel(t *testing.T) {
+	require.True(t, isKeyfileOnDevice("/keyfile:LABEL=myusbkey"))
+}
+
+func TestIsKeyfileOnDevicePartuuid(t *testing.T) {
+	require.True(t, isKeyfileOnDevice("/key:PARTUUID=f1e2d3c4-b5a6-4789-8abc-def123456789"))
+}
+
+func TestIsKeyfileOnDevicePartlabel(t *testing.T) {
+	require.True(t, isKeyfileOnDevice("/key:PARTLABEL=usbkeys"))
+}
+
+func TestIsKeyfileOnDevicePlainPath(t *testing.T) {
+	require.False(t, isKeyfileOnDevice("/etc/keys/root.key"))
+}
+
+func TestIsKeyfileOnDeviceColonNonDevice(t *testing.T) {
+	// colon present but right side is not a device specifier
+	require.False(t, isKeyfileOnDevice("/path/key:something"))
+}
+
+func TestIsKeyfileOnDeviceEmpty(t *testing.T) {
+	require.False(t, isKeyfileOnDevice(""))
+}
+
+func TestAppendCrypttabKeyfileOnDeviceNotBundled(t *testing.T) {
+	dir := t.TempDir()
+
+	// The keyfile itself doesn't exist on the host — it lives on a runtime device.
+	// The generator should skip bundling it without error.
+	crypttab := filepath.Join(dir, "crypttab.initramfs")
+	content := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /keyfile:UUID=f1e2d3c4-b5a6-4789-8abc-def123456789 discard\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img := newTestImage(t)
+	require.NoError(t, img.appendCrypttabFrom(crypttab))
+	require.True(t, img.contains["/etc/crypttab"])
+	// the device-resident keyfile path must NOT be bundled
+	require.False(t, img.contains["/keyfile"])
+}
+
 func TestAppendCrypttabCommentAndBlankLines(t *testing.T) {
 	dir := t.TempDir()
 

--- a/generator/crypttab_test.go
+++ b/generator/crypttab_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestImage creates a minimal in-memory Image for generator unit tests.
+func newTestImage(t *testing.T) *Image {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "test.img")
+	img, err := NewImage(f, "none", false)
+	require.NoError(t, err)
+	t.Cleanup(func() { img.Cleanup() })
+	return img
+}
+
+func TestAppendCrypttabAbsent(t *testing.T) {
+	img := newTestImage(t)
+	// point at a path that doesn't exist — should silently succeed
+	require.NoError(t, img.appendCrypttabFrom(filepath.Join(t.TempDir(), "no-such-file")))
+	require.False(t, img.contains["/etc/crypttab"])
+}
+
+func TestAppendCrypttabBundled(t *testing.T) {
+	dir := t.TempDir()
+	crypttab := filepath.Join(dir, "crypttab.initramfs")
+	require.NoError(t, os.WriteFile(crypttab, []byte("cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none discard\n"), 0o644))
+
+	img := newTestImage(t)
+	require.NoError(t, img.appendCrypttabFrom(crypttab))
+	require.True(t, img.contains["/etc/crypttab"])
+}
+
+func TestAppendCrypttabNoautoSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	// create a keyfile that would be bundled if the entry weren't noauto
+	kf := filepath.Join(dir, "secret.key")
+	require.NoError(t, os.WriteFile(kf, []byte("hunter2"), 0o600))
+
+	crypttab := filepath.Join(dir, "crypttab.initramfs")
+	content := "cryptswap UUID=11111111-1111-1111-1111-111111111111 " + kf + " noauto\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img := newTestImage(t)
+	require.NoError(t, img.appendCrypttabFrom(crypttab))
+	// crypttab itself is bundled
+	require.True(t, img.contains["/etc/crypttab"])
+	// but the keyfile referenced by the noauto entry should NOT be bundled
+	require.False(t, img.contains[kf])
+}
+
+func TestAppendCrypttabKeyfileBundled(t *testing.T) {
+	dir := t.TempDir()
+
+	kf := filepath.Join(dir, "swap.key")
+	require.NoError(t, os.WriteFile(kf, []byte("supersecret"), 0o600))
+
+	crypttab := filepath.Join(dir, "crypttab.initramfs")
+	content := "cryptswap UUID=22222222-2222-2222-2222-222222222222 " + kf + " discard\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img := newTestImage(t)
+	require.NoError(t, img.appendCrypttabFrom(crypttab))
+	require.True(t, img.contains[kf])
+}
+
+func TestAppendCrypttabKeyfileMissing(t *testing.T) {
+	dir := t.TempDir()
+
+	crypttab := filepath.Join(dir, "crypttab.initramfs")
+	content := "cryptswap UUID=22222222-2222-2222-2222-222222222222 /nonexistent/key.file discard\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img := newTestImage(t)
+	require.Error(t, img.appendCrypttabFrom(crypttab))
+}
+
+func TestAppendCrypttabNoneKeyfileSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	crypttab := filepath.Join(dir, "crypttab.initramfs")
+	require.NoError(t, os.WriteFile(crypttab, []byte("cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none discard\n"), 0o644))
+
+	img := newTestImage(t)
+	require.NoError(t, img.appendCrypttabFrom(crypttab))
+}
+
+func TestAppendCrypttabHeaderBundled(t *testing.T) {
+	dir := t.TempDir()
+
+	hdr := filepath.Join(dir, "root.hdr")
+	require.NoError(t, os.WriteFile(hdr, []byte("fake-luks-header"), 0o600))
+
+	crypttab := filepath.Join(dir, "crypttab.initramfs")
+	content := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none header=" + hdr + "\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img := newTestImage(t)
+	require.NoError(t, img.appendCrypttabFrom(crypttab))
+	require.True(t, img.contains[hdr])
+}
+
+func TestAppendCrypttabHeaderRelativePathError(t *testing.T) {
+	dir := t.TempDir()
+
+	crypttab := filepath.Join(dir, "crypttab.initramfs")
+	content := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none header=relative/path.hdr\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img := newTestImage(t)
+	require.Error(t, img.appendCrypttabFrom(crypttab))
+}
+
+func TestAppendCrypttabCommentAndBlankLines(t *testing.T) {
+	dir := t.TempDir()
+
+	crypttab := filepath.Join(dir, "crypttab.initramfs")
+	content := `
+# This is a comment
+
+cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none discard
+# another comment
+`
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img := newTestImage(t)
+	require.NoError(t, img.appendCrypttabFrom(crypttab))
+	require.True(t, img.contains["/etc/crypttab"])
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -25,6 +25,7 @@ type generatorConfig struct {
 	compression             string
 	timeout                 time.Duration
 	extraFiles              []string
+	crypttabFile            string // path to crypttab on host; empty = use default /etc/crypttab.initramfs
 	output                  string
 	forceOverwrite          bool // overwrite output file
 	initBinary              string
@@ -116,7 +117,11 @@ func generateInitRamfs(conf *generatorConfig) error {
 		return err
 	}
 
-	if err := img.appendCrypttab(); err != nil {
+	crypttabPath := conf.crypttabFile
+	if crypttabPath == "" {
+		crypttabPath = "/etc/crypttab.initramfs"
+	}
+	if err := img.appendCrypttabFrom(crypttabPath); err != nil {
 		return err
 	}
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -116,6 +116,10 @@ func generateInitRamfs(conf *generatorConfig) error {
 		return err
 	}
 
+	if err := img.appendCrypttab(); err != nil {
+		return err
+	}
+
 	kmod, err := NewKmod(conf)
 	if err != nil {
 		return err

--- a/generator/main.go
+++ b/generator/main.go
@@ -22,6 +22,7 @@ var opts struct {
 		KernelVersion    string `long:"kernel-version" description:"Linux kernel version to generate initramfs for"`
 		ModulesDirectory string `long:"modules-dir" description:"Directory with kernel modules, if not set then /usr/lib/modules/$kernel-version is used"`
 		ConfigFile       string `long:"config" default:"/etc/booster.yaml" description:"Configuration file path"`
+		CrypttabFile     string `long:"crypttab" description:"Path to crypttab file to bundle (default: /etc/crypttab.initramfs)"`
 		Universal        bool   `long:"universal" description:"Add wide range of modules/tools to allow this image boot at different machines"`
 		Strip            bool   `long:"strip" description:"Strip ELF files (binaries, shared libraries and kernel modules) before adding it to the image"`
 		Args             struct {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/anatol/booster
 
 go 1.26
 
+replace github.com/anatol/luks.go => /home/stew/Coding/claude/luks.go
+
 require (
 	github.com/anatol/clevis.go v0.0.0-20251105050026-c2c7ddab8f14
 	github.com/anatol/devmapper.go v0.0.0-20250316020617-2671eefd35d7

--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 )
 
 func parseCmdline() error {
@@ -152,6 +154,14 @@ func getNextParam(params string, index int) (string, string, int) {
 func parseParams(params string) error {
 	var luksOptions []string
 
+	var tokenOpts struct {
+		fido2           bool
+		tpm2            bool
+		timeout         time.Duration
+		timeoutExplicit bool
+	}
+	var tokenOptsSeen bool
+
 	var key, value string
 	i := 0
 
@@ -219,6 +229,26 @@ func parseParams(params string) error {
 			rootRw = true
 		case "rd.luks.options":
 			for o := range strings.SplitSeq(value, ",") {
+				if strings.HasPrefix(o, "fido2-device=") {
+					tokenOpts.fido2 = true
+					tokenOptsSeen = true
+					continue
+				}
+				if strings.HasPrefix(o, "tpm2-device=") {
+					tokenOpts.tpm2 = true
+					tokenOptsSeen = true
+					continue
+				}
+				if strings.HasPrefix(o, "token-timeout=") {
+					d, err := parseTokenTimeout(strings.TrimPrefix(o, "token-timeout="))
+					if err != nil {
+						return fmt.Errorf("invalid token-timeout in rd.luks.options: %v", err)
+					}
+					tokenOpts.timeout = d
+					tokenOpts.timeoutExplicit = true
+					tokenOptsSeen = true
+					continue
+				}
 				flag, ok := rdLuksOptions[o]
 				if !ok {
 					return fmt.Errorf("unknown value in rd.luks.options: %v", o)
@@ -288,11 +318,48 @@ func parseParams(params string) error {
 		}
 	}
 
-	if luksOptions != nil {
+	if luksOptions != nil || tokenOptsSeen {
 		for i := range luksMappings {
-			luksMappings[i].options = luksOptions
+			if luksOptions != nil {
+				luksMappings[i].options = luksOptions
+			}
+			if tokenOptsSeen {
+				luksMappings[i].tokenFido2 = tokenOpts.fido2
+				luksMappings[i].tokenTpm2 = tokenOpts.tpm2
+				// Default 30s timeout prevents hang when token device is absent.
+				// token-timeout=0 explicitly means wait forever.
+				if (tokenOpts.fido2 || tokenOpts.tpm2) && !tokenOpts.timeoutExplicit {
+					luksMappings[i].tokenTimeout = 30 * time.Second
+				} else {
+					luksMappings[i].tokenTimeout = tokenOpts.timeout
+				}
+			}
 		}
 	}
 
 	return nil
+}
+
+// parseTokenTimeout parses token-timeout value from rd.luks.options.
+// A bare integer (no suffix) is treated as seconds, matching systemd semantics.
+// A value of 0 means wait forever.
+func parseTokenTimeout(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty timeout value")
+	}
+	isAllDigits := true
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			isAllDigits = false
+			break
+		}
+	}
+	if isAllDigits {
+		secs, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(secs) * time.Second, nil
+	}
+	return time.ParseDuration(s)
 }

--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -305,7 +305,12 @@ func parseParams(params string) error {
 			}
 
 			m := findOrCreateLuksMapping(uuid)
-			m.keyfile = keyfile
+			path, ref, err := parseKeyfileField(keyfile)
+			if err != nil {
+				return fmt.Errorf("rd.luks.key: %v", err)
+			}
+			m.keyfile = path
+			m.keyfileDeviceRef = ref
 		case "zfs":
 			zfsDataset = value
 		default:

--- a/init/cmdline_test.go
+++ b/init/cmdline_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -9,7 +10,7 @@ import (
 func TestParseParamsInvalidLuksOptions(t *testing.T) {
 	luksMappings = nil
 
-	require.Error(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root rd.luks.name=7843d77f-cdd6-4289-a4de-a708c4aacede=swap rd.luks.name=7f28c723-fd6b-4640-bc94-9366edd8880d=cache root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f video=efifb:on add_efi_memmap zswap.enabled=1 zswap.max_pool_percent=100 zswap.zpool=z3fold resume=/dev/mapper/swap acpi=copy_dsdt rd.luks.options=tpm2-device=auto"))
+	require.Error(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root rd.luks.name=7843d77f-cdd6-4289-a4de-a708c4aacede=swap rd.luks.name=7f28c723-fd6b-4640-bc94-9366edd8880d=cache root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f video=efifb:on add_efi_memmap zswap.enabled=1 zswap.max_pool_percent=100 zswap.zpool=z3fold resume=/dev/mapper/swap acpi=copy_dsdt rd.luks.options=bogus-option"))
 }
 
 func TestParseParams(t *testing.T) {
@@ -146,4 +147,53 @@ func TestGetNextParamMulti(t *testing.T) {
 			require.Equal(t, output.outIndex, i)
 		}
 	}
+}
+
+func TestParseParamsTokenOptions(t *testing.T) {
+	luksMappings = nil
+
+	require.NoError(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f rd.luks.options=fido2-device=auto,no-read-workqueue"))
+	require.Len(t, luksMappings, 1)
+
+	root := luksMappings[0]
+	require.True(t, root.tokenFido2)
+	require.False(t, root.tokenTpm2)
+	require.Equal(t, []string{"no-read-workqueue"}, root.options)
+	// default 30s timeout applied when fido2-device=auto is set without explicit token-timeout
+	require.Equal(t, 30*time.Second, root.tokenTimeout)
+}
+
+func TestParseParamsTpm2DeviceAuto(t *testing.T) {
+	luksMappings = nil
+
+	require.NoError(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f rd.luks.options=tpm2-device=auto"))
+	require.Len(t, luksMappings, 1)
+
+	root := luksMappings[0]
+	require.False(t, root.tokenFido2)
+	require.True(t, root.tokenTpm2)
+	require.Equal(t, 30*time.Second, root.tokenTimeout)
+}
+
+func TestParseParamsTokenTimeout(t *testing.T) {
+	// explicit duration suffix
+	luksMappings = nil
+	require.NoError(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f rd.luks.options=fido2-device=auto,token-timeout=60s"))
+	require.Equal(t, 60*time.Second, luksMappings[0].tokenTimeout)
+
+	// bare integer treated as seconds
+	luksMappings = nil
+	require.NoError(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f rd.luks.options=fido2-device=auto,token-timeout=45"))
+	require.Equal(t, 45*time.Second, luksMappings[0].tokenTimeout)
+
+	// explicit token-timeout=0 means wait forever (no default override)
+	luksMappings = nil
+	require.NoError(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f rd.luks.options=fido2-device=auto,token-timeout=0"))
+	require.Equal(t, time.Duration(0), luksMappings[0].tokenTimeout)
+}
+
+func TestParseParamsInvalidTokenTimeout(t *testing.T) {
+	luksMappings = nil
+
+	require.Error(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f rd.luks.options=fido2-device=auto,token-timeout=notaduration"))
 }

--- a/init/console.go
+++ b/init/console.go
@@ -178,10 +178,9 @@ func readPasswordLine(reader io.Reader) ([]byte, error) {
 
 var inputMutex sync.Mutex
 
-func readPassword(prompt, postPrompt string) ([]byte, error) {
-	inputMutex.Lock()
-	defer inputMutex.Unlock()
-
+// readPasswordLocked reads a password from stdin. The caller must hold
+// inputMutex before calling this function.
+func readPasswordLocked(prompt, postPrompt string) ([]byte, error) {
 	console(prompt)
 
 	stdin := os.Stdin
@@ -210,4 +209,10 @@ func readPassword(prompt, postPrompt string) ([]byte, error) {
 		console("\n")
 	}
 	return password, err
+}
+
+func readPassword(prompt, postPrompt string) ([]byte, error) {
+	inputMutex.Lock()
+	defer inputMutex.Unlock()
+	return readPasswordLocked(prompt, postPrompt)
 }

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -63,6 +63,7 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 			options         []string
 			header          string
 			keySlot         = -1
+			tries           int
 			fido2           bool
 			tpm2            bool
 			timeout         time.Duration
@@ -105,8 +106,11 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 				// TODO: keyfile-offset= / keyfile-size= — read a sub-range of the keyfile;
 				// pass offset/size to recoverKeyfilePassword once supported.
 			case strings.HasPrefix(opt, "tries="):
-				// TODO: tries=N — limit keyboard password retries to N attempts;
-				// currently the keyboard prompt retries indefinitely.
+				n, err := strconv.Atoi(strings.TrimPrefix(opt, "tries="))
+				if err != nil || n < 0 {
+					return nil, fmt.Errorf("crypttab entry %q: invalid tries value: %q", name, strings.TrimPrefix(opt, "tries="))
+				}
+				tries = n
 			default:
 				if flag, ok := rdLuksOptions[opt]; ok {
 					options = append(options, flag)
@@ -131,6 +135,7 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 			options: options,
 			header:  header,
 			keySlot: keySlot,
+			tries:   tries,
 		}
 		m.tokenFido2 = fido2
 		m.tokenTpm2 = tpm2

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -98,6 +98,15 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 					return nil, fmt.Errorf("crypttab entry %q: invalid key-slot: %v", name, err)
 				}
 				keySlot = n
+			case opt == "nofail":
+				// TODO: nofail — non-fatal unlock failure; requires rearchitecting
+				// boot dependency logic so a failed unlock doesn't block non-root mounts.
+			case strings.HasPrefix(opt, "keyfile-offset="), strings.HasPrefix(opt, "keyfile-size="):
+				// TODO: keyfile-offset= / keyfile-size= — read a sub-range of the keyfile;
+				// pass offset/size to recoverKeyfilePassword once supported.
+			case strings.HasPrefix(opt, "tries="):
+				// TODO: tries=N — limit keyboard password retries to N attempts;
+				// currently the keyboard prompt retries indefinitely.
 			default:
 				if flag, ok := rdLuksOptions[opt]; ok {
 					options = append(options, flag)

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -11,6 +11,25 @@ import (
 	"time"
 )
 
+// parseKeyfileField parses the keyfile field from a crypttab or rd.luks.key value.
+// If the right-hand side of a colon is a device specifier (UUID=, LABEL=, PARTUUID=, PARTLABEL=),
+// the device ref is returned and path contains only the left-hand side (path within that device).
+// Otherwise path == raw and ref == nil.
+func parseKeyfileField(raw string) (path string, ref *deviceRef, err error) {
+	if idx := strings.Index(raw, ":"); idx >= 0 {
+		right := raw[idx+1:]
+		if strings.HasPrefix(right, "UUID=") || strings.HasPrefix(right, "LABEL=") ||
+			strings.HasPrefix(right, "PARTUUID=") || strings.HasPrefix(right, "PARTLABEL=") {
+			ref, err = parseDeviceRef(right)
+			if err != nil {
+				return "", nil, fmt.Errorf("keyfile device ref %q: %v", right, err)
+			}
+			return raw[:idx], ref, nil
+		}
+	}
+	return raw, nil, nil
+}
+
 // parseCrypttab reads /etc/crypttab (bundled from the host's /etc/crypttab.initramfs)
 // and returns a slice of LUKS mappings to unlock at boot.
 // Returns nil without error if /etc/crypttab is absent — opt-in by file presence.
@@ -67,6 +86,7 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 			tries           int
 			keyfileOffset   int64
 			keyfileSize     int64
+			keyfileTimeout  time.Duration
 			fido2           bool
 			tpm2            bool
 			timeout         time.Duration
@@ -94,6 +114,12 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 				}
 				timeout = d
 				timeoutExplicit = true
+			case strings.HasPrefix(opt, "keyfile-timeout="):
+				d, err := parseTokenTimeout(strings.TrimPrefix(opt, "keyfile-timeout="))
+				if err != nil {
+					return nil, fmt.Errorf("crypttab entry %q: invalid keyfile-timeout: %v", name, err)
+				}
+				keyfileTimeout = d
 			case strings.HasPrefix(opt, "header="):
 				header = strings.TrimPrefix(opt, "header=")
 			case strings.HasPrefix(opt, "key-slot="):
@@ -139,17 +165,28 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 			return nil, fmt.Errorf("crypttab entry %q: invalid device %q: %v", name, deviceStr, err)
 		}
 
+		keyfilePath, keyfileRef, err := parseKeyfileField(keyfile)
+		if err != nil {
+			return nil, fmt.Errorf("crypttab entry %q: %v", name, err)
+		}
+
+		if keyfileRef != nil && deviceRefEqual(ref, keyfileRef) {
+			return nil, fmt.Errorf("crypttab entry %q: keyfile device must not be the LUKS device", name)
+		}
+
 		m := &luksMapping{
-			ref:           ref,
-			name:          name,
-			keyfile:       keyfile,
-			options:       options,
-			header:        header,
-			keySlot:       keySlot,
-			tries:         tries,
-			noFail:        noFail,
-			keyfileOffset: keyfileOffset,
-			keyfileSize:   keyfileSize,
+			ref:              ref,
+			name:             name,
+			keyfile:          keyfilePath,
+			options:          options,
+			header:           header,
+			keySlot:          keySlot,
+			tries:            tries,
+			noFail:           noFail,
+			keyfileOffset:    keyfileOffset,
+			keyfileSize:      keyfileSize,
+			keyfileDeviceRef: keyfileRef,
+			keyfileTimeout:   keyfileTimeout,
 		}
 		m.tokenFido2 = fido2
 		m.tokenTpm2 = tpm2

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -60,6 +60,7 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 
 		var (
 			noauto          bool
+			noFail          bool
 			options         []string
 			header          string
 			keySlot         = -1
@@ -100,8 +101,7 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 				}
 				keySlot = n
 			case opt == "nofail":
-				// TODO: nofail — non-fatal unlock failure; requires rearchitecting
-				// boot dependency logic so a failed unlock doesn't block non-root mounts.
+				noFail = true
 			case strings.HasPrefix(opt, "keyfile-offset="), strings.HasPrefix(opt, "keyfile-size="):
 				// TODO: keyfile-offset= / keyfile-size= — read a sub-range of the keyfile;
 				// pass offset/size to recoverKeyfilePassword once supported.
@@ -136,6 +136,7 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 			header:  header,
 			keySlot: keySlot,
 			tries:   tries,
+			noFail:  noFail,
 		}
 		m.tokenFido2 = fido2
 		m.tokenTpm2 = tpm2

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// parseCrypttab reads /etc/crypttab (bundled from the host's /etc/crypttab.initramfs)
+// and returns a slice of LUKS mappings to unlock at boot.
+// Returns nil without error if /etc/crypttab is absent — opt-in by file presence.
+func parseCrypttab() ([]*luksMapping, error) {
+	f, err := os.Open("/etc/crypttab")
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return parseCrypttabReader(f)
+}
+
+// parseCrypttabReader is the testable core: it parses crypttab lines from r.
+func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
+	var mappings []*luksMapping
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		name := fields[0]
+		deviceStr := fields[1]
+
+		var keyfile string
+		if len(fields) >= 3 {
+			keyfile = fields[2]
+			if keyfile == "none" || keyfile == "-" {
+				keyfile = ""
+			}
+		}
+
+		var optStr string
+		if len(fields) >= 4 {
+			optStr = fields[3]
+		}
+
+		var (
+			noauto          bool
+			options         []string
+			header          string
+			keySlot         = -1
+			fido2           bool
+			tpm2            bool
+			timeout         time.Duration
+			timeoutExplicit bool
+		)
+
+		for _, opt := range strings.Split(optStr, ",") {
+			opt = strings.TrimSpace(opt)
+			switch {
+			case opt == "":
+				continue
+			case opt == "noauto":
+				noauto = true
+			case opt == "swap" || opt == "tmp" || opt == "plain" || opt == "bitlk" || opt == "tcrypt":
+				// non-LUKS modes — skip this entry
+				noauto = true
+			case strings.HasPrefix(opt, "fido2-device="):
+				fido2 = true
+			case strings.HasPrefix(opt, "tpm2-device="):
+				tpm2 = true
+			case strings.HasPrefix(opt, "token-timeout="):
+				d, err := parseTokenTimeout(strings.TrimPrefix(opt, "token-timeout="))
+				if err != nil {
+					return nil, fmt.Errorf("crypttab entry %q: invalid token-timeout: %v", name, err)
+				}
+				timeout = d
+				timeoutExplicit = true
+			case strings.HasPrefix(opt, "header="):
+				header = strings.TrimPrefix(opt, "header=")
+			case strings.HasPrefix(opt, "key-slot="):
+				n, err := strconv.Atoi(strings.TrimPrefix(opt, "key-slot="))
+				if err != nil {
+					return nil, fmt.Errorf("crypttab entry %q: invalid key-slot: %v", name, err)
+				}
+				keySlot = n
+			default:
+				if flag, ok := rdLuksOptions[opt]; ok {
+					options = append(options, flag)
+				}
+				// unknown options are silently ignored, matching systemd behaviour
+			}
+		}
+
+		if noauto {
+			continue
+		}
+
+		ref, err := parseDeviceRef(deviceStr)
+		if err != nil {
+			return nil, fmt.Errorf("crypttab entry %q: invalid device %q: %v", name, deviceStr, err)
+		}
+
+		m := &luksMapping{
+			ref:     ref,
+			name:    name,
+			keyfile: keyfile,
+			options: options,
+			header:  header,
+			keySlot: keySlot,
+		}
+		m.tokenFido2 = fido2
+		m.tokenTpm2 = tpm2
+		// Apply default 30 s token timeout when a token option is set without an
+		// explicit token-timeout=, matching the rd.luks.options behaviour in cmdline.go.
+		if (fido2 || tpm2) && !timeoutExplicit {
+			m.tokenTimeout = 30 * time.Second
+		} else {
+			m.tokenTimeout = timeout
+		}
+
+		mappings = append(mappings, m)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return mappings, nil
+}
+
+// luksMatchExists reports whether luksMappings already contains an entry whose
+// device reference matches ref.  Used to let kernel cmdline take precedence over
+// /etc/crypttab entries.
+func luksMatchExists(ref *deviceRef) bool {
+	for _, m := range luksMappings {
+		if deviceRefEqual(m.ref, ref) {
+			return true
+		}
+	}
+	return false
+}
+
+// deviceRefEqual returns true when a and b describe the same device.
+func deviceRefEqual(a, b *deviceRef) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.format != b.format {
+		return false
+	}
+	switch a.format {
+	case refFsUUID, refGptUUID:
+		return bytes.Equal(a.data.(UUID), b.data.(UUID))
+	case refGptUUIDPartoff:
+		ad, bd := a.data.(gptPartoffData), b.data.(gptPartoffData)
+		return bytes.Equal(ad.uuid, bd.uuid) && ad.offset == bd.offset
+	case refFsLabel, refGptLabel, refPath, refHwPath, refWwID:
+		return a.data.(string) == b.data.(string)
+	default:
+		return false
+	}
+}

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -65,6 +65,8 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 			header          string
 			keySlot         = -1
 			tries           int
+			keyfileOffset   int64
+			keyfileSize     int64
 			fido2           bool
 			tpm2            bool
 			timeout         time.Duration
@@ -102,9 +104,18 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 				keySlot = n
 			case opt == "nofail":
 				noFail = true
-			case strings.HasPrefix(opt, "keyfile-offset="), strings.HasPrefix(opt, "keyfile-size="):
-				// TODO: keyfile-offset= / keyfile-size= — read a sub-range of the keyfile;
-				// pass offset/size to recoverKeyfilePassword once supported.
+			case strings.HasPrefix(opt, "keyfile-offset="):
+				n, err := strconv.ParseInt(strings.TrimPrefix(opt, "keyfile-offset="), 10, 64)
+				if err != nil || n < 0 {
+					return nil, fmt.Errorf("crypttab entry %q: invalid keyfile-offset: %q", name, strings.TrimPrefix(opt, "keyfile-offset="))
+				}
+				keyfileOffset = n
+			case strings.HasPrefix(opt, "keyfile-size="):
+				n, err := strconv.ParseInt(strings.TrimPrefix(opt, "keyfile-size="), 10, 64)
+				if err != nil || n < 0 {
+					return nil, fmt.Errorf("crypttab entry %q: invalid keyfile-size: %q", name, strings.TrimPrefix(opt, "keyfile-size="))
+				}
+				keyfileSize = n
 			case strings.HasPrefix(opt, "tries="):
 				n, err := strconv.Atoi(strings.TrimPrefix(opt, "tries="))
 				if err != nil || n < 0 {
@@ -129,14 +140,16 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 		}
 
 		m := &luksMapping{
-			ref:     ref,
-			name:    name,
-			keyfile: keyfile,
-			options: options,
-			header:  header,
-			keySlot: keySlot,
-			tries:   tries,
-			noFail:  noFail,
+			ref:           ref,
+			name:          name,
+			keyfile:       keyfile,
+			options:       options,
+			header:        header,
+			keySlot:       keySlot,
+			tries:         tries,
+			noFail:        noFail,
+			keyfileOffset: keyfileOffset,
+			keyfileSize:   keyfileSize,
 		}
 		m.tokenFido2 = fido2
 		m.tokenTpm2 = tpm2

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -131,6 +131,37 @@ func TestParseCrypttabNofailDefault(t *testing.T) {
 	require.False(t, m[0].noFail)
 }
 
+func TestParseCrypttabKeyfileOffset(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /etc/key keyfile-offset=512\n")
+	require.Len(t, m, 1)
+	require.Equal(t, int64(512), m[0].keyfileOffset)
+	require.Equal(t, int64(0), m[0].keyfileSize)
+}
+
+func TestParseCrypttabKeyfileSize(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /etc/key keyfile-size=64\n")
+	require.Len(t, m, 1)
+	require.Equal(t, int64(0), m[0].keyfileOffset)
+	require.Equal(t, int64(64), m[0].keyfileSize)
+}
+
+func TestParseCrypttabKeyfileOffsetAndSize(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /etc/key keyfile-offset=128,keyfile-size=32\n")
+	require.Len(t, m, 1)
+	require.Equal(t, int64(128), m[0].keyfileOffset)
+	require.Equal(t, int64(32), m[0].keyfileSize)
+}
+
+func TestParseCrypttabKeyfileOffsetInvalid(t *testing.T) {
+	_, err := parseCrypttabReader(strings.NewReader("cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /etc/key keyfile-offset=bad\n"))
+	require.Error(t, err)
+}
+
+func TestParseCrypttabKeyfileSizeInvalid(t *testing.T) {
+	_, err := parseCrypttabReader(strings.NewReader("cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /etc/key keyfile-size=-1\n"))
+	require.Error(t, err)
+}
+
 func TestParseCrypttabTries(t *testing.T) {
 	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tries=3\n")
 	require.Len(t, m, 1)

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -246,6 +246,108 @@ func TestDeviceRefEqual(t *testing.T) {
 	require.False(t, deviceRefEqual(nil, a))
 }
 
+func TestParseKeyfileFieldPlain(t *testing.T) {
+	path, ref, err := parseKeyfileField("/etc/keys/root.key")
+	require.NoError(t, err)
+	require.Equal(t, "/etc/keys/root.key", path)
+	require.Nil(t, ref)
+}
+
+func TestParseKeyfileFieldEmpty(t *testing.T) {
+	path, ref, err := parseKeyfileField("")
+	require.NoError(t, err)
+	require.Equal(t, "", path)
+	require.Nil(t, ref)
+}
+
+func TestParseKeyfileFieldUUID(t *testing.T) {
+	path, ref, err := parseKeyfileField("/keyfile:UUID=f1e2d3c4-b5a6-4789-8abc-def123456789")
+	require.NoError(t, err)
+	require.Equal(t, "/keyfile", path)
+	require.NotNil(t, ref)
+	require.Equal(t, refFsUUID, ref.format)
+}
+
+func TestParseKeyfileFieldLabel(t *testing.T) {
+	path, ref, err := parseKeyfileField("/keyfile:LABEL=myusbkey")
+	require.NoError(t, err)
+	require.Equal(t, "/keyfile", path)
+	require.NotNil(t, ref)
+	require.Equal(t, refFsLabel, ref.format)
+	require.Equal(t, "myusbkey", ref.data.(string))
+}
+
+func TestParseKeyfileFieldPartuuid(t *testing.T) {
+	path, ref, err := parseKeyfileField("/key:PARTUUID=f1e2d3c4-b5a6-4789-8abc-def123456789")
+	require.NoError(t, err)
+	require.Equal(t, "/key", path)
+	require.NotNil(t, ref)
+	require.Equal(t, refGptUUID, ref.format)
+}
+
+func TestParseKeyfileFieldPartlabel(t *testing.T) {
+	path, ref, err := parseKeyfileField("/key:PARTLABEL=usbkeys")
+	require.NoError(t, err)
+	require.Equal(t, "/key", path)
+	require.NotNil(t, ref)
+	require.Equal(t, refGptLabel, ref.format)
+	require.Equal(t, "usbkeys", ref.data.(string))
+}
+
+func TestParseKeyfileFieldColonNonDevice(t *testing.T) {
+	// colon present but right side is not a recognised device specifier — treat whole string as path
+	path, ref, err := parseKeyfileField("/etc/key:something")
+	require.NoError(t, err)
+	require.Equal(t, "/etc/key:something", path)
+	require.Nil(t, ref)
+}
+
+func TestParseKeyfileFieldInvalidUUID(t *testing.T) {
+	_, _, err := parseKeyfileField("/keyfile:UUID=not-a-valid-uuid")
+	require.Error(t, err)
+}
+
+func TestParseCrypttabKeyfileOnDevice(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /keyfile:UUID=f1e2d3c4-b5a6-4789-8abc-def123456789\n")
+	require.Len(t, m, 1)
+	require.Equal(t, "/keyfile", m[0].keyfile)
+	require.NotNil(t, m[0].keyfileDeviceRef)
+	require.Equal(t, refFsUUID, m[0].keyfileDeviceRef.format)
+}
+
+func TestParseCrypttabKeyfileTimeout(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /keyfile:UUID=f1e2d3c4-b5a6-4789-8abc-def123456789 keyfile-timeout=30\n")
+	require.Len(t, m, 1)
+	require.Equal(t, 30*time.Second, m[0].keyfileTimeout)
+}
+
+func TestParseCrypttabKeyfileTimeoutZero(t *testing.T) {
+	// keyfile-timeout=0 means wait forever
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /keyfile:UUID=f1e2d3c4-b5a6-4789-8abc-def123456789 keyfile-timeout=0\n")
+	require.Len(t, m, 1)
+	require.Equal(t, time.Duration(0), m[0].keyfileTimeout)
+}
+
+func TestParseCrypttabKeyfileTimeoutInvalid(t *testing.T) {
+	_, err := parseCrypttabReader(strings.NewReader("cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /keyfile keyfile-timeout=bad\n"))
+	require.Error(t, err)
+}
+
+func TestParseCrypttabSameDeviceError(t *testing.T) {
+	// keyfile device UUID == LUKS device UUID → parse-time error
+	_, err := parseCrypttabReader(strings.NewReader("cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /keyfile:UUID=ab6d7d78-b816-4495-928d-766d6607035e\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "keyfile device must not be the LUKS device")
+}
+
+func TestParseCrypttabKeyfileOnDeviceNoRef(t *testing.T) {
+	// plain keyfile path (no colon) → keyfileDeviceRef must be nil
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /etc/keys/root.key discard\n")
+	require.Len(t, m, 1)
+	require.Nil(t, m[0].keyfileDeviceRef)
+	require.Equal(t, time.Duration(0), m[0].keyfileTimeout)
+}
+
 func TestLuksMatchExists(t *testing.T) {
 	uuidStr := "ab6d7d78-b816-4495-928d-766d6607035e"
 	uuid, err := parseUUID(uuidStr)

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anatol/luks.go"
+	"github.com/stretchr/testify/require"
+)
+
+func crypttabMappings(t *testing.T, input string) []*luksMapping {
+	t.Helper()
+	m, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	return m
+}
+
+func TestParseCrypttabEmpty(t *testing.T) {
+	require.Empty(t, crypttabMappings(t, ""))
+	require.Empty(t, crypttabMappings(t, "# just a comment\n\n"))
+}
+
+func TestParseCrypttabBasic(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none\n")
+	require.Len(t, m, 1)
+	require.Equal(t, "cryptroot", m[0].name)
+	require.Equal(t, refFsUUID, m[0].ref.format)
+	require.Equal(t, "ab6d7d78-b816-4495-928d-766d6607035e", m[0].ref.data.(UUID).toString())
+	require.Empty(t, m[0].keyfile)
+	require.Empty(t, m[0].options)
+	require.Equal(t, -1, m[0].keySlot)
+}
+
+func TestParseCrypttabKeyfileDash(t *testing.T) {
+	// both "none" and "-" mean interactive passphrase
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e -\n")
+	require.Len(t, m, 1)
+	require.Empty(t, m[0].keyfile)
+}
+
+func TestParseCrypttabKeyfile(t *testing.T) {
+	m := crypttabMappings(t, "cryptswap UUID=deadbeef-dead-beef-dead-beefdeadbeef /etc/keys/swap.key discard\n")
+	require.Len(t, m, 1)
+	require.Equal(t, "/etc/keys/swap.key", m[0].keyfile)
+}
+
+func TestParseCrypttabNoauto(t *testing.T) {
+	input := `
+cryptroot  UUID=ab6d7d78-b816-4495-928d-766d6607035e  none  discard
+cryptswap  UUID=def-00000000-0000-0000-0000-000000456789  none  noauto
+`
+	m := crypttabMappings(t, input)
+	require.Len(t, m, 1)
+	require.Equal(t, "cryptroot", m[0].name)
+}
+
+func TestParseCrypttabNonLuksModes(t *testing.T) {
+	input := `
+cryptroot  UUID=ab6d7d78-b816-4495-928d-766d6607035e  none  discard
+swapvol    UUID=11111111-1111-1111-1111-111111111111  /dev/urandom  swap
+tmpvol     UUID=22222222-2222-2222-2222-222222222222  /dev/urandom  tmp
+plainvol   UUID=33333333-3333-3333-3333-333333333333  none  plain
+`
+	m := crypttabMappings(t, input)
+	require.Len(t, m, 1)
+	require.Equal(t, "cryptroot", m[0].name)
+}
+
+func TestParseCrypttabDmCryptFlags(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none discard,no-read-workqueue,no-write-workqueue\n")
+	require.Len(t, m, 1)
+	require.ElementsMatch(t, []string{luks.FlagAllowDiscards, luks.FlagNoReadWorkqueue, luks.FlagNoWriteWorkqueue}, m[0].options)
+}
+
+func TestParseCrypttabFido2(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none fido2-device=auto\n")
+	require.Len(t, m, 1)
+	require.True(t, m[0].tokenFido2)
+	require.False(t, m[0].tokenTpm2)
+	require.Equal(t, 30*time.Second, m[0].tokenTimeout) // default timeout applied
+}
+
+func TestParseCrypttabTpm2(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tpm2-device=auto\n")
+	require.Len(t, m, 1)
+	require.True(t, m[0].tokenTpm2)
+	require.False(t, m[0].tokenFido2)
+	require.Equal(t, 30*time.Second, m[0].tokenTimeout)
+}
+
+func TestParseCrypttabTokenTimeout(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none fido2-device=auto,token-timeout=60\n")
+	require.Len(t, m, 1)
+	require.Equal(t, 60*time.Second, m[0].tokenTimeout)
+}
+
+func TestParseCrypttabTokenTimeoutZero(t *testing.T) {
+	// token-timeout=0 means wait forever
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tpm2-device=auto,token-timeout=0\n")
+	require.Len(t, m, 1)
+	require.Equal(t, time.Duration(0), m[0].tokenTimeout)
+}
+
+func TestParseCrypttabHeader(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none header=/etc/luks-headers/root.hdr\n")
+	require.Len(t, m, 1)
+	require.Equal(t, "/etc/luks-headers/root.hdr", m[0].header)
+}
+
+func TestParseCrypttabKeySlot(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none key-slot=2\n")
+	require.Len(t, m, 1)
+	require.Equal(t, 2, m[0].keySlot)
+}
+
+func TestParseCrypttabKeySlotInvalid(t *testing.T) {
+	_, err := parseCrypttabReader(strings.NewReader("cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none key-slot=notanumber\n"))
+	require.Error(t, err)
+}
+
+func TestParseCrypttabTokenTimeoutInvalid(t *testing.T) {
+	_, err := parseCrypttabReader(strings.NewReader("cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none fido2-device=auto,token-timeout=bad\n"))
+	require.Error(t, err)
+}
+
+func TestParseCrypttabDevicePath(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot /dev/sda2 none discard\n")
+	require.Len(t, m, 1)
+	require.Equal(t, refPath, m[0].ref.format)
+	require.Equal(t, "/dev/sda2", m[0].ref.data.(string))
+}
+
+func TestParseCrypttabLabelDevice(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot LABEL=myluksroot none\n")
+	require.Len(t, m, 1)
+	require.Equal(t, refFsLabel, m[0].ref.format)
+	require.Equal(t, "myluksroot", m[0].ref.data.(string))
+}
+
+func TestParseCrypttabMultipleEntries(t *testing.T) {
+	input := `
+# root volume
+cryptroot  UUID=ab6d7d78-b816-4495-928d-766d6607035e  none             discard,fido2-device=auto
+# data volume
+cryptdata  UUID=deadbeef-dead-beef-dead-beefdeadbeef  /etc/keys/data   discard
+`
+	m := crypttabMappings(t, input)
+	require.Len(t, m, 2)
+
+	require.Equal(t, "cryptroot", m[0].name)
+	require.True(t, m[0].tokenFido2)
+	require.Empty(t, m[0].keyfile)
+
+	require.Equal(t, "cryptdata", m[1].name)
+	require.False(t, m[1].tokenFido2)
+	require.Equal(t, "/etc/keys/data", m[1].keyfile)
+}
+
+func TestParseCrypttabUnknownOptionsIgnored(t *testing.T) {
+	// unknown options should be silently ignored (systemd behaviour)
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none discard,x-some-unknown-option\n")
+	require.Len(t, m, 1)
+	require.Equal(t, []string{luks.FlagAllowDiscards}, m[0].options)
+}
+
+func TestDeviceRefEqual(t *testing.T) {
+	uuidStr := "ab6d7d78-b816-4495-928d-766d6607035e"
+	uuid, err := parseUUID(uuidStr)
+	require.NoError(t, err)
+
+	a := &deviceRef{format: refFsUUID, data: uuid}
+	b := &deviceRef{format: refFsUUID, data: uuid}
+	require.True(t, deviceRefEqual(a, b))
+
+	c := &deviceRef{format: refFsLabel, data: "myroot"}
+	d := &deviceRef{format: refFsLabel, data: "myroot"}
+	require.True(t, deviceRefEqual(c, d))
+
+	// different formats
+	require.False(t, deviceRefEqual(a, c))
+
+	// nil cases
+	require.True(t, deviceRefEqual(nil, nil))
+	require.False(t, deviceRefEqual(a, nil))
+	require.False(t, deviceRefEqual(nil, a))
+}
+
+func TestLuksMatchExists(t *testing.T) {
+	uuidStr := "ab6d7d78-b816-4495-928d-766d6607035e"
+	uuid, err := parseUUID(uuidStr)
+	require.NoError(t, err)
+
+	ref := &deviceRef{format: refFsUUID, data: uuid}
+
+	// save and restore global state
+	saved := luksMappings
+	defer func() { luksMappings = saved }()
+
+	luksMappings = nil
+	require.False(t, luksMatchExists(ref))
+
+	luksMappings = []*luksMapping{{ref: ref, name: "cryptroot", keySlot: -1}}
+	require.True(t, luksMatchExists(ref))
+
+	other, _ := parseUUID("deadbeef-dead-beef-dead-beefdeadbeef")
+	otherRef := &deviceRef{format: refFsUUID, data: other}
+	require.False(t, luksMatchExists(otherRef))
+}

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -119,6 +119,18 @@ func TestParseCrypttabKeySlotInvalid(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseCrypttabNofail(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none nofail\n")
+	require.Len(t, m, 1)
+	require.True(t, m[0].noFail)
+}
+
+func TestParseCrypttabNofailDefault(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none discard\n")
+	require.Len(t, m, 1)
+	require.False(t, m[0].noFail)
+}
+
 func TestParseCrypttabTries(t *testing.T) {
 	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tries=3\n")
 	require.Len(t, m, 1)

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -119,6 +119,23 @@ func TestParseCrypttabKeySlotInvalid(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseCrypttabTries(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tries=3\n")
+	require.Len(t, m, 1)
+	require.Equal(t, 3, m[0].tries)
+}
+
+func TestParseCrypttabTriesZero(t *testing.T) {
+	m := crypttabMappings(t, "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tries=0\n")
+	require.Len(t, m, 1)
+	require.Equal(t, 0, m[0].tries)
+}
+
+func TestParseCrypttabTriesInvalid(t *testing.T) {
+	_, err := parseCrypttabReader(strings.NewReader("cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tries=bad\n"))
+	require.Error(t, err)
+}
+
 func TestParseCrypttabTokenTimeoutInvalid(t *testing.T) {
 	_, err := parseCrypttabReader(strings.NewReader("cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none fido2-device=auto,token-timeout=bad\n"))
 	require.Error(t, err)

--- a/init/luks.go
+++ b/init/luks.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/anatol/clevis.go"
@@ -25,10 +26,13 @@ import (
 // specifies information needed to process/open a LUKS device
 // often these mappings specified by a user via command-line
 type luksMapping struct {
-	ref     *deviceRef
-	name    string
-	keyfile string
-	options []string
+	ref          *deviceRef
+	name         string
+	keyfile      string
+	options      []string      // dm-crypt flags for d.FlagsAdd
+	tokenFido2   bool          // fido2-device=auto was set
+	tokenTpm2    bool          // tpm2-device=auto was set
+	tokenTimeout time.Duration // 0 = wait forever; >0 = defer keyboard until elapsed
 }
 
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
@@ -472,6 +476,34 @@ func luksOpen(dev string, mapping *luksMapping) error {
 
 	volumes := make(chan *luks.Volume)
 
+	// done is closed when a token has successfully unlocked the device,
+	// signalling fallback goroutines not to start the keyboard prompt.
+	done := make(chan struct{})
+	var closeDone sync.Once
+
+	// priorityTypes holds token types that should delay the keyboard prompt.
+	priorityTypes := make(map[string]bool)
+	if mapping.tokenFido2 {
+		priorityTypes["systemd-fido2"] = true
+	}
+	if mapping.tokenTpm2 {
+		priorityTypes["systemd-tpm2"] = true
+	}
+	hasPriority := len(priorityTypes) > 0
+
+	var tokenWg sync.WaitGroup
+	var keyboardOnce sync.Once
+
+	startKeyboard := func(checkSlots []int) {
+		keyboardOnce.Do(func() {
+			if len(mapping.keyfile) > 0 {
+				go recoverKeyfilePassword(volumes, d, checkSlots, mapping.name, mapping.keyfile)
+			} else {
+				go requestKeyboardPassword(volumes, d, checkSlots, mapping.name)
+			}
+		})
+	}
+
 	slotsWithTokens := make(map[int]bool)
 	tokens, err := d.Tokens()
 	if err != nil {
@@ -481,7 +513,15 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		if t.Type == "systemd-recovery" {
 			continue // skip systemd-recovery tokens as they are supposed to be entered by a keyboard later
 		}
-		go recoverTokenPassword(volumes, d, t)
+		if hasPriority && priorityTypes[t.Type] {
+			tokenWg.Add(1)
+			go func(tok luks.Token) {
+				defer tokenWg.Done()
+				recoverTokenPassword(volumes, d, tok)
+			}(t)
+		} else {
+			go recoverTokenPassword(volumes, d, t)
+		}
 		for _, s := range t.Slots {
 			slotsWithTokens[s] = true
 		}
@@ -494,17 +534,31 @@ func luksOpen(dev string, mapping *luksMapping) error {
 			checkSlotsWithPassword = append(checkSlotsWithPassword, s)
 		}
 	}
+
 	if len(checkSlotsWithPassword) > 0 {
-		// is there a keyfile defined for the password for this volume?
-		if len(mapping.keyfile) > 0 {
-			// if the keyfile doesn't work we will fallback to password
-			go recoverKeyfilePassword(volumes, d, checkSlotsWithPassword, mapping.name, mapping.keyfile)
+		if hasPriority {
+			// Launch a fallback goroutine: wait for priority tokens to finish
+			// (or for tokenTimeout to elapse), then start keyboard if not done.
+			go func() {
+				if mapping.tokenTimeout > 0 {
+					waitTimeout(&tokenWg, mapping.tokenTimeout)
+				} else {
+					tokenWg.Wait()
+				}
+				select {
+				case <-done:
+					// token already succeeded, skip keyboard
+				default:
+					startKeyboard(checkSlotsWithPassword)
+				}
+			}()
 		} else {
-			go requestKeyboardPassword(volumes, d, checkSlotsWithPassword, mapping.name)
+			startKeyboard(checkSlotsWithPassword)
 		}
 	}
 
 	v := <-volumes
+	closeDone.Do(func() { close(done) })
 
 	if err := loadRequiredCryptoModules(v.StorageEncryption); err != nil {
 		return err

--- a/init/luks.go
+++ b/init/luks.go
@@ -14,13 +14,14 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"regexp"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/anatol/clevis.go"
 	"github.com/anatol/luks.go"
+	"golang.org/x/sys/unix"
 )
 
 // specifies information needed to process/open a LUKS device
@@ -37,8 +38,10 @@ type luksMapping struct {
 	keySlot       int           // -1 = try all slots; >=0 restricts password checks to that slot
 	tries         int           // 0 = unlimited keyboard retries; >0 = max attempts
 	noFail        bool          // if true, unlock failure is non-fatal (boot continues)
-	keyfileOffset int64         // byte offset into keyfile (0 = start)
-	keyfileSize   int64         // bytes to read from keyfile (0 = read to end)
+	keyfileOffset    int64         // byte offset into keyfile (0 = start)
+	keyfileSize      int64         // bytes to read from keyfile (0 = read to end)
+	keyfileDeviceRef *deviceRef    // non-nil when keyfile lives on a separate device
+	keyfileTimeout   time.Duration // 0 = use MountTimeout; >0 = per-entry device wait timeout
 }
 
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
@@ -442,28 +445,51 @@ func readKeyfile(path string, offset, size int64) ([]byte, error) {
 	return io.ReadAll(f)
 }
 
-func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, keyfile string, maxTries int, keyfileOffset, keyfileSize int64) {
-	var err error
-	var password []byte
+func mountKeyDevice(ref *deviceRef, mountPoint string, timeout time.Duration) (func(), error) {
+	blk, err := waitForDeviceRef(ref, timeout)
+	if err != nil {
+		return nil, err
+	}
+	if !blk.isFs {
+		return nil, fmt.Errorf("keyfile device %s is not a mountable filesystem", blk.path)
+	}
+	if err := os.MkdirAll(mountPoint, 0o700); err != nil {
+		return nil, err
+	}
+	flags := uintptr(unix.MS_RDONLY | unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_NODEV)
+	if err := unix.Mount(blk.path, mountPoint, blk.format, flags, ""); err != nil {
+		return nil, fmt.Errorf("mounting keyfile device %s: %v", blk.path, err)
+	}
+	return func() {
+		_ = unix.Unmount(mountPoint, unix.MNT_DETACH)
+		_ = os.Remove(mountPoint)
+	}, nil
+}
 
-	// keyfile might be in the format /path:UUID=<DEV UUID> to indicate the keyfile lives on another device
-	parts := regexp.MustCompile("(?i):UUID=").Split(keyfile, 2)
-
-	if len(parts) == 1 {
-		password, err = readKeyfile(parts[0], keyfileOffset, keyfileSize)
-
-		if err != nil {
-			warning("reading password: %v", err)
+// acquireKeyfilePassword reads the keyfile, mounting a separate device if needed.
+// The device is unmounted before this function returns.
+func acquireKeyfilePassword(mapping *luksMapping) ([]byte, error) {
+	keyPath := mapping.keyfile
+	if mapping.keyfileDeviceRef != nil {
+		timeout := mapping.keyfileTimeout
+		if timeout == 0 {
+			timeout = time.Duration(config.MountTimeout) * time.Second
 		}
-	} else {
-		// read password from device matching uuid
-		uuid, err := parseUUID(parts[1])
+		mountPoint := "/run/booster/keydev-" + mapping.name
+		unmount, err := mountKeyDevice(mapping.keyfileDeviceRef, mountPoint, timeout)
 		if err != nil {
-			warning("invalid UUID %s in rd.luks.key boot param: %s", uuid, keyfile)
-		} else {
-			// TODO: access path on uuid device, read password
-			warning("user wants keyfile from device %s, but I don't know how to do that", uuid)
+			return nil, err
 		}
+		defer unmount()
+		keyPath = filepath.Join(mountPoint, mapping.keyfile)
+	}
+	return readKeyfile(keyPath, mapping.keyfileOffset, mapping.keyfileSize)
+}
+
+func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mapping *luksMapping) {
+	password, err := acquireKeyfilePassword(mapping)
+	if err != nil {
+		warning("keyfile %s: %v — falling back to keyboard", mapping.keyfile, err)
 	}
 
 	if len(password) > 0 {
@@ -478,12 +504,10 @@ func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots
 			volumes <- v
 			return
 		}
+		warning("keyfile %s does not match any slot for %s", mapping.keyfile, mapping.name)
 	}
 
-	warning("password in keyfile %s was unable to unseal %s", keyfile, mappingName)
-
-	// have to use keyboard password
-	requestKeyboardPassword(volumes, d, checkSlots, mappingName, maxTries)
+	requestKeyboardPassword(volumes, d, checkSlots, mapping.name, mapping.tries)
 }
 
 func tryPassphraseAgainstSlots(volumes chan *luks.Volume, d luks.Device, checkSlots []int, password []byte) bool {
@@ -507,8 +531,11 @@ func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlot
 	// plymouthd is still starting, causing the graphical prompt to fail.
 	waitForPlymouthInit()
 
-	// Try passwords that already unlocked another volume before prompting.
+	// Fast path: try passwords already in the cache without acquiring the
+	// console mutex.  These come from volumes that finished unlocking before
+	// this goroutine reached this point.
 	passphraseCache.Lock()
+	seenCount := len(passphraseCache.passwords)
 	cached := append([][]byte(nil), passphraseCache.passwords...)
 	passphraseCache.Unlock()
 
@@ -529,6 +556,7 @@ func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlot
 
 		var password []byte
 		var err error
+		consoleLocked := false
 
 		if plymouthEnabled {
 			password, err = plymouthAskPassword(prompt)
@@ -537,14 +565,42 @@ func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlot
 				password, err = readPassword(prompt, "   Unlocking...")
 			}
 		} else {
-			password, err = readPassword(prompt, "   Unlocking...")
+			// Acquire the console mutex and hold it through PBKDF.  This
+			// eliminates the race where two goroutines for concurrent LUKS
+			// volumes both see an empty cache and start prompting before
+			// either finishes key derivation: the next goroutine to acquire
+			// the mutex will find the cached password and can unlock silently
+			// without a second prompt.
+			inputMutex.Lock()
+			consoleLocked = true
+
+			// Re-check cache for entries added while we waited for the mutex
+			// (a concurrent goroutine may have finished unlocking by now).
+			passphraseCache.Lock()
+			newPws := append([][]byte(nil), passphraseCache.passwords[seenCount:]...)
+			seenCount = len(passphraseCache.passwords)
+			passphraseCache.Unlock()
+			for _, pw := range newPws {
+				if tryPassphraseAgainstSlots(volumes, d, checkSlots, pw) {
+					inputMutex.Unlock()
+					return
+				}
+			}
+
+			password, err = readPasswordLocked(prompt, "   Unlocking...")
 		}
 
 		if err != nil {
 			warning("reading password: %v", err)
+			if consoleLocked {
+				inputMutex.Unlock()
+			}
 			return
 		}
 		if len(password) == 0 {
+			if consoleLocked {
+				inputMutex.Unlock()
+			}
 			continue
 		}
 
@@ -552,8 +608,16 @@ func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlot
 		if tryPassphraseAgainstSlots(volumes, d, checkSlots, password) {
 			passphraseCache.Lock()
 			passphraseCache.passwords = append(passphraseCache.passwords, password)
+			seenCount = len(passphraseCache.passwords)
 			passphraseCache.Unlock()
+			if consoleLocked {
+				inputMutex.Unlock()
+			}
 			return
+		}
+
+		if consoleLocked {
+			inputMutex.Unlock()
 		}
 
 		// retry password
@@ -568,12 +632,15 @@ func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlot
 func luksOpen(dev string, mapping *luksMapping) error {
 	module := loadModules("dm_crypt")
 
+	var (
+		d   luks.Device
+		err error
+	)
 	if mapping.header != "" {
-		// TODO: use luks.OpenWithHeader(dev, mapping.header) once pilotstew/luks.go fork is available
-		return fmt.Errorf("LUKS device %s: detached header not yet supported (requires luks.go fork)", mapping.name)
+		d, err = luks.OpenWithHeader(dev, mapping.header)
+	} else {
+		d, err = luks.Open(dev)
 	}
-
-	d, err := luks.Open(dev)
 	if err != nil {
 		return err
 	}
@@ -633,7 +700,7 @@ func luksOpen(dev string, mapping *luksMapping) error {
 			if len(mapping.keyfile) > 0 {
 				go func() {
 					defer senderWg.Done()
-					recoverKeyfilePassword(volumes, d, checkSlots, mapping.name, mapping.keyfile, mapping.tries, mapping.keyfileOffset, mapping.keyfileSize)
+					recoverKeyfilePassword(volumes, d, checkSlots, mapping)
 				}()
 			} else {
 				go func() {

--- a/init/luks.go
+++ b/init/luks.go
@@ -35,6 +35,7 @@ type luksMapping struct {
 	tokenTimeout time.Duration // 0 = wait forever; >0 = defer keyboard until elapsed
 	header       string        // detached LUKS header path (empty = embedded header)
 	keySlot      int           // -1 = try all slots; >=0 restricts password checks to that slot
+	tries        int           // 0 = unlimited keyboard retries; >0 = max attempts
 }
 
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
@@ -411,7 +412,7 @@ func recoverTokenPassword(volumes chan *luks.Volume, d luks.Device, t luks.Token
 	return false
 }
 
-func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, keyfile string) {
+func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, keyfile string, maxTries int) {
 	var err error
 	var password []byte
 
@@ -452,16 +453,48 @@ func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots
 	warning("password in keyfile %s was unable to unseal %s", keyfile, mappingName)
 
 	// have to use keyboard password
-	requestKeyboardPassword(volumes, d, checkSlots, mappingName)
+	requestKeyboardPassword(volumes, d, checkSlots, mappingName, maxTries)
 }
 
-func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string) {
+func tryPassphraseAgainstSlots(volumes chan *luks.Volume, d luks.Device, checkSlots []int, password []byte) bool {
+	for _, s := range checkSlots {
+		v, err := d.UnsealVolume(s, password)
+		if err == luks.ErrPassphraseDoesNotMatch {
+			continue
+		} else if err != nil {
+			warning("unlocking slot %v: %v", s, err)
+			continue
+		}
+		volumes <- v
+		return true
+	}
+	return false
+}
+
+func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, maxTries int) {
 	// Wait for plymouth initialization to complete before attempting to use
 	// it. Without this, udev events can trigger LUKS password prompts while
 	// plymouthd is still starting, causing the graphical prompt to fail.
 	waitForPlymouthInit()
 
+	// Try passwords that already unlocked another volume before prompting.
+	passphraseCache.Lock()
+	cached := append([][]byte(nil), passphraseCache.passwords...)
+	passphraseCache.Unlock()
+
+	for _, pw := range cached {
+		if tryPassphraseAgainstSlots(volumes, d, checkSlots, pw) {
+			return
+		}
+	}
+
+	attempts := 0
 	for {
+		if maxTries > 0 && attempts >= maxTries {
+			warning("maximum passphrase attempts (%d) reached for %s", maxTries, mappingName)
+			return
+		}
+
 		prompt := fmt.Sprintf("Enter passphrase for %s:", mappingName)
 
 		var password []byte
@@ -485,15 +518,11 @@ func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlot
 			continue
 		}
 
-		for _, s := range checkSlots {
-			v, err := d.UnsealVolume(s, password)
-			if err == luks.ErrPassphraseDoesNotMatch {
-				continue
-			} else if err != nil {
-				warning("unlocking slot %v: %v", s, err)
-				continue
-			}
-			volumes <- v
+		attempts++
+		if tryPassphraseAgainstSlots(volumes, d, checkSlots, password) {
+			passphraseCache.Lock()
+			passphraseCache.passwords = append(passphraseCache.passwords, password)
+			passphraseCache.Unlock()
 			return
 		}
 
@@ -567,9 +596,9 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	startKeyboard := func(checkSlots []int) {
 		keyboardOnce.Do(func() {
 			if len(mapping.keyfile) > 0 {
-				go recoverKeyfilePassword(volumes, d, checkSlots, mapping.name, mapping.keyfile)
+				go recoverKeyfilePassword(volumes, d, checkSlots, mapping.name, mapping.keyfile, mapping.tries)
 			} else {
-				go requestKeyboardPassword(volumes, d, checkSlots, mapping.name)
+				go requestKeyboardPassword(volumes, d, checkSlots, mapping.name, mapping.tries)
 			}
 		})
 	}

--- a/init/luks.go
+++ b/init/luks.go
@@ -33,10 +33,12 @@ type luksMapping struct {
 	tokenFido2   bool          // fido2-device=auto was set
 	tokenTpm2    bool          // tpm2-device=auto was set
 	tokenTimeout time.Duration // 0 = wait forever; >0 = defer keyboard until elapsed
-	header       string        // detached LUKS header path (empty = embedded header)
-	keySlot      int           // -1 = try all slots; >=0 restricts password checks to that slot
-	tries        int           // 0 = unlimited keyboard retries; >0 = max attempts
-	noFail       bool          // if true, unlock failure is non-fatal (boot continues)
+	header        string        // detached LUKS header path (empty = embedded header)
+	keySlot       int           // -1 = try all slots; >=0 restricts password checks to that slot
+	tries         int           // 0 = unlimited keyboard retries; >0 = max attempts
+	noFail        bool          // if true, unlock failure is non-fatal (boot continues)
+	keyfileOffset int64         // byte offset into keyfile (0 = start)
+	keyfileSize   int64         // bytes to read from keyfile (0 = read to end)
 }
 
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
@@ -413,7 +415,34 @@ func recoverTokenPassword(volumes chan *luks.Volume, d luks.Device, t luks.Token
 	return false
 }
 
-func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, keyfile string, maxTries int) {
+// readKeyfile reads keyfile contents, optionally starting at keyfileOffset and
+// limiting to keyfileSize bytes (0 means read to end of file).
+func readKeyfile(path string, offset, size int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	if offset > 0 {
+		if _, err := f.Seek(offset, 0); err != nil {
+			return nil, fmt.Errorf("keyfile seek: %v", err)
+		}
+	}
+
+	if size > 0 {
+		buf := make([]byte, size)
+		n, err := io.ReadFull(f, buf)
+		if err != nil && err != io.ErrUnexpectedEOF {
+			return nil, fmt.Errorf("keyfile read: %v", err)
+		}
+		return buf[:n], nil
+	}
+
+	return io.ReadAll(f)
+}
+
+func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, keyfile string, maxTries int, keyfileOffset, keyfileSize int64) {
 	var err error
 	var password []byte
 
@@ -421,7 +450,7 @@ func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots
 	parts := regexp.MustCompile("(?i):UUID=").Split(keyfile, 2)
 
 	if len(parts) == 1 {
-		password, err = os.ReadFile(parts[0])
+		password, err = readKeyfile(parts[0], keyfileOffset, keyfileSize)
 
 		if err != nil {
 			warning("reading password: %v", err)
@@ -604,7 +633,7 @@ func luksOpen(dev string, mapping *luksMapping) error {
 			if len(mapping.keyfile) > 0 {
 				go func() {
 					defer senderWg.Done()
-					recoverKeyfilePassword(volumes, d, checkSlots, mapping.name, mapping.keyfile, mapping.tries)
+					recoverKeyfilePassword(volumes, d, checkSlots, mapping.name, mapping.keyfile, mapping.tries, mapping.keyfileOffset, mapping.keyfileSize)
 				}()
 			} else {
 				go func() {

--- a/init/luks.go
+++ b/init/luks.go
@@ -33,6 +33,8 @@ type luksMapping struct {
 	tokenFido2   bool          // fido2-device=auto was set
 	tokenTpm2    bool          // tpm2-device=auto was set
 	tokenTimeout time.Duration // 0 = wait forever; >0 = defer keyboard until elapsed
+	header       string        // detached LUKS header path (empty = embedded header)
+	keySlot      int           // -1 = try all slots; >=0 restricts password checks to that slot
 }
 
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
@@ -120,7 +122,7 @@ func isHidRawFido2(devName string) (bool, error) {
 	return false, nil
 }
 
-func recoverFido2Password(devName string, credential string, salt string, relyingParty string, pinRequired bool, userPresenceRequired bool, userVerificationRequired bool) ([]byte, error) {
+func recoverFido2Password(devName string, credential string, salt string, relyingParty string, pinRequired bool, userPresenceRequired bool, userVerificationRequired bool, mappingName string) ([]byte, error) {
 	usbhidWg.Wait()
 
 	isFido2, err := isHidRawFido2(devName)
@@ -185,12 +187,11 @@ func recoverFido2Password(devName string, credential string, salt string, relyin
 		if _, err := pipeErr.Read(buff); err != nil {
 			return nil, err
 		}
-		// Dealing with Yubikey using command-line tools is getting out of control
-		// TODO: find a way to do the same using libfido2
-		prompt := "Enter PIN for " + device + ":"
-		if strings.HasPrefix(string(buff), prompt) {
+		fido2Prompt := "Enter PIN for " + device + ":"
+		displayPrompt := "Enter FIDO2 PIN for " + mappingName + ":"
+		if strings.HasPrefix(string(buff), fido2Prompt) {
 			// fido2-assert tool requests for PIN
-			pin, err := readPassword(prompt, "")
+			pin, err := readPassword(displayPrompt, "")
 			if err != nil {
 				return nil, err
 			}
@@ -216,9 +217,29 @@ func recoverFido2Password(devName string, credential string, salt string, relyin
 	return lines[4], nil
 }
 
+// isFido2PinInvalidError reports whether err indicates a wrong FIDO2 PIN.
+// With fido2-assert the error text contains "PIN_INVALID" when the PIN is incorrect.
+func isFido2PinInvalidError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "PIN_INVALID")
+}
+
 var hidrawDevices = make(chan string, 10) // channel that receives 'add hidraw' events
 
-func recoverSystemdFido2Password(t luks.Token) ([]byte, error) {
+// passphraseCache stores passwords that have successfully unlocked a LUKS
+// volume so they can be tried silently against other volumes before prompting.
+var passphraseCache struct {
+	sync.Mutex
+	passwords [][]byte
+}
+
+// recoverSystemdFido2Password attempts to recover a LUKS passphrase from a
+// systemd-fido2 token.  done is closed when the LUKS device has been unlocked
+// by any means (keyboard, another token, etc.) — this cancels a pending FIDO2
+// wait so the goroutine exits cleanly rather than blocking forever.
+func recoverSystemdFido2Password(t luks.Token, mappingName string, done <-chan struct{}) ([]byte, error) {
 	var node struct {
 		Credential               string `json:"fido2-credential"` // base64
 		Salt                     string `json:"fido2-salt"`       // base64
@@ -230,7 +251,6 @@ func recoverSystemdFido2Password(t luks.Token) ([]byte, error) {
 	if err := json.Unmarshal(t.Payload, &node); err != nil {
 		return nil, err
 	}
-
 	if node.RelyingParty == "" {
 		node.RelyingParty = "io.systemd.cryptsetup"
 	}
@@ -239,33 +259,61 @@ func recoverSystemdFido2Password(t luks.Token) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	// Seed the channel with devices already present in sysfs so they are
+	// processed before any late-arriving udev events.
 	go func() {
 		for _, d := range dir {
-			// run it in a separate goroutine to avoid blocking on channel
 			hidrawDevices <- d.Name()
 		}
 	}()
 
 	seenHidrawDevices := make(set)
 
-	for devName := range hidrawDevices {
+	for {
+		var devName string
+		select {
+		case <-done:
+			// Device unlocked by keyboard or another token — exit cleanly.
+			return nil, fmt.Errorf("FIDO2 recovery cancelled")
+		case devName = <-hidrawDevices:
+		}
+
 		if seenHidrawDevices[devName] {
 			continue
 		}
 		seenHidrawDevices[devName] = true
 
-		password, err := recoverFido2Password(devName, node.Credential, node.Salt, node.RelyingParty, node.PinRequired, node.UserPresenceRequired, node.UserVerificationRequired)
+		maxAttempts := 1
+		if node.PinRequired {
+			maxAttempts = 3
+		}
+		var password []byte
+		var err error
+		for attempt := 0; attempt < maxAttempts; attempt++ {
+			password, err = recoverFido2Password(devName, node.Credential, node.Salt, node.RelyingParty, node.PinRequired, node.UserPresenceRequired, node.UserVerificationRequired, mappingName)
+			if err == nil {
+				break
+			}
+			if !isFido2PinInvalidError(err) {
+				break
+			}
+			if attempt < maxAttempts-1 {
+				if plymouthEnabled {
+					plymouthMessage("FIDO2 PIN incorrect, please try again")
+				} else {
+					warning("FIDO2 PIN incorrect, please try again")
+				}
+			}
+		}
 		if err != nil {
-			if err != io.EOF {
-				info("%v", err)
+			info("%v", err)
+			if plymouthEnabled {
+				plymouthMessage("") // clear any "PIN incorrect" message
 			}
 			continue
 		}
 		return password, nil
 	}
-
-	return nil, fmt.Errorf("no matching fido2 devices available")
 }
 
 func recoverSystemdTPM2Password(t luks.Token) ([]byte, error) {
@@ -324,7 +372,7 @@ func recoverSystemdTPM2Password(t luks.Token) ([]byte, error) {
 	return []byte(base64.StdEncoding.EncodeToString(password)), nil
 }
 
-func recoverTokenPassword(volumes chan *luks.Volume, d luks.Device, t luks.Token) {
+func recoverTokenPassword(volumes chan *luks.Volume, d luks.Device, t luks.Token, mappingName string, done <-chan struct{}) bool {
 	var password []byte
 	var err error
 
@@ -332,17 +380,17 @@ func recoverTokenPassword(volumes chan *luks.Volume, d luks.Device, t luks.Token
 	case "clevis":
 		password, err = recoverClevisPassword(t, d.Version())
 	case "systemd-fido2":
-		password, err = recoverSystemdFido2Password(t)
+		password, err = recoverSystemdFido2Password(t, mappingName, done)
 	case "systemd-tpm2":
 		password, err = recoverSystemdTPM2Password(t)
 	default:
 		info("token #%d has unknown type: %s", t.ID, t.Type)
-		return
+		return false
 	}
 
 	if err != nil {
 		warning("recovering %s token #%d failed: %v", t.Type, t.ID, err)
-		return
+		return false
 	}
 
 	info("recovered password from %s token #%d", t.Type, t.ID)
@@ -357,9 +405,10 @@ func recoverTokenPassword(volumes chan *luks.Volume, d luks.Device, t luks.Token
 		}
 		info("password from %s token #%d matches", t.Type, t.ID)
 		volumes <- v
-		return
+		return true
 	}
 	info("password from %s token #%d does not match", t.Type, t.ID)
+	return false
 }
 
 func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, keyfile string) {
@@ -460,13 +509,34 @@ func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlot
 func luksOpen(dev string, mapping *luksMapping) error {
 	module := loadModules("dm_crypt")
 
+	if mapping.header != "" {
+		// TODO: use luks.OpenWithHeader(dev, mapping.header) once pilotstew/luks.go fork is available
+		return fmt.Errorf("LUKS device %s: detached header not yet supported (requires luks.go fork)", mapping.name)
+	}
+
 	d, err := luks.Open(dev)
 	if err != nil {
 		return err
 	}
 	defer d.Close()
 
-	if len(d.Slots()) == 0 {
+	// availableSlots is d.Slots() optionally filtered to a single key slot (crypttab key-slot=).
+	availableSlots := d.Slots()
+	if mapping.keySlot >= 0 {
+		filtered := make([]int, 0, 1)
+		for _, s := range availableSlots {
+			if s == mapping.keySlot {
+				filtered = append(filtered, s)
+				break
+			}
+		}
+		availableSlots = filtered
+	}
+
+	if len(availableSlots) == 0 {
+		if mapping.keySlot >= 0 {
+			return fmt.Errorf("device %s: key slot %d not found or not active", dev, mapping.keySlot)
+		}
 		return fmt.Errorf("device %s has no slots to unlock", dev)
 	}
 
@@ -513,14 +583,24 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		if t.Type == "systemd-recovery" {
 			continue // skip systemd-recovery tokens as they are supposed to be entered by a keyboard later
 		}
+		// systemd-fido2 and systemd-tpm2 require explicit opt-in via fido2-device= / tpm2-device=,
+		// matching systemd-cryptsetup behaviour.
+		if t.Type == "systemd-fido2" && !mapping.tokenFido2 {
+			continue
+		}
+		if t.Type == "systemd-tpm2" && !mapping.tokenTpm2 {
+			continue
+		}
 		if hasPriority && priorityTypes[t.Type] {
 			tokenWg.Add(1)
 			go func(tok luks.Token) {
-				defer tokenWg.Done()
-				recoverTokenPassword(volumes, d, tok)
+				if recoverTokenPassword(volumes, d, tok, mapping.name, done) {
+					closeDone.Do(func() { close(done) })
+				}
+				tokenWg.Done()
 			}(t)
 		} else {
-			go recoverTokenPassword(volumes, d, t)
+			go recoverTokenPassword(volumes, d, t, mapping.name, done)
 		}
 		for _, s := range t.Slots {
 			slotsWithTokens[s] = true
@@ -528,7 +608,7 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	}
 
 	var checkSlotsWithPassword []int
-	for _, s := range d.Slots() {
+	for _, s := range availableSlots {
 		if !slotsWithTokens[s] {
 			// only slots that do not have tokens will be checked with keyboard password
 			checkSlotsWithPassword = append(checkSlotsWithPassword, s)
@@ -608,8 +688,9 @@ func matchLuksMapping(blk *blkInfo) *luksMapping {
 	if blk.matchesRef(cmdRoot) {
 		info("LUKS device %s matches root=, unlock this device", blk.path)
 		m := &luksMapping{
-			ref:  cmdRoot,
-			name: "root",
+			ref:     cmdRoot,
+			name:    "root",
+			keySlot: -1,
 		}
 		cmdRoot = &deviceRef{format: refPath, data: "/dev/mapper/root"}
 		return m
@@ -642,8 +723,9 @@ func findOrCreateLuksMapping(uuid UUID) *luksMapping {
 
 	// didn't locate the device make a new one
 	m := &luksMapping{
-		ref:  &deviceRef{refFsUUID, uuid},
-		name: "luks-" + uuid.toString(),
+		ref:     &deviceRef{refFsUUID, uuid},
+		name:    "luks-" + uuid.toString(),
+		keySlot: -1,
 	}
 	luksMappings = append(luksMappings, m)
 

--- a/init/luks.go
+++ b/init/luks.go
@@ -36,6 +36,7 @@ type luksMapping struct {
 	header       string        // detached LUKS header path (empty = embedded header)
 	keySlot      int           // -1 = try all slots; >=0 restricts password checks to that slot
 	tries        int           // 0 = unlimited keyboard retries; >0 = max attempts
+	noFail       bool          // if true, unlock failure is non-fatal (boot continues)
 }
 
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
@@ -591,14 +592,25 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	hasPriority := len(priorityTypes) > 0
 
 	var tokenWg sync.WaitGroup
+	// senderWg tracks every goroutine that may send to volumes.  When it
+	// reaches zero all unlock paths have given up; the watcher closes volumes
+	// so luksOpen can unblock instead of hanging forever.
+	var senderWg sync.WaitGroup
 	var keyboardOnce sync.Once
 
 	startKeyboard := func(checkSlots []int) {
 		keyboardOnce.Do(func() {
+			senderWg.Add(1)
 			if len(mapping.keyfile) > 0 {
-				go recoverKeyfilePassword(volumes, d, checkSlots, mapping.name, mapping.keyfile, mapping.tries)
+				go func() {
+					defer senderWg.Done()
+					recoverKeyfilePassword(volumes, d, checkSlots, mapping.name, mapping.keyfile, mapping.tries)
+				}()
 			} else {
-				go requestKeyboardPassword(volumes, d, checkSlots, mapping.name, mapping.tries)
+				go func() {
+					defer senderWg.Done()
+					requestKeyboardPassword(volumes, d, checkSlots, mapping.name, mapping.tries)
+				}()
 			}
 		})
 	}
@@ -622,14 +634,20 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		}
 		if hasPriority && priorityTypes[t.Type] {
 			tokenWg.Add(1)
+			senderWg.Add(1)
 			go func(tok luks.Token) {
+				defer tokenWg.Done()
+				defer senderWg.Done()
 				if recoverTokenPassword(volumes, d, tok, mapping.name, done) {
 					closeDone.Do(func() { close(done) })
 				}
-				tokenWg.Done()
 			}(t)
 		} else {
-			go recoverTokenPassword(volumes, d, t, mapping.name, done)
+			senderWg.Add(1)
+			go func(tok luks.Token) {
+				defer senderWg.Done()
+				recoverTokenPassword(volumes, d, tok, mapping.name, done)
+			}(t)
 		}
 		for _, s := range t.Slots {
 			slotsWithTokens[s] = true
@@ -666,8 +684,28 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		}
 	}
 
-	v := <-volumes
+	// Watcher: when every unlock goroutine has given up without success,
+	// close volumes so luksOpen unblocks rather than hanging forever.
+	go func() {
+		senderWg.Wait()
+		select {
+		case <-done:
+			// Already unlocked — leave volumes alone.
+		default:
+			close(volumes)
+		}
+	}()
+
+	v, ok := <-volumes
 	closeDone.Do(func() { close(done) })
+	if !ok {
+		// All unlock paths exhausted without success.
+		if mapping.noFail {
+			warning("nofail: all unlock attempts for %s exhausted, skipping", mapping.name)
+			return nil
+		}
+		return fmt.Errorf("all unlock paths for LUKS device %s exhausted", dev)
+	}
 
 	if err := loadRequiredCryptoModules(v.StorageEncryption); err != nil {
 		return err
@@ -736,7 +774,12 @@ func handleLuksBlockDevice(blk *blkInfo) error {
 	}
 	info("a mapping for LUKS device %s has been found", blk.path)
 
-	return luksOpen(blk.path, m)
+	err := luksOpen(blk.path, m)
+	if err != nil && m.noFail {
+		warning("nofail: unable to open LUKS device %s (%s), skipping: %v", blk.path, m.name, err)
+		return nil
+	}
+	return err
 }
 
 func findOrCreateLuksMapping(uuid UUID) *luksMapping {

--- a/init/main.go
+++ b/init/main.go
@@ -82,6 +82,9 @@ var (
 
 	seenDevices       = make(set) // devices that are already seen by the system, the devices might be fully processed or processing right now
 	processingDevices = make(map[string]*sync.WaitGroup)
+
+	processedBlkInfos []*blkInfo               // append-only; protected by devicesMutex
+	deviceReadyCond   = sync.NewCond(&devicesMutex)
 )
 
 // waitForDeviceToProcess waits till the given device gets handled.
@@ -106,6 +109,34 @@ func markDeviceProcessed(dev string) {
 
 	wg := processingDevices[dev]
 	wg.Done()
+}
+
+// waitForDeviceRef waits until a processed block device matching ref appears.
+// When timeout > 0 it gives up after that duration; timeout == 0 waits forever.
+func waitForDeviceRef(ref *deviceRef, timeout time.Duration) (*blkInfo, error) {
+	var deadline time.Time
+	if timeout > 0 {
+		deadline = time.Now().Add(timeout)
+		go func() {
+			time.Sleep(timeout)
+			deviceReadyCond.Broadcast()
+		}()
+	}
+
+	devicesMutex.Lock()
+	defer devicesMutex.Unlock()
+
+	for {
+		for _, blk := range processedBlkInfos {
+			if blk.matchesRef(ref) {
+				return blk, nil
+			}
+		}
+		if timeout > 0 && time.Now().After(deadline) {
+			return nil, fmt.Errorf("timeout waiting for keyfile device")
+		}
+		deviceReadyCond.Wait()
+	}
 }
 
 func diskSymlink(typ, oldname, newname string) error {
@@ -159,6 +190,11 @@ func addBlockDevice(devpath string, isDevice bool, symlinks []string) error {
 	}
 
 	blk.symlinks = symlinks
+
+	devicesMutex.Lock()
+	processedBlkInfos = append(processedBlkInfos, blk)
+	devicesMutex.Unlock()
+	deviceReadyCond.Broadcast()
 
 	if blk.uuid != nil {
 		if err := diskSymlink("uuid", devpath, blk.uuid.toString()); err != nil {
@@ -926,6 +962,10 @@ func boost() error {
 		if err := os.MkdirAll("/dev/disk/by-"+by, 0o755); err != nil {
 			return err
 		}
+	}
+
+	if err := os.MkdirAll("/run/booster", 0o700); err != nil {
+		return err
 	}
 
 	go func() { check(scanSysModaliases()) }()

--- a/init/main.go
+++ b/init/main.go
@@ -878,6 +878,17 @@ func boost() error {
 		return err
 	}
 
+	// Merge /etc/crypttab entries; kernel cmdline takes precedence.
+	if ctMappings, err := parseCrypttab(); err != nil {
+		warning("crypttab: %v", err)
+	} else {
+		for _, cm := range ctMappings {
+			if !luksMatchExists(cm.ref) {
+				luksMappings = append(luksMappings, cm)
+			}
+		}
+	}
+
 	// Check if plymouth should be enabled: needs both config and "splash" kernel param
 	if config.EnablePlymouth {
 		cmdlineBytes, err := os.ReadFile("/proc/cmdline")

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -23,7 +23,44 @@ var assetGenerators = map[string]assetGenerator{
 	"luks2.clevis.yubikey.img": {"luks.sh", []string{"LUKS_VERSION=2", "LUKS_PASSWORD=1234", "LUKS_UUID=f2473f71-9a61-4b16-ae54-8f942b2daf52", "FS_UUID=7acb3a9e-9b50-4aa2-9965-e41ae8467d8a", "CLEVIS_PIN=yubikey", `CLEVIS_CONFIG={"slot":2}`}},
 	"luks2.clevis.remote.img":  {"luks.sh", []string{"LUKS_VERSION=2", "LUKS_PASSWORD=1234", "LUKS_UUID=f2473f71-9a61-4b16-ae54-8f942b2daf22", "FS_UUID=7acb3a9e-9b51-4aa2-9965-e41ae8467d8a", "CLEVIS_PIN=remote", `CLEVIS_CONFIG={"adv":"assets/remote/key.pub", "port":34551}`}},
 	// camellia is a loadable module at Arch and it is a good candidate to verify loading it works correctly
-	"luks2.external.module.img": {"luks.sh", []string{"LUKS_VERSION=2", "LUKS_PASSWORD=1234", "LUKS_UUID=ad575500-a9e3-4692-b1b2-eed95a6e8ce2", "FS_UUID=0118f2b1-3c4f-4eff-9663-b58447ad797c", `LUKS_PARAMS=-c camellia-xts-plain64 -s 512 -h sha512 -i 8000 --pbkdf argon2id --pbkdf-memory 4100000`}},
+	"luks2.external.module.img":   {"luks.sh", []string{"LUKS_VERSION=2", "LUKS_PASSWORD=1234", "LUKS_UUID=ad575500-a9e3-4692-b1b2-eed95a6e8ce2", "FS_UUID=0118f2b1-3c4f-4eff-9663-b58447ad797c", `LUKS_PARAMS=-c camellia-xts-plain64 -s 512 -h sha512 -i 8000 --pbkdf argon2id --pbkdf-memory 4100000`}},
+	// luks2.keyfile_offset.img: LUKS2 image enrolled with a keyfile that has a 512-byte random
+	// preamble before the real key material.  Tests keyfile-offset= and keyfile-size= in crypttab.
+	// The keyfile (preamble+key) is written to KEYFILE_OUTPUT alongside the image.
+	"luks2.keyfile_offset.img": {"luks_keyfile_offset.sh", []string{
+		"LUKS_UUID=c0d3f4a5-b6e7-4809-9abc-def012345678",
+		"FS_UUID=d1e2f3a4-c5b6-4789-abcd-ef0123456789",
+		"KEYFILE_OUTPUT=assets/luks2.keyfile_offset.key",
+	}},
+	// luks2.keyfile_device.img and its companion keydev are both created by a single generator run.
+	"luks2.keyfile_device.img": {"luks_keyfile_device.sh", []string{
+		"LUKS_UUID=7c2a39be-15d1-4b71-9f2e-5c4d1a3b8e6f",
+		"FS_UUID=a3d8e2c1-4f7b-4e9c-b2a1-6d5f3c8e1a7b",
+		"KEYDEV_UUID=f1e2d3c4-b5a6-4789-8abc-def123456789",
+		"KEYDEV_OUTPUT=assets/luks2.keyfile_device.keydev.img",
+	}},
+	// luks2.btrfs_two_a.img + luks2.btrfs_two_a2.img: two LUKS2 drives with the
+	// SAME passphrase forming a btrfs RAID1.  Tests passphrase cache (enter once,
+	// both drives unlock automatically).
+	"luks2.btrfs_two_a.img": {"luks_btrfs_two.sh", []string{
+		"LUKS_UUID1=a1b2c3d4-1111-4111-8111-111111111111",
+		"LUKS_UUID2=a2b2c3d4-2222-4222-8222-222222222222",
+		"LUKS_PASSWORD1=1234",
+		"LUKS_PASSWORD2=1234",
+		"FS_UUID=a3b2c3d4-3333-4333-8333-333333333333",
+		"OUTPUT2=assets/luks2.btrfs_two_a2.img",
+	}},
+	// luks2.btrfs_two_b.img + luks2.btrfs_two_b2.img: two LUKS2 drives with
+	// DIFFERENT passphrases forming a btrfs RAID1.  Tests that booster prompts
+	// for each passphrase and waits for both drives before mounting btrfs.
+	"luks2.btrfs_two_b.img": {"luks_btrfs_two.sh", []string{
+		"LUKS_UUID1=b1b2c3d4-1111-4111-8111-111111111112",
+		"LUKS_UUID2=b2b2c3d4-2222-4222-8222-222222222223",
+		"LUKS_PASSWORD1=1234",
+		"LUKS_PASSWORD2=5678",
+		"FS_UUID=b3b2c3d4-3333-4333-8333-333333333334",
+		"OUTPUT2=assets/luks2.btrfs_two_b2.img",
+	}},
 	"gpt.img":                   {"gpt.sh", []string{"FS_UUID=e5404205-ac6a-4e94-bb3b-14433d0af7d1", "FS_LABEL=newpart"}},
 	"gpt_4ksector.img":          {"gpt_4ksector.sh", nil},
 	"lvm.img":                   {"lvm.sh", []string{"FS_UUID=74c9e30c-506f-4106-9f61-a608466ef29c", "FS_LABEL=lvmr00t"}},

--- a/tests/btrfs_test.go
+++ b/tests/btrfs_test.go
@@ -16,3 +16,70 @@ func TestBtrfsRaid0(t *testing.T) {
 
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
 }
+
+const (
+	btrfsSharedLuksUUID1 = "a1b2c3d4-1111-4111-8111-111111111111"
+	btrfsSharedLuksUUID2 = "a2b2c3d4-2222-4222-8222-222222222222"
+	btrfsSharedFsUUID    = "a3b2c3d4-3333-4333-8333-333333333333"
+
+	btrfsDiffLuksUUID1 = "b1b2c3d4-1111-4111-8111-111111111112"
+	btrfsDiffLuksUUID2 = "b2b2c3d4-2222-4222-8222-222222222223"
+	btrfsDiffFsUUID    = "b3b2c3d4-3333-4333-8333-333333333334"
+)
+
+// TestBtrfsRaid1LuksSharedPassphrase boots a system whose root is a btrfs
+// RAID1 spanning two LUKS2-encrypted drives that share the same passphrase.
+// Booster prompts once (for crypt2, the virtio_blk drive that appears first).
+// After PBKDF completes, the passphrase is cached; crypt1 acquires the console
+// mutex, finds the cached password, and unlocks silently — no second prompt.
+// waitForBtrfsDevicesReady then assembles and mounts btrfs.
+func TestBtrfsRaid1LuksSharedPassphrase(t *testing.T) {
+	vm, err := buildVmInstance(t, Opts{
+		// luks2.btrfs_two_a2.img (crypt2, password "1234") is the virtio_blk
+		// drive and appears first; luks2.btrfs_two_a.img (crypt1) is the
+		// virtio-scsi drive and appears second.
+		disk:   "assets/luks2.btrfs_two_a.img",
+		params: []string{"-drive", "file=assets/luks2.btrfs_two_a2.img,if=virtio,format=raw"},
+		kernelArgs: []string{
+			"rd.luks.name=" + btrfsSharedLuksUUID1 + "=crypt1",
+			"rd.luks.name=" + btrfsSharedLuksUUID2 + "=crypt2",
+			"root=UUID=" + btrfsSharedFsUUID,
+		},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	// crypt2 prompts first; one passphrase is enough for both drives.
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for crypt2:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestBtrfsRaid1LuksDifferentPassphrases boots a system whose root is a btrfs
+// RAID1 spanning two LUKS2-encrypted drives with distinct passphrases.
+// crypt2 (virtio_blk, appears first) prompts first; its password is cached but
+// does not match crypt1, so crypt1 prompts separately after crypt2's PBKDF.
+// waitForBtrfsDevicesReady holds the mount until both dm-crypt devices are open.
+func TestBtrfsRaid1LuksDifferentPassphrases(t *testing.T) {
+	vm, err := buildVmInstance(t, Opts{
+		// luks2.btrfs_two_b2.img is crypt2 (password "5678", virtio_blk, first).
+		// luks2.btrfs_two_b.img  is crypt1 (password "1234", virtio-scsi, second).
+		disk:   "assets/luks2.btrfs_two_b.img",
+		params: []string{"-drive", "file=assets/luks2.btrfs_two_b2.img,if=virtio,format=raw"},
+		kernelArgs: []string{
+			"rd.luks.name=" + btrfsDiffLuksUUID1 + "=crypt1",
+			"rd.luks.name=" + btrfsDiffLuksUUID2 + "=crypt2",
+			"root=UUID=" + btrfsDiffFsUUID,
+		},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	// crypt2 prompts first; cache tries "5678" against crypt1 (no match);
+	// crypt1 then prompts for its own passphrase.
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for crypt2:"))
+	require.NoError(t, vm.ConsoleWrite("5678\n"))
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for crypt1:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}

--- a/tests/generators/luks_btrfs_two.sh
+++ b/tests/generators/luks_btrfs_two.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Creates two LUKS2-encrypted disk images whose decrypted contents form a
+# single btrfs RAID1 filesystem.  Used to test multi-device btrfs with
+# encrypted drives (shared and distinct passphrases).
+#
+# Required env vars:
+#   OUTPUT           path for the first LUKS image
+#   OUTPUT2          path for the second LUKS image
+#   LUKS_UUID1       UUID for the first LUKS container
+#   LUKS_UUID2       UUID for the second LUKS container
+#   LUKS_PASSWORD1   passphrase for the first LUKS container
+#   LUKS_PASSWORD2   passphrase for the second LUKS container
+#   FS_UUID          btrfs filesystem UUID (shared across both member devices)
+
+set -o errexit
+
+DEV1_NAME="luks-${LUKS_UUID1}"
+DEV2_NAME="luks-${LUKS_UUID2}"
+lodev1=
+lodev2=
+rootdir=
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  [ -n "${rootdir}" ] && { sudo umount "${rootdir}"; rm -rf "${rootdir}"; }
+  sudo cryptsetup close "${DEV1_NAME}" 2>/dev/null || true
+  sudo cryptsetup close "${DEV2_NAME}" 2>/dev/null || true
+  [ -n "${lodev1}" ] && sudo losetup -d "${lodev1}"
+  [ -n "${lodev2}" ] && sudo losetup -d "${lodev2}"
+}
+
+truncate --size 300M "${OUTPUT}"
+truncate --size 300M "${OUTPUT2}"
+
+lodev1=$(sudo losetup -f --show "${OUTPUT}")
+lodev2=$(sudo losetup -f --show "${OUTPUT2}")
+
+echo -n "${LUKS_PASSWORD1}" | sudo cryptsetup luksFormat --uuid "${LUKS_UUID1}" --type luks2 --key-file=- "${lodev1}"
+echo -n "${LUKS_PASSWORD2}" | sudo cryptsetup luksFormat --uuid "${LUKS_UUID2}" --type luks2 --key-file=- "${lodev2}"
+
+echo -n "${LUKS_PASSWORD1}" | sudo cryptsetup open --key-file=- "${lodev1}" "${DEV1_NAME}"
+echo -n "${LUKS_PASSWORD2}" | sudo cryptsetup open --key-file=- "${lodev2}" "${DEV2_NAME}"
+
+sudo mkfs.btrfs --uuid "${FS_UUID}" -d raid1 -m raid1 \
+  "/dev/mapper/${DEV1_NAME}" "/dev/mapper/${DEV2_NAME}"
+
+rootdir=$(mktemp -d)
+sudo mount "/dev/mapper/${DEV1_NAME}" "${rootdir}"
+sudo chown "${USER}" "${rootdir}"
+mkdir "${rootdir}/sbin"
+cp assets/init "${rootdir}/sbin/init"

--- a/tests/generators/luks_keyfile_device.sh
+++ b/tests/generators/luks_keyfile_device.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Creates two disk images:
+#   $OUTPUT        — LUKS2 root disk, unlocked by keyfile only (no password slot)
+#   $KEYDEV_OUTPUT — small ext4 "key device" containing the keyfile at /keyfile
+#
+# Required env vars:
+#   OUTPUT          path for the LUKS root image
+#   KEYDEV_OUTPUT   path for the key device image
+#   LUKS_UUID       UUID for the LUKS container
+#   FS_UUID         UUID for the ext4 filesystem inside LUKS
+#   KEYDEV_UUID     UUID for the ext4 key device filesystem
+
+set -o errexit
+
+LUKS_DEV_NAME="luks-${LUKS_UUID}"
+KEYFILE=$(mktemp)
+
+rootlodev=
+keylodev=
+rootdir=
+keydir=
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  [ -n "${rootdir}" ]   && { sudo umount "${rootdir}"; rm -rf "${rootdir}"; }
+  [ -n "${keydir}" ]    && { sudo umount "${keydir}";  rm -rf "${keydir}"; }
+  sudo cryptsetup close "${LUKS_DEV_NAME}" 2>/dev/null || true
+  [ -n "${rootlodev}" ] && sudo losetup -d "${rootlodev}"
+  [ -n "${keylodev}" ]  && sudo losetup -d "${keylodev}"
+  rm -f "${KEYFILE}"
+}
+
+# Generate a random binary keyfile
+dd if=/dev/urandom of="${KEYFILE}" bs=512 count=8 status=none
+
+# --- key device: small ext4 image containing the keyfile ---
+truncate --size 10M "${KEYDEV_OUTPUT}"
+mkfs.ext4 -U "${KEYDEV_UUID}" "${KEYDEV_OUTPUT}"
+keylodev=$(sudo losetup -f --show "${KEYDEV_OUTPUT}")
+keydir=$(mktemp -d)
+sudo mount "${keylodev}" "${keydir}"
+sudo chown "${USER}" "${keydir}"
+cp "${KEYFILE}" "${keydir}/keyfile"
+sudo umount "${keydir}"
+rm -rf "${keydir}"; keydir=
+sudo losetup -d "${keylodev}"; keylodev=
+
+# --- LUKS root disk: keyfile-only (no password slot) ---
+truncate --size 40M "${OUTPUT}"
+rootlodev=$(sudo losetup -f --show "${OUTPUT}")
+sudo cryptsetup luksFormat --uuid "${LUKS_UUID}" --type luks2 \
+  --key-file "${KEYFILE}" "${rootlodev}"
+sudo cryptsetup open --key-file "${KEYFILE}" "${rootlodev}" "${LUKS_DEV_NAME}"
+sudo mkfs.ext4 -U "${FS_UUID}" "/dev/mapper/${LUKS_DEV_NAME}"
+rootdir=$(mktemp -d)
+sudo mount "/dev/mapper/${LUKS_DEV_NAME}" "${rootdir}"
+sudo chown "${USER}" "${rootdir}"
+mkdir "${rootdir}/sbin"
+cp assets/init "${rootdir}/sbin/init"

--- a/tests/generators/luks_keyfile_offset.sh
+++ b/tests/generators/luks_keyfile_offset.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Creates a LUKS2 image whose enrolled keyfile has a 512-byte random preamble
+# (bytes 0-511) followed by 4096 bytes of actual key material (bytes 512-4607).
+# At boot, crypttab must supply keyfile-offset=512,keyfile-size=4096 to skip
+# the preamble and read only the real key.
+#
+# Required env vars:
+#   OUTPUT           path for the LUKS image
+#   KEYFILE_OUTPUT   path where the combined keyfile (preamble + key) is written
+#   LUKS_UUID        UUID for the LUKS container
+#   FS_UUID          UUID for the ext4 filesystem inside LUKS
+
+set -o errexit
+
+LUKS_DEV_NAME="luks-${LUKS_UUID}"
+TMPKF=$(mktemp)
+lodev=
+rootdir=
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  [ -n "${rootdir}" ] && { sudo umount "${rootdir}"; rm -rf "${rootdir}"; }
+  sudo cryptsetup close "${LUKS_DEV_NAME}" 2>/dev/null || true
+  [ -n "${lodev}" ]   && sudo losetup -d "${lodev}"
+  rm -f "${TMPKF}"
+}
+
+# 512 bytes of random preamble + 4096 bytes of actual key = 4608 bytes total
+dd if=/dev/urandom of="${TMPKF}" bs=512 count=9 status=none
+cp "${TMPKF}" "${KEYFILE_OUTPUT}"
+
+truncate --size 40M "${OUTPUT}"
+lodev=$(sudo losetup -f --show "${OUTPUT}")
+sudo cryptsetup luksFormat --uuid "${LUKS_UUID}" --type luks2 \
+  --key-file "${TMPKF}" --keyfile-offset 512 --keyfile-size 4096 "${lodev}"
+sudo cryptsetup open \
+  --key-file "${TMPKF}" --keyfile-offset 512 --keyfile-size 4096 \
+  "${lodev}" "${LUKS_DEV_NAME}"
+sudo mkfs.ext4 -U "${FS_UUID}" "/dev/mapper/${LUKS_DEV_NAME}"
+rootdir=$(mktemp -d)
+sudo mount "/dev/mapper/${LUKS_DEV_NAME}" "${rootdir}"
+sudo chown "${USER}" "${rootdir}"
+mkdir "${rootdir}/sbin"
+cp assets/init "${rootdir}/sbin/init"

--- a/tests/luks_test.go
+++ b/tests/luks_test.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -82,5 +84,120 @@ func TestLoadableCryptoModule(t *testing.T) {
 
 	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
 	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+const (
+	keyfileDevLuksUUID   = "7c2a39be-15d1-4b71-9f2e-5c4d1a3b8e6f"
+	keyfileDevFsUUID     = "a3d8e2c1-4f7b-4e9c-b2a1-6d5f3c8e1a7b"
+	keyfileDevKeydevUUID = "f1e2d3c4-b5a6-4789-8abc-def123456789"
+
+	keyfileOffsetLuksUUID = "c0d3f4a5-b6e7-4809-9abc-def012345678"
+	keyfileOffsetFsUUID   = "d1e2f3a4-c5b6-4789-abcd-ef0123456789"
+)
+
+// TestLUKS2KeyfileOnDeviceCmdline verifies that booster can unlock a LUKS2
+// volume whose keyfile lives on a separate block device, specified via the
+// rd.luks.key=/path:UUID=<keydev> kernel parameter.
+func TestLUKS2KeyfileOnDeviceCmdline(t *testing.T) {
+	vm, err := buildVmInstance(t, Opts{
+		disk:   "assets/luks2.keyfile_device.img",
+		params: []string{"-drive", "file=assets/luks2.keyfile_device.keydev.img,if=virtio,format=raw"},
+		kernelArgs: []string{
+			"rd.luks.name=" + keyfileDevLuksUUID + "=cryptroot",
+			"rd.luks.key=" + keyfileDevLuksUUID + "=/keyfile:UUID=" + keyfileDevKeydevUUID,
+			"root=/dev/mapper/cryptroot",
+		},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestLUKS2KeyfileOnDeviceCrypttab verifies the same keyfile-on-device unlock
+// path but driven by /etc/crypttab (the keyfile= field with :UUID= suffix).
+func TestLUKS2KeyfileOnDeviceCrypttab(t *testing.T) {
+	crypttab := filepath.Join(t.TempDir(), "crypttab.initramfs")
+	content := "cryptroot UUID=" + keyfileDevLuksUUID + " /keyfile:UUID=" + keyfileDevKeydevUUID + "\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.keyfile_device.img",
+		params:       []string{"-drive", "file=assets/luks2.keyfile_device.keydev.img,if=virtio,format=raw"},
+		kernelArgs:   []string{"root=UUID=" + keyfileDevFsUUID},
+		crypttabFile: crypttab,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestLUKS2CrypttabPassphrase verifies that booster can unlock a LUKS2 volume
+// driven entirely by /etc/crypttab (no rd.luks.* kernel arguments).
+func TestLUKS2CrypttabPassphrase(t *testing.T) {
+	crypttab := filepath.Join(t.TempDir(), "crypttab.initramfs")
+	content := "cryptroot UUID=639b8fdd-36ba-443e-be3e-e5b335935502 none\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.img",
+		kernelArgs:   []string{"root=UUID=7bbf9363-eb42-4476-8c1c-9f1f4d091385"},
+		crypttabFile: crypttab,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestLUKS2NofailCrypttab verifies that a crypttab entry with nofail does not
+// prevent boot when the referenced device is absent.
+func TestLUKS2NofailCrypttab(t *testing.T) {
+	crypttab := filepath.Join(t.TempDir(), "crypttab.initramfs")
+	content := "cryptroot UUID=639b8fdd-36ba-443e-be3e-e5b335935502 none\n" +
+		"nonexistent UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee none nofail\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.img",
+		kernelArgs:   []string{"root=UUID=7bbf9363-eb42-4476-8c1c-9f1f4d091385"},
+		crypttabFile: crypttab,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestLUKS2CrypttabKeyfileOffsetSize verifies that booster can unlock a LUKS2
+// volume using a bundled keyfile with keyfile-offset= and keyfile-size= in
+// /etc/crypttab — the keyfile has a 512-byte random preamble before the real
+// key material.
+func TestLUKS2CrypttabKeyfileOffsetSize(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.keyfile_offset.img"))
+
+	// The keyfile was written alongside the image by the asset generator.
+	// Use its absolute path so the booster generator can bundle it.
+	keyfilePath, err := filepath.Abs("assets/luks2.keyfile_offset.key")
+	require.NoError(t, err)
+
+	crypttab := filepath.Join(t.TempDir(), "crypttab.initramfs")
+	content := "cryptroot UUID=" + keyfileOffsetLuksUUID + " " + keyfilePath + " keyfile-offset=512,keyfile-size=4096\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.keyfile_offset.img",
+		kernelArgs:   []string{"root=UUID=" + keyfileOffsetFsUUID},
+		crypttabFile: crypttab,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
 }

--- a/tests/util.go
+++ b/tests/util.go
@@ -181,6 +181,9 @@ func generateInitRamfs(workDir string, opts Opts) (string, error) {
 	if opts.modulesDirectory != "" {
 		generatorArgs = append(generatorArgs, "--modules-dir", opts.modulesDirectory)
 	}
+	if opts.crypttabFile != "" {
+		generatorArgs = append(generatorArgs, "--crypttab", opts.crypttabFile)
+	}
 	generatorArgs = append(generatorArgs, output)
 	cmd := exec.Command(binariesDir+"/generator", generatorArgs...)
 	if testing.Verbose() {
@@ -317,6 +320,7 @@ type Opts struct {
 	enableZfs            bool
 	zfsImportParams      string
 	zfsCachePath         string // TODO: do we need any of these parameters?
+	crypttabFile         string // path to a crypttab to bundle into the image
 }
 
 func buildVmInstance(t *testing.T, opts Opts) (*vmtest.Qemu, error) {
@@ -337,6 +341,12 @@ func buildVmInstance(t *testing.T, opts Opts) (*vmtest.Qemu, error) {
 	if opts.kernelVersion == "" {
 		if kernel, ok := kernelVersions["linux"]; ok {
 			opts.kernelVersion = kernel
+		} else if len(kernelVersions) > 0 {
+			// Fall back to any available kernel (e.g. linux-cachyos on CachyOS systems).
+			for _, ver := range kernelVersions {
+				opts.kernelVersion = ver
+				break
+			}
 		} else {
 			require.Fail(t, "System does not have 'linux' package installed needed for the integration tests")
 		}


### PR DESCRIPTION
## Summary

Adds support for `/etc/crypttab.initramfs`, which is bundled into the
initramfs as `/etc/crypttab` at image-build time (opt-in by file presence,
same pattern as mkinitcpio/dracut).  Kernel cmdline `rd.luks.*` parameters
take precedence over crypttab entries for the same device.

**Prerequisites included in this PR:**

- `rd.luks.options`: support `fido2-device=auto`, `tpm2-device=auto`, and
  `token-timeout=` — defers the keyboard prompt until the token attempt
  completes (or times out), preventing simultaneous FIDO2 and keyboard
  unlock flows.  Also improves the FIDO2 PIN prompt to show the LUKS
  mapping name and retry on incorrect PIN.

**New crypttab options:**

| Option | Description |
|--------|-------------|
| `x-initrd.attach` | include entry in initramfs unlock queue |
| `discard`, `same-cpu-crypt`, etc. | dm-crypt flags (same as `rd.luks.options`) |
| `fido2-device=auto`, `tpm2-device=auto` | hardware token unlock |
| `token-timeout=` | defer keyboard until token times out |
| `key-slot=` | restrict unlock to a specific LUKS key slot |
| `noauto` | skip entry (not yet wired, stub only) |
| `tries=N` | limit keyboard passphrase attempts |
| `nofail` | non-fatal unlock failure — boot continues |
| `keyfile-offset=`, `keyfile-size=` | byte range within keyfile |
| `keyfile:UUID=…` / `keyfile:LABEL=…` | keyfile on a separate device |

Also fixes a passphrase cache race: when two LUKS volumes appear
simultaneously (e.g. btrfs RAID1 across two encrypted drives), the second
goroutine now finds the cached password and unlocks silently without a
second prompt.

## Test plan

- [ ] Unit tests: `go test ./init/... ./generator/...`
- [ ] QEMU integration tests: `cd tests && go test -v -run "TestLuksCrypttab|TestLuksKeyfileDevice|TestLuksKeyfileOffset|TestBtrfsRaid1Luks"`
- [ ] Manual: create `/etc/crypttab.initramfs`, rebuild initramfs, boot