### PR TITLE
Add remote ssh LUKS device unlocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ generator/assets/*.ko*
 generator/assets/*.mod
 generator/assets/*.mod.*
 generator/assets/*.o
+
+ssh_host_*

--- a/generator/config.go
+++ b/generator/config.go
@@ -23,6 +23,12 @@ type UserConfig struct {
 		IP         string `yaml:",omitempty"`            // e.g. 10.0.2.15/24
 		Gateway    string `yaml:",omitempty"`            // e.g. 10.0.2.255
 		DNSServers string `yaml:"dns_servers,omitempty"` // comma-separated list of ips, e.g. 10.0.1.1,8.8.8.8
+
+		SshAddr           string `yaml:"ssh_addr,omitempty"`
+		SshServerKeys     string `yaml:"ssh_server_keys,omitempty"`
+		SshUser           string `yaml:"ssh_user,omitempty"`
+		SshPass           string `yaml:"ssh_pass,omitempty"`
+		SshAuthorizedKeys string `yaml:"ssh_authorized_keys,omitempty"`
 	}
 	Universal            bool   `yaml:",omitempty"`
 	Modules              string `yaml:",omitempty"`                   // comma separated list of extra modules to add to initramfs
@@ -96,6 +102,13 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 				conf.networkActiveInterfaces = append(conf.networkActiveInterfaces, ifc.HardwareAddr)
 			}
 		}
+
+		// copy ssh config
+		conf.sshAddr = n.SshAddr
+		conf.sshServerKeys = n.SshServerKeys
+		conf.sshUser = n.SshUser
+		conf.sshPass = n.SshPass
+		conf.sshAuthorizedKeys = n.SshAuthorizedKeys
 	}
 	conf.universal = u.Universal || opts.BuildCommand.Universal
 	if u.Modules != "" {

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -44,6 +44,12 @@ type generatorConfig struct {
 
 	enablePlymouth bool
 
+	sshAddr           string
+	sshServerKeys     string
+	sshUser           string
+	sshPass           string
+	sshAuthorizedKeys string
+
 	// virtual console configs
 	enableVirtualConsole     bool
 	vconsolePath, localePath string
@@ -455,6 +461,12 @@ func (img *Image) appendInitConfig(conf *generatorConfig, kmod *Kmod, vconsole *
 	if conf.networkActiveInterfaces != nil {
 		initConfig.Network.Interfaces = conf.networkActiveInterfaces
 	}
+
+	initConfig.Network.SshAddr = conf.sshAddr
+	initConfig.Network.SshServerKeys = conf.sshServerKeys
+	initConfig.Network.SshUser = conf.sshUser
+	initConfig.Network.SshPass = conf.sshPass
+	initConfig.Network.SshAuthorizedKeys = conf.sshAuthorizedKeys
 
 	content, err := yaml.Marshal(initConfig)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/anatol/tang.go v0.0.0-20250920193351-e505ad2c76db
 	github.com/anatol/vmtest v0.0.0-20250627153117-302402d269a6
 	github.com/cavaliergopher/cpio v1.0.1
+	github.com/gliderlabs/ssh v0.3.8
+	github.com/go-crypt/crypt v0.4.10
 	github.com/google/go-tpm v0.9.7
 	github.com/google/renameio/v2 v2.0.0
 	github.com/insomniacslk/dhcp v0.0.0-20251020182700-175e84fbb167
@@ -27,9 +29,11 @@ require (
 )
 
 require (
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/dgryski/go-camellia v0.0.0-20191119043421-69a8a13fb23d // indirect
+	github.com/go-crypt/x v0.4.13 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/jzelinskie/whirlpool v0.0.0-20201016144138-0675e54bb004 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/anatol/tang.go v0.0.0-20250920193351-e505ad2c76db h1:4AyNx4ipXJv+OGyH
 github.com/anatol/tang.go v0.0.0-20250920193351-e505ad2c76db/go.mod h1:dH7UKUQ+S9LM+IT3Va46o5lIlhRt3PeQFoZKOBOlpYI=
 github.com/anatol/vmtest v0.0.0-20250627153117-302402d269a6 h1:zdaWj/ncXyzpPH3YqACvJXMrJxkkILrnWbjHojHBctc=
 github.com/anatol/vmtest v0.0.0-20250627153117-302402d269a6/go.mod h1:m5pN88x7ZnEDGXZldwg7RCX+EikR9qz/iSI2GzXq++Y=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/cavaliergopher/cpio v1.0.1 h1:KQFSeKmZhv0cr+kawA3a0xTQCU4QxXF1vhU7P7av2KM=
 github.com/cavaliergopher/cpio v1.0.1/go.mod h1:pBdaqQjnvXxdS/6CvNDwIANIFSP0xRKI16PX4xejRQc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -21,6 +23,12 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvw
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/dgryski/go-camellia v0.0.0-20191119043421-69a8a13fb23d h1:CPqTNIigGweVPT4CYb+OO2E6XyRKFOmvTHwWRLgCAlE=
 github.com/dgryski/go-camellia v0.0.0-20191119043421-69a8a13fb23d/go.mod h1:QX5ZVULjAfZJux/W62Y91HvCh9hyW6enAwcrrv/sLj0=
+github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
+github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
+github.com/go-crypt/crypt v0.4.10 h1:bJiJ9MRrKjHQEfbZMT+Q/XkwxoU3oahCJv1eLJ4u0UU=
+github.com/go-crypt/crypt v0.4.10/go.mod h1:KHr1XXnCbQ3rkNhoJovldRd3mbLSnkuAeAPmrTBvxKI=
+github.com/go-crypt/x v0.4.13 h1:aE4ieFDpDoHKzF1qKOhadZAS8GHZR6bSxUkKVOdIx1c=
+github.com/go-crypt/x v0.4.13/go.mod h1:KWDO2p5WT94GKRj6fdNo7+XKTya53zfxCB1V3e2B9hU=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/google/go-tpm v0.9.7 h1:u89J4tUUeDTlH8xxC3CTW7OHZjbjKoHdQ9W7gCUhtxA=

--- a/init/config.go
+++ b/init/config.go
@@ -10,6 +10,12 @@ type InitNetworkConfig struct {
 	IP         string `yaml:",omitempty"`            // e.g. 10.0.2.15/24
 	Gateway    string `yaml:",omitempty"`            // e.g. 10.0.2.255
 	DNSServers string `yaml:"dns_servers,omitempty"` // comma-separated list of ips, e.g. 10.0.1.1,8.8.8.8
+
+	SshAddr           string `yaml:"ssh_addr,omitempty"`
+	SshServerKeys     string `yaml:"ssh_server_keys,omitempty"`
+	SshUser           string `yaml:"ssh_user,omitempty"`
+	SshPass           string `yaml:"ssh_pass,omitempty"`
+	SshAuthorizedKeys string `yaml:"ssh_authorized_keys,omitempty"`
 }
 
 type VirtualConsole struct {

--- a/init/luks.go
+++ b/init/luks.go
@@ -367,7 +367,6 @@ func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots
 
 	if len(parts) == 1 {
 		password, err = os.ReadFile(parts[0])
-
 		if err != nil {
 			warning("reading password: %v", err)
 		}

--- a/init/main.go
+++ b/init/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -741,6 +742,7 @@ func switchRoot() error {
 func cleanup() {
 	close(udevQuitLoop)
 	udevConn.Close()
+	sshShutdown()
 	shutdownNetwork()
 }
 
@@ -924,6 +926,18 @@ func boost() error {
 		if err := mountZfsRoot(); err != nil {
 			return err
 		}
+	}
+
+	// start ssh
+	if config.Network != nil && (config.Network.SshPass != "" || config.Network.SshAuthorizedKeys != "") {
+		// ensure secure key
+		if config.Network.SshServerKeys == "" {
+			var err error
+			if config.Network.SshServerKeys, err = sshGenEcdsaKey(rand.Reader); err != nil {
+				warning("ssh: unable to generate ecdsa key: %v", err)
+			}
+		}
+		go sshRun(config.Network)
 	}
 
 	if config.MountTimeout != 0 {

--- a/init/ssh.go
+++ b/init/ssh.go
@@ -1,0 +1,354 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"strings"
+	"syscall"
+	"unicode"
+
+	"github.com/anatol/luks.go"
+	"github.com/gliderlabs/ssh"
+	"github.com/go-crypt/crypt"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+var sshServer *ssh.Server
+
+// sshRun creates a ssh server and starts it.
+func sshRun(cfg *InitNetworkConfig) {
+	// sanity check
+	if cfg.SshPass == "" && cfg.SshAuthorizedKeys == "" {
+		debug("ssh: ssh_pass and ssh_authorized_keys not specified: not starting server")
+		return
+	}
+
+	// build server
+	var err error
+	if sshServer, err = sshServerBuild(cfg); err != nil {
+		warning("ssh: unable to create server: %v", err)
+		return
+	}
+
+	// start
+	info("ssh: starting on %s", sshServer.Addr)
+	if err := sshServer.ListenAndServe(); err != nil && !errors.Is(err, ssh.ErrServerClosed) {
+		warning("ssh: unable to start server: %v", err)
+	}
+}
+
+// sshShutdown closes the ssh server.
+func sshShutdown() {
+	if sshServer != nil {
+		if err := sshServer.Close(); err != nil {
+			debug("ssh: error closing server: %v", err)
+		}
+		sshServer = nil
+	}
+}
+
+// sshServerBuild creates the ssh server based on the passed configuration.
+func sshServerBuild(cfg *InitNetworkConfig) (*ssh.Server, error) {
+	// server options
+	var opts []ssh.Option
+	if cfg.SshServerKeys == "" {
+		warning("ssh: no server keys provided -- will result in non-quantum/non-forward secure key")
+	} else {
+		debug("ssh: adding server keys")
+		opts = append(opts, ssh.HostKeyPEM([]byte(cfg.SshServerKeys)))
+	}
+	if cfg.SshPass != "" {
+		debug("ssh: adding password auth")
+		opts = append(opts, sshPass(cfg))
+	}
+	if cfg.SshAuthorizedKeys != "" {
+		debug("ssh: adding key auth")
+		opts = append(opts, sshAuthorizedKeys(cfg))
+	}
+
+	// default listen on port 22
+	addr := cfg.SshAddr
+	if addr == "" {
+		addr = ":22"
+	}
+
+	// server
+	s := &ssh.Server{
+		Addr:    addr,
+		Handler: sshSessionHandler,
+	}
+
+	// set server options
+	for _, o := range opts {
+		if o == nil {
+			continue
+		}
+		if err := s.SetOption(o); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+// sshPass creates a [ssh.Option] to add a password handler to a ssh server.
+func sshPass(cfg *InitNetworkConfig) ssh.Option {
+	user := cfg.SshUser
+	if user == "" {
+		user = "root"
+	}
+
+	// create crypt decoder
+	dec, err := crypt.NewDecoderAll()
+	if err != nil {
+		warning("ssh: unable to create crypt decoder: %v", err)
+		return nil
+	}
+
+	// create crypt digest
+	d, err := dec.Decode(cfg.SshPass)
+
+	// match func
+	var match func(string) bool
+	if err == nil {
+		match = d.Match
+	} else {
+		warning("ssh: unable to create crypt digest, falling back to plaintext auth: %v", err)
+		match = func(pass string) bool {
+			return cfg.SshPass == pass
+		}
+	}
+	return ssh.PasswordAuth(func(ctx ssh.Context, pass string) bool {
+		u, remoteAddr := ctx.User(), ctx.RemoteAddr()
+		if user != u {
+			warning("ssh: session %q [%s]: invalid user: user is not %q", u, remoteAddr, user)
+			return false
+		}
+		m, s := match(pass), "invalid"
+		if m {
+			s = "accepted"
+		}
+		warning("ssh: session %q [%s]: password %s", u, remoteAddr, s)
+		return m
+	})
+}
+
+// sshAuthorizedKeys creates a [ssh.Option] to add a authorized key handler to
+// a ssh server.
+func sshAuthorizedKeys(cfg *InitNetworkConfig) ssh.Option {
+	// parse authorized keys
+	var authorizedKeys []ssh.PublicKey
+	i := 0
+	for line := range strings.SplitSeq(cfg.SshAuthorizedKeys, "\n") {
+		key, _, _, _, err := ssh.ParseAuthorizedKey(bytes.TrimSpace([]byte(line)))
+		if err != nil {
+			warning("ssh: ssh_authorized_keys line %d is invalid, skipping: %v", i+1, err)
+		}
+		authorizedKeys = append(authorizedKeys, key)
+		i++
+	}
+	user := cfg.SshUser
+	if user == "" {
+		user = "root"
+	}
+	return ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
+		u, remoteAddr, skey := ctx.User(), ctx.RemoteAddr(), sshMarshalKey(key)
+		debug("ssh: session %q [%s]: key %q auth", u, remoteAddr, skey)
+		if user != u {
+			warning("ssh: session %q [%s]: invalid user: user is not %q", u, remoteAddr, user)
+			return false
+		}
+		for _, k := range authorizedKeys {
+			if ssh.KeysEqual(key, k) {
+				debug("ssh: session %q [%s]: key %q matched", u, remoteAddr, skey)
+				return true
+			}
+			debug("ssh: session %q [%s]: key %q did not match", u, remoteAddr, skey)
+		}
+		debug("ssh: session %q [%s]: key %q not authorized", u, remoteAddr, skey)
+		return false
+	})
+}
+
+// sshSessionHandler handles ssh sessions.
+func sshSessionHandler(sess ssh.Session) {
+	warning("ssh: session %q [%s]: opened", sess.User(), sess.RemoteAddr())
+	defer func() {
+		warning("ssh: session %q [%s]: closed", sess.User(), sess.RemoteAddr())
+	}()
+
+	// collect passwords
+	for r := bufio.NewReader(sess); ; {
+		if _, err := io.WriteString(sess, "Enter passphrase: "); err != nil {
+			return
+		}
+		pass, err := r.ReadString('\r')
+		if err != nil {
+			return
+		}
+		_, _ = io.WriteString(sess, "\n")
+		pass = strings.TrimRightFunc(pass, unicode.IsSpace)
+		if len(pass) == 0 {
+			continue
+		}
+		sshWarning(sess, "Attempting unlock...")
+		if sshUnlock(sess, []byte(pass)) {
+			break
+		}
+		sshWarning(sess, "No devices unlocked by password.")
+	}
+}
+
+// sshUnlock attempts to LUKS unlock all devices with the provided password.
+func sshUnlock(sess ssh.Session, pass []byte) bool {
+	// ensure module has been loaded
+	loadModules("dm_crypt").Wait()
+
+	devicesMutex.Lock()
+	defer devicesMutex.Unlock()
+
+	unlocked := false
+	for devpath := range seenDevices {
+		sshDebug(sess, "device %s attempting to open", devpath)
+		// find luks block devices
+		blk, err := readBlkInfo(devpath)
+		switch {
+		case err != nil:
+			sshDebug(sess, "device %s read block info error: %v", devpath, err)
+			continue
+		case blk.format != "luks":
+			sshDebug(sess, "device %s block info format is %q, skipping", devpath, blk.format)
+			continue
+		}
+
+		// check if mapped device
+		mapping := matchLuksMapping(blk)
+		if mapping == nil {
+			sshDebug(sess, "device %s does not match luks mapping", devpath)
+			continue
+		}
+
+		// open
+		d, err := luks.Open(devpath)
+		if err != nil {
+			sshDebug(sess, "device %s unable to luks open device: %v", mapping.name, err)
+			continue
+		}
+
+		// check slots
+		if len(d.Slots()) == 0 {
+			sshDebug(sess, "device %s has no unlock slots", mapping.name)
+			continue
+		}
+
+		// add options
+		if err := d.FlagsAdd(mapping.options...); err != nil {
+			sshDebug(sess, "device %s unable to add option flags %v: %v", mapping.name, mapping.options, err)
+			continue
+		}
+
+		// unlock slots
+		slots := make(map[int]bool)
+		for _, s := range d.Slots() {
+			slots[s] = true
+		}
+
+		// unlock tokens
+		tokens, err := d.Tokens()
+		if err != nil {
+			sshDebug(sess, "device %s unable to retrieve tokens: %v", mapping.name, err)
+			continue
+		}
+
+		// exclude unlock tokens from slots
+		for _, t := range tokens {
+			for _, s := range t.Slots {
+				delete(slots, s)
+			}
+		}
+
+		// iterate slots
+		for s := range maps.Keys(slots) {
+			// unlock
+			v, err := d.UnsealVolume(s, pass)
+			if err != nil {
+				sshDebug(sess, "device %s slot #%d was not unlocked: %v", mapping.name, s, err)
+				continue
+			}
+
+			// setup additional modules
+			sshInfo(sess, "device %s slot #%d matches password", mapping.name, s)
+			if err := loadRequiredCryptoModules(v.StorageEncryption); err != nil {
+				sshWarning(sess, "device %s unable to load required crypto modules %q: %v", mapping.name, v.StorageEncryption, err)
+				continue
+			}
+
+			// map
+			if err := v.SetupMapper(mapping.name); err != nil && !errors.Is(err, syscall.EBUSY) {
+				sshWarning(sess, "device %s unable to setup volume mapping: %v", mapping.name, err)
+				continue
+			}
+
+			sshInfo(sess, "device %s unlocked successfully", mapping.name)
+			unlocked = true
+			break
+		}
+
+		// close luks device
+		_ = d.Close()
+
+		if unlocked {
+			break
+		}
+	}
+	return unlocked
+}
+
+// sshGenEcdsaKey generates a ECDSA signing key in PEM encoded format.
+func sshGenEcdsaKey(r io.Reader) (string, error) {
+	if r == nil {
+		r = rand.Reader
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), r)
+	if err != nil {
+		return "", err
+	}
+	enc, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return "", err
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: enc,
+	})), nil
+}
+
+// sshInfo writes a message to the ssh session as well as via [info].
+func sshInfo(sess ssh.Session, format string, v ...any) {
+	info("ssh: session %q [%s]: "+format, append([]any{sess.User(), sess.RemoteAddr()}, v...)...)
+	fmt.Fprintf(sess, strings.TrimRightFunc(format, unicode.IsSpace)+"\n", v...)
+}
+
+// sshWarning writes a message to the ssh session as well as via [warning].
+func sshWarning(sess ssh.Session, format string, v ...any) {
+	warning("ssh: session %q [%s]: "+format, append([]any{sess.User(), sess.RemoteAddr()}, v...)...)
+	fmt.Fprintf(sess, strings.TrimRightFunc(format, unicode.IsSpace)+"\n", v...)
+}
+
+// sshDebug writes a message to [debug].
+func sshDebug(sess ssh.Session, format string, v ...any) {
+	debug("ssh: session %q [%s]: "+format, append([]any{sess.User(), sess.RemoteAddr()}, v...)...)
+}
+
+// sshMarhsalKey returns a printable string for a [ssh.PublicKey].
+func sshMarshalKey(k ssh.PublicKey) string {
+	return string(bytes.TrimRightFunc(gossh.MarshalAuthorizedKey(k), unicode.IsSpace))
+}


### PR DESCRIPTION
Adds a SSH server that enables unlocking LUKS devices with a passphrase. The SSH server is enabled only when the `network:` configuration is defined, and when either `ssh_pass:` or `ssh_authorized_keys:` is defined under `network:`.

Example configuration:

```yaml
network:
  dhcp: true
  ssh_addr: ":2222"
  ssh_server_keys: |-
    -----BEGIN OPENSSH PRIVATE KEY-----
    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS
    1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQQDMfxplAcF1tRvQgpIXz3cUJ1G9L70
    PJLmDx3IL1CwMWu5r1d1/XxsHA8Tau9CRGVliQvyKTBhlRrs3ViM8glbAAAAqEhXJrpIVy
    a6AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAMx/GmUBwXW1G9C
    CkhfPdxQnUb0vvQ8kuYPHcgvULAxa7mvV3X9fGwcDxNq70JEZWWJC/IpMGGVGuzdWIzyCV
    sAAAAhAPghE5yL0ITueX8r8vhYA+aG6F3UMGlwANugAK2poytVAAAAD2tlbkBrZW4tZGVz
    a3RvcA==
    -----END OPENSSH PRIVATE KEY-----
  ssh_user: my_user
  ssh_pass: "$1$FecCMLMd$R10.c/UKY4IaKwrLo4NaT0"
  ssh_authorized_keys: |-
    ssh-ed25519 AAAACFFFFFFFFBBBBTTTTFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF+ user@localhost
```

When enabled as above, the Booster `init` process will start a SSH server at boot listening oen all interfaces on port 2222, using the specified server private key, and only allowing logins from `my_user` (default user is `root` when not specified).

Additionally, password authentication will be available (the password above is hash of "password"), as well as public-key authentication for the provided authorized key. If `ssh_pass:` is not provided, then password authentication will not be available.

Similarly, if `ssh_authorized_keys:` is not provided, then public-key authentication will not be available.

When both `ssh_pass:` and `ssh_authorized_keys:` are not provided, the SSH server will not be started.

An example remote unlock session:

```sh
$ ssh -p 2222 my_user@example.com
Enter passphrase:
Attempting unlock...
device /dev/md1 slot #0 matches password
device /dev/md1 unlocked successfully
Connection to localhost closed.
```

The `ssh_pass:` in the example configuration above was generated as follows:

```sh
echo "password" | mkpasswd -H md5 -s
```

Any standard crypt-style prefixed password hashes, as well as plaintext passwords are supported for `ssh_pass:`.

See the [`github.com/go-crypt/crypt`](https://github.com/go-crypt/crypt) package for more information.

If `ssh_server_keys:` is not provided, a random ECDSA key will be generated and used instead.

Implements #191.