### PR TITLE
init: rd.luks.header= kernel parameter for detached LUKS headers

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -119,6 +119,10 @@ Some parts of booster boot functionality can be modified with kernel boot parame
  * `rd.luks.uuid=$UUID` UUID of the LUKS partition where the root partition is enclosed. booster will try to unlock this LUKS device.
  * `rd.luks.name=$UUID=$NAME` similar to rd.luks.uuid parameter but also specifies the name used for the LUKS device opening.
  * `rd.luks.key=$UUID=$PATH` absolute path to a keyfile in the initrd/initramfs which can be used to unlock the device identified by UUID, if this file does not exist or fails to unlock it will fall back to a password request.
+ * `rd.luks.header=$UUID=$PATH` detached LUKS header for the device identified by `$UUID`. `$PATH` can take three forms:
+    * **Initramfs file** — an absolute path (e.g. `/etc/luks/root.hdr`) to a header file bundled into the initramfs at build time via `extra_files`.
+    * **Raw block device** — a device path (e.g. `/dev/sdb`) where the LUKS header begins at byte offset 0. Booster waits for the device to appear and passes it directly to cryptsetup without mounting.
+    * **File on a separate device** — `$path:$deviceref` where `$deviceref` is `UUID=...`, `LABEL=...`, `PARTUUID=...`, or `PARTLABEL=...`. Booster mounts the device read-only, reads the header file, then unmounts before unlocking.
  * `rd.luks.options=opt1,opt2` a comma-separated list of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`.
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
  * `rd.modules_force_load` a comma-separated list of extra kernel modules which should be force loaded.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/anatol/clevis.go v0.0.0-20251105050026-c2c7ddab8f14
 	github.com/anatol/devmapper.go v0.0.0-20250316020617-2671eefd35d7
 	github.com/anatol/go-udev v0.0.0-20220806124306-5f28d899f64f
-	github.com/anatol/luks.go v0.0.0-20250316021219-8cd744c3576f
+	github.com/anatol/luks.go v0.0.0-20260311221814-15ee027e288c
 	github.com/anatol/smart.go v0.0.0-20260312005832-ba85fde868de
 	github.com/anatol/tang.go v0.0.0-20250920193351-e505ad2c76db
 	github.com/anatol/vmtest v0.0.0-20250627153117-302402d269a6

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/anatol/devmapper.go v0.0.0-20250316020617-2671eefd35d7 h1:rmzBzcHwcMj
 github.com/anatol/devmapper.go v0.0.0-20250316020617-2671eefd35d7/go.mod h1:gc23OPOgbAUVQPvBD6aJTlpnwmKfx3AdrmjkBXstafE=
 github.com/anatol/go-udev v0.0.0-20220806124306-5f28d899f64f h1:Dxki5W8sSFVyPkoYut11RXlIzouHVM5dX99qUL8xsGA=
 github.com/anatol/go-udev v0.0.0-20220806124306-5f28d899f64f/go.mod h1:xM57GU8ntwu+q88yo/exYza/WG1fKGxhJUtvtebxdXg=
-github.com/anatol/luks.go v0.0.0-20250316021219-8cd744c3576f h1:4tLJrnm3h3biCFsXHQ9w6DVGwuZXW4KMfiKV/atSYXg=
-github.com/anatol/luks.go v0.0.0-20250316021219-8cd744c3576f/go.mod h1:kEOnWwULAKOORfFvE4dEkdRZJS7+NMJKxRb/vWvmARk=
+github.com/anatol/luks.go v0.0.0-20260311221814-15ee027e288c h1:6SEiatFEIEO8sxxNQLkjzR2e9EOYHJzFg+JUgMrZRhI=
+github.com/anatol/luks.go v0.0.0-20260311221814-15ee027e288c/go.mod h1:kEOnWwULAKOORfFvE4dEkdRZJS7+NMJKxRb/vWvmARk=
 github.com/anatol/smart.go v0.0.0-20260312005832-ba85fde868de h1:xDc8kZVHTjYLIP1EAq0rt3lMAU1HQ+pWDjn3cfolNl0=
 github.com/anatol/smart.go v0.0.0-20260312005832-ba85fde868de/go.mod h1:ukYit5s/IEmWOGZokOlZs6bIvV5xD4bly0SFawzj7+8=
 github.com/anatol/tang.go v0.0.0-20250920193351-e505ad2c76db h1:4AyNx4ipXJv+OGyH/29A7qPTUmaEnZRLQDz74AZh9R4=

--- a/init/blkinfo.go
+++ b/init/blkinfo.go
@@ -249,6 +249,17 @@ func probeFat(f *os.File) *blkInfo {
 	return nil
 }
 
+// probeLuksHeader reads LUKS metadata from a detached header file path.
+// Returns nil if the file is not a valid LUKS header.
+func probeLuksHeader(headerPath string) *blkInfo {
+	f, err := os.Open(headerPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	return probeLuks(f)
+}
+
 func probeLuks(f *os.File) *blkInfo {
 	// https://gitlab.com/cryptsetup/cryptsetup/-/wikis/LUKS-standard/on-disk-format.pdf
 	// both LUKS v1 and v2 have the same magic and UUID offset

--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -7,6 +7,26 @@ import (
 	"strings"
 )
 
+// parsePathWithDeviceRef parses a "path:SPECIFIER=value" string where the
+// right side of the colon is a device specifier (UUID=, LABEL=, PARTUUID=,
+// PARTLABEL=). If matched, path is the left side and ref is the parsed device
+// ref. Otherwise path == raw and ref == nil.
+// fieldName is used only in error messages (e.g. "keyfile", "header").
+func parsePathWithDeviceRef(raw, fieldName string) (path string, ref *deviceRef, err error) {
+	if idx := strings.Index(raw, ":"); idx >= 0 {
+		right := raw[idx+1:]
+		if strings.HasPrefix(right, "UUID=") || strings.HasPrefix(right, "LABEL=") ||
+			strings.HasPrefix(right, "PARTUUID=") || strings.HasPrefix(right, "PARTLABEL=") {
+			ref, err = parseDeviceRef(right)
+			if err != nil {
+				return "", nil, fmt.Errorf("%s device ref %q: %v", fieldName, right, err)
+			}
+			return raw[:idx], ref, nil
+		}
+	}
+	return raw, nil, nil
+}
+
 func parseCmdline() error {
 	b, err := os.ReadFile("/proc/cmdline")
 	if err != nil {
@@ -276,6 +296,30 @@ func parseParams(params string) error {
 
 			m := findOrCreateLuksMapping(uuid)
 			m.keyfile = keyfile
+		case "rd.luks.header":
+			// Format: rd.luks.header=<UUID>=<path>
+			// where UUID identifies the LUKS device and path is the detached header.
+			// path may be an absolute initramfs file, a /dev/xxx raw block device,
+			// or a /file/path:UUID=xxx reference to a file on a separate device.
+			eqIdx := strings.Index(value, "=")
+			if eqIdx < 0 {
+				return fmt.Errorf("invalid rd.luks.header kernel parameter %q, expected format rd.luks.header=<UUID>=<path>", value)
+			}
+			uuid, err := parseUUID(value[:eqIdx])
+			if err != nil {
+				return fmt.Errorf("invalid UUID %s in rd.luks.header boot param: %v", value[:eqIdx], err)
+			}
+			headerPath := value[eqIdx+1:]
+			if headerPath == "" {
+				return fmt.Errorf("rd.luks.header: header path is empty")
+			}
+			path, ref, err := parsePathWithDeviceRef(headerPath, "header")
+			if err != nil {
+				return fmt.Errorf("rd.luks.header: %v", err)
+			}
+			m := findOrCreateLuksMapping(uuid)
+			m.header = path
+			m.headerDeviceRef = ref
 		case "zfs":
 			zfsDataset = value
 		default:

--- a/init/cmdline_test.go
+++ b/init/cmdline_test.go
@@ -147,3 +147,25 @@ func TestGetNextParamMulti(t *testing.T) {
 		}
 	}
 }
+
+func TestParseParamsLuksHeader(t *testing.T) {
+	luksMappings = nil
+
+	require.NoError(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root rd.luks.header=ab6d7d78-b816-4495-928d-766d6607035e=/etc/luks-headers/root.hdr root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f"))
+	require.Len(t, luksMappings, 1)
+	require.Equal(t, "/etc/luks-headers/root.hdr", luksMappings[0].header)
+}
+
+func TestParseParamsLuksHeaderInvalid(t *testing.T) {
+	luksMappings = nil
+	// no = separator between UUID and path
+	require.Error(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root rd.luks.header=ab6d7d78-b816-4495-928d-766d6607035e root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f"))
+
+	luksMappings = nil
+	// invalid UUID
+	require.Error(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root rd.luks.header=notauuid=/etc/luks-headers/root.hdr root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f"))
+
+	luksMappings = nil
+	// empty path
+	require.Error(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root rd.luks.header=ab6d7d78-b816-4495-928d-766d6607035e= root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f"))
+}

--- a/init/luks.go
+++ b/init/luks.go
@@ -14,12 +14,14 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/anatol/clevis.go"
 	"github.com/anatol/luks.go"
+	"golang.org/x/sys/unix"
 )
 
 // specifies information needed to process/open a LUKS device
@@ -455,10 +457,73 @@ func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlot
 	}
 }
 
+func mountDeviceReadOnly(ref *deviceRef, mountPoint string, timeout time.Duration) (func(), error) {
+	blk, err := waitForDeviceRef(ref, timeout)
+	if err != nil {
+		return nil, err
+	}
+	if !blk.isFs {
+		return nil, fmt.Errorf("device %s is not a mountable filesystem", blk.path)
+	}
+	if err := os.MkdirAll(mountPoint, 0o700); err != nil {
+		return nil, err
+	}
+	flags := uintptr(unix.MS_RDONLY | unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_NODEV)
+	if err := unix.Mount(blk.path, mountPoint, blk.format, flags, ""); err != nil {
+		return nil, fmt.Errorf("mounting device %s: %v", blk.path, err)
+	}
+	return func() {
+		_ = unix.Unmount(mountPoint, unix.MNT_DETACH)
+		_ = os.Remove(mountPoint)
+	}, nil
+}
+
+// acquireHeader resolves the detached LUKS header path for a mapping, waiting
+// for the header device to appear if necessary. The returned cleanup function
+// unmounts any temporarily-mounted device; callers must defer it.
+// If the mapping has no detached header, path is "" and cleanup is a no-op.
+func acquireHeader(m *luksMapping) (path string, cleanup func(), err error) {
+	if m.header == "" {
+		return "", func() {}, nil
+	}
+	timeout := time.Duration(config.MountTimeout) * time.Second
+	if m.headerDeviceRef != nil {
+		// Header is a file on a separate filesystem device.
+		mp := "/run/booster/hdrdev-" + m.name
+		unmount, err := mountDeviceReadOnly(m.headerDeviceRef, mp, timeout)
+		if err != nil {
+			return "", nil, err
+		}
+		return filepath.Join(mp, m.header), unmount, nil
+	}
+	if strings.HasPrefix(m.header, "/dev/") {
+		// Header is a raw block device — wait for it to appear.
+		ref := &deviceRef{refPath, m.header}
+		if _, err := waitForDeviceRef(ref, timeout); err != nil {
+			return "", nil, fmt.Errorf("header device %s: %v", m.header, err)
+		}
+	}
+	// Bundled initramfs file or now-present block device path.
+	return m.header, func() {}, nil
+}
+
 func luksOpen(dev string, mapping *luksMapping) error {
 	module := loadModules("dm_crypt")
 
-	d, err := luks.Open(dev)
+	var (
+		d   luks.Device
+		err error
+	)
+	headerPath, headerCleanup, err := acquireHeader(mapping)
+	if err != nil {
+		return err
+	}
+	defer headerCleanup()
+	if headerPath != "" {
+		d, err = luks.OpenWithHeader(dev, headerPath)
+	} else {
+		d, err = luks.Open(dev)
+	}
 	if err != nil {
 		return err
 	}

--- a/init/luks.go
+++ b/init/luks.go
@@ -25,10 +25,12 @@ import (
 // specifies information needed to process/open a LUKS device
 // often these mappings specified by a user via command-line
 type luksMapping struct {
-	ref     *deviceRef
-	name    string
-	keyfile string
-	options []string
+	ref             *deviceRef
+	name            string
+	keyfile         string
+	options         []string
+	header          string     // detached LUKS header path (empty = embedded header)
+	headerDeviceRef *deviceRef // non-nil when header is a file on a separate device
 }
 
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html

--- a/init/main.go
+++ b/init/main.go
@@ -185,6 +185,27 @@ func addBlockDevice(devpath string, isDevice bool, symlinks []string) error {
 		return handleGptBlockDevice(blk)
 	}
 
+	// Detached LUKS header: the data device carries no embedded header so
+	// probeLuks returns nil and blk.format is empty.  Check whether any
+	// luksMapping has a header= path whose UUID matches the mapping's ref;
+	// if so, adopt this device as the data device for that mapping.
+	if blk.format == "" {
+		for _, m := range luksMappings {
+			if m.header == "" {
+				continue
+			}
+			hdrBlk := probeLuksHeader(m.header)
+			if hdrBlk == nil {
+				continue
+			}
+			if hdrBlk.matchesRef(m.ref) {
+				blk.format = "luks"
+				blk.uuid = hdrBlk.uuid
+				return handleLuksBlockDevice(blk)
+			}
+		}
+	}
+
 	if blk.matchesRef(cmdResume) {
 		if err := resume(devpath); err != nil {
 			return err

--- a/init/main.go
+++ b/init/main.go
@@ -82,6 +82,15 @@ var (
 
 	seenDevices       = make(set) // devices that are already seen by the system, the devices might be fully processed or processing right now
 	processingDevices = make(map[string]*sync.WaitGroup)
+
+	processedBlkInfos []*blkInfo               // append-only; protected by devicesMutex
+	deviceReadyCond   = sync.NewCond(&devicesMutex)
+
+	// pendingDevices accumulates format=="" block devices that could not be
+	// matched to a LUKS mapping on first arrival.  They are retried when a
+	// detached header device appears.
+	pendingDevicesMu sync.Mutex
+	pendingDevices   []*blkInfo
 )
 
 // waitForDeviceToProcess waits till the given device gets handled.
@@ -106,6 +115,34 @@ func markDeviceProcessed(dev string) {
 
 	wg := processingDevices[dev]
 	wg.Done()
+}
+
+// waitForDeviceRef blocks until a block device matching ref appears in
+// processedBlkInfos, or until timeout elapses (0 = wait forever).
+func waitForDeviceRef(ref *deviceRef, timeout time.Duration) (*blkInfo, error) {
+	var deadline time.Time
+	if timeout > 0 {
+		deadline = time.Now().Add(timeout)
+		go func() {
+			time.Sleep(timeout)
+			deviceReadyCond.Broadcast()
+		}()
+	}
+
+	devicesMutex.Lock()
+	defer devicesMutex.Unlock()
+
+	for {
+		for _, blk := range processedBlkInfos {
+			if blk.matchesRef(ref) {
+				return blk, nil
+			}
+		}
+		if timeout > 0 && time.Now().After(deadline) {
+			return nil, fmt.Errorf("timeout waiting for device")
+		}
+		deviceReadyCond.Wait()
+	}
 }
 
 func diskSymlink(typ, oldname, newname string) error {
@@ -160,6 +197,11 @@ func addBlockDevice(devpath string, isDevice bool, symlinks []string) error {
 
 	blk.symlinks = symlinks
 
+	devicesMutex.Lock()
+	processedBlkInfos = append(processedBlkInfos, blk)
+	devicesMutex.Unlock()
+	deviceReadyCond.Broadcast()
+
 	if blk.uuid != nil {
 		if err := diskSymlink("uuid", devpath, blk.uuid.toString()); err != nil {
 			return err
@@ -173,7 +215,68 @@ func addBlockDevice(devpath string, isDevice bool, symlinks []string) error {
 		}
 	}
 
-	// check non-mountable types that require extra processing
+	return processBlkInfo(blk)
+}
+
+// probeHeaderOnDevice non-blockingly checks whether m's header device is already
+// in processedBlkInfos.  If so it mounts it read-only and returns the full path
+// to the header file together with a cleanup function that unmounts it.
+// Returns ("", no-op) when the device has not yet appeared or is not mountable.
+// The caller must invoke cleanup() after use.
+func probeHeaderOnDevice(m *luksMapping) (path string, cleanup func()) {
+	noop := func() {}
+	devicesMutex.Lock()
+	var hdrDev *blkInfo
+	for _, b := range processedBlkInfos {
+		if b.matchesRef(m.headerDeviceRef) {
+			hdrDev = b
+			break
+		}
+	}
+	devicesMutex.Unlock()
+	if hdrDev == nil || !hdrDev.isFs {
+		return "", noop
+	}
+	mp := "/run/booster/hdrdev-probe-" + m.name
+	if err := os.MkdirAll(mp, 0o700); err != nil {
+		return "", noop
+	}
+	flags := uintptr(unix.MS_RDONLY | unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_NODEV)
+	if err := unix.Mount(hdrDev.path, mp, hdrDev.format, flags, ""); err != nil {
+		_ = os.Remove(mp)
+		return "", noop
+	}
+	return filepath.Join(mp, m.header), func() {
+		_ = unix.Unmount(mp, unix.MNT_DETACH)
+		_ = os.Remove(mp)
+	}
+}
+
+// processBlkInfo dispatches a newly-discovered (or retried) block device to the
+// appropriate handler.  Called from addBlockDevice for new devices and directly
+// from retryPendingDevices for previously-unmatched devices.
+func processBlkInfo(blk *blkInfo) error {
+	devpath := blk.path
+
+	// Intercept raw block devices that serve as detached LUKS headers so they
+	// are not erroneously opened as LUKS data devices.  Trigger a retry of any
+	// data devices that were parked in pending while waiting for this header.
+	for _, m := range luksMappings {
+		if m.headerDeviceRef == nil && m.header == devpath {
+			retryPendingDevices()
+			return nil
+		}
+	}
+
+	// If a filesystem device arrives that matches any mapping's headerDeviceRef,
+	// trigger retry so data devices in pending can now mount it and open the header.
+	for _, m := range luksMappings {
+		if m.headerDeviceRef != nil && blk.matchesRef(m.headerDeviceRef) {
+			retryPendingDevices()
+			break
+		}
+	}
+
 	switch blk.format {
 	case "luks":
 		return handleLuksBlockDevice(blk)
@@ -185,14 +288,46 @@ func addBlockDevice(devpath string, isDevice bool, symlinks []string) error {
 		return handleGptBlockDevice(blk)
 	}
 
-	// Detached LUKS header: the data device carries no embedded header so
-	// probeLuks returns nil and blk.format is empty.  Check whether any
-	// luksMapping has a header= path whose UUID matches the mapping's ref;
-	// if so, adopt this device as the data device for that mapping.
 	if blk.format == "" {
+		// Case 1: header is a file on a separate device (headerDeviceRef != nil).
+		// Try direct ref match first (works for PARTUUID/path/label on the data device).
+		// Fall back to probing via the header device: the LUKS UUID lives in the header
+		// file, not in the data device, so UUID-based refs require reading the header.
 		for _, m := range luksMappings {
-			if m.header == "" {
+			if m.headerDeviceRef == nil {
 				continue
+			}
+			if blk.matchesRef(m.ref) {
+				blk.format = "luks"
+				return handleLuksBlockDevice(blk)
+			}
+			// Non-blocking probe: if the header device is already in processedBlkInfos,
+			// mount it and read the header to recover the LUKS UUID for matching.
+			hdrPath, cleanup := probeHeaderOnDevice(m)
+			if hdrPath != "" {
+				hdrBlk := probeLuksHeader(hdrPath)
+				cleanup()
+				if hdrBlk != nil && hdrBlk.matchesRef(m.ref) {
+					blk.format = "luks"
+					blk.uuid = hdrBlk.uuid
+					return handleLuksBlockDevice(blk)
+				}
+			}
+		}
+
+		// Case 2: header is a raw block device or a bundled initramfs file.
+		// Try direct ref matching first (works for path/label/hwpath refs on the
+		// data device without needing to probe the header).  Fall back to probing
+		// the header to obtain the LUKS UUID for UUID-based refs.
+		for _, m := range luksMappings {
+			if m.header == "" || m.headerDeviceRef != nil {
+				continue
+			}
+			if blk.matchesRef(m.ref) {
+				// Matched by path/label/hwpath — acquireHeader in luksOpen will
+				// wait for the header device if it has not appeared yet.
+				blk.format = "luks"
+				return handleLuksBlockDevice(blk)
 			}
 			hdrBlk := probeLuksHeader(m.header)
 			if hdrBlk == nil {
@@ -204,6 +339,12 @@ func addBlockDevice(devpath string, isDevice bool, symlinks []string) error {
 				return handleLuksBlockDevice(blk)
 			}
 		}
+
+		// Not matched as a LUKS data device.  Park in pending in case a detached
+		// header device arrives later and makes a match possible.
+		pendingDevicesMu.Lock()
+		pendingDevices = append(pendingDevices, blk)
+		pendingDevicesMu.Unlock()
 	}
 
 	if blk.matchesRef(cmdResume) {
@@ -227,6 +368,20 @@ func addBlockDevice(devpath string, isDevice bool, symlinks []string) error {
 	}
 
 	return nil
+}
+
+// retryPendingDevices replays all devices that were parked in pendingDevices
+// because no LUKS mapping could be matched at their original arrival time.
+func retryPendingDevices() {
+	pendingDevicesMu.Lock()
+	pending := pendingDevices
+	pendingDevices = nil
+	pendingDevicesMu.Unlock()
+	for _, blk := range pending {
+		if err := processBlkInfo(blk); err != nil {
+			warning("retry pending device %s: %v", blk.path, err)
+		}
+	}
 }
 
 func setupDiskSymlinks(devpath string, blk *blkInfo, err error) error {

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -24,6 +24,22 @@ var assetGenerators = map[string]assetGenerator{
 	"luks2.clevis.remote.img":  {"luks.sh", []string{"LUKS_VERSION=2", "LUKS_PASSWORD=1234", "LUKS_UUID=f2473f71-9a61-4b16-ae54-8f942b2daf22", "FS_UUID=7acb3a9e-9b51-4aa2-9965-e41ae8467d8a", "CLEVIS_PIN=remote", `CLEVIS_CONFIG={"adv":"assets/remote/key.pub", "port":34551}`}},
 	// camellia is a loadable module at Arch and it is a good candidate to verify loading it works correctly
 	"luks2.external.module.img": {"luks.sh", []string{"LUKS_VERSION=2", "LUKS_PASSWORD=1234", "LUKS_UUID=ad575500-a9e3-4692-b1b2-eed95a6e8ce2", "FS_UUID=0118f2b1-3c4f-4eff-9663-b58447ad797c", `LUKS_PARAMS=-c camellia-xts-plain64 -s 512 -h sha512 -i 8000 --pbkdf argon2id --pbkdf-memory 4100000`}},
+	// luks2.detached_header.img: LUKS2 image whose header is stored in a separate file.
+	// Tests rd.luks.header= detached-header unlock via kernel cmdline.
+	// The header file is written to HEADER_OUTPUT alongside the image.
+	"luks2.detached_header.img": {"luks_detached_header.sh", []string{
+		"LUKS_UUID=cbd49694-81de-41bd-a850-0d934aff8328",
+		"FS_UUID=781780d2-bf67-4a17-9ca8-fd22336c1b2e",
+		"HEADER_OUTPUT=assets/luks2.detached_header.hdr",
+	}},
+	// luks2.detached_header.hdrdev.img: small ext4 device containing luks2.detached_header.hdr
+	// at /root.hdr.  Used by TestLUKS2DetachedHeaderCmdlineOnDevice to exercise the
+	// rd.luks.header=UUID=/root.hdr:UUID=<devuuid> cmdline path (headerDeviceRef != nil).
+	// Depends on luks2.detached_header.img having been generated first (creates the .hdr file).
+	"luks2.detached_header.hdrdev.img": {"luks_detached_header_device.sh", []string{
+		"HDRDEV_UUID=e2d8f1a3-7b4c-4e9d-a1b2-3c4d5e6f7a8b",
+		"HEADER_INPUT=assets/luks2.detached_header.hdr",
+	}},
 	"gpt.img":                   {"gpt.sh", []string{"FS_UUID=e5404205-ac6a-4e94-bb3b-14433d0af7d1", "FS_LABEL=newpart"}},
 	"gpt_4ksector.img":          {"gpt_4ksector.sh", nil},
 	"lvm.img":                   {"lvm.sh", []string{"FS_UUID=74c9e30c-506f-4106-9f61-a608466ef29c", "FS_LABEL=lvmr00t"}},

--- a/tests/generators/luks_detached_header.sh
+++ b/tests/generators/luks_detached_header.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Creates a LUKS2 image with a detached header.
+# The LUKS metadata lives in HEADER_OUTPUT; the encrypted payload lives in OUTPUT.
+# At boot, crypttab must supply header=<path> (or rd.luks.header=) pointing to
+# the bundled header file.
+#
+# Required env vars:
+#   OUTPUT        path for the encrypted data image
+#   HEADER_OUTPUT path where the detached header file is written
+#   LUKS_UUID     UUID for the LUKS container
+#   FS_UUID       UUID for the ext4 filesystem inside LUKS
+
+set -o errexit
+
+LUKS_DEV_NAME="luks-${LUKS_UUID}"
+lodev=
+rootdir=
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  [ -n "${rootdir}" ] && { sudo umount "${rootdir}"; rm -rf "${rootdir}"; }
+  sudo cryptsetup close "${LUKS_DEV_NAME}" 2>/dev/null || true
+  [ -n "${lodev}" ] && sudo losetup -d "${lodev}"
+}
+
+truncate --size 40M "${OUTPUT}"
+truncate --size 2M  "${HEADER_OUTPUT}"
+
+lodev=$(sudo losetup -f --show "${OUTPUT}")
+
+# Format with detached header: metadata goes to HEADER_OUTPUT, payload to lodev
+sudo cryptsetup luksFormat \
+  --type luks2 \
+  --uuid "${LUKS_UUID}" \
+  --header "${HEADER_OUTPUT}" \
+  "${lodev}" <<< "1234"
+
+sudo cryptsetup open \
+  --header "${HEADER_OUTPUT}" \
+  "${lodev}" "${LUKS_DEV_NAME}" <<< "1234"
+
+sudo mkfs.ext4 -U "${FS_UUID}" "/dev/mapper/${LUKS_DEV_NAME}"
+rootdir=$(mktemp -d)
+sudo mount "/dev/mapper/${LUKS_DEV_NAME}" "${rootdir}"
+sudo chown "${USER}" "${rootdir}"
+mkdir "${rootdir}/sbin"
+cp assets/init "${rootdir}/sbin/init"

--- a/tests/generators/luks_detached_header_device.sh
+++ b/tests/generators/luks_detached_header_device.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Creates a small ext4 "header device" image containing a LUKS detached header
+# file at /root.hdr.  Used by TestLUKS2DetachedHeaderCmdlineOnDevice to exercise
+# the rd.luks.header=UUID=/root.hdr:UUID=<devuuid> cmdline syntax.
+#
+# Required env vars:
+#   OUTPUT        path for the header device image
+#   HDRDEV_UUID   UUID for the ext4 header-device filesystem
+#   HEADER_INPUT  path to the detached LUKS header file to embed
+
+set -o errexit
+
+lodev=
+hdrdir=
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  [ -n "${hdrdir}" ] && { sudo umount "${hdrdir}"; rm -rf "${hdrdir}"; }
+  [ -n "${lodev}" ]  && sudo losetup -d "${lodev}"
+}
+
+truncate --size 10M "${OUTPUT}"
+mkfs.ext4 -U "${HDRDEV_UUID}" "${OUTPUT}"
+lodev=$(sudo losetup -f --show "${OUTPUT}")
+hdrdir=$(mktemp -d)
+sudo mount "${lodev}" "${hdrdir}"
+sudo chown "${USER}" "${hdrdir}"
+cp "${HEADER_INPUT}" "${hdrdir}/root.hdr"
+sudo umount "${hdrdir}"; hdrdir=
+sudo losetup -d "${lodev}"; lodev=

--- a/tests/luks_test.go
+++ b/tests/luks_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -84,3 +85,85 @@ func TestLoadableCryptoModule(t *testing.T) {
 	require.NoError(t, vm.ConsoleWrite("1234\n"))
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
 }
+
+const (
+	detachedHeaderLuksUUID   = "cbd49694-81de-41bd-a850-0d934aff8328"
+	detachedHeaderFsUUID     = "781780d2-bf67-4a17-9ca8-fd22336c1b2e"
+	detachedHeaderHdrdevUUID = "e2d8f1a3-7b4c-4e9d-a1b2-3c4d5e6f7a8b"
+)
+
+// TestLUKS2DetachedHeaderCmdline verifies the detached-header unlock path
+// driven by the rd.luks.header= kernel parameter.
+func TestLUKS2DetachedHeaderCmdline(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.detached_header.img"))
+
+	headerPath, err := filepath.Abs("assets/luks2.detached_header.hdr")
+	require.NoError(t, err)
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:       "assets/luks2.detached_header.img",
+		extraFiles: headerPath,
+		kernelArgs: []string{
+			"rd.luks.name=" + detachedHeaderLuksUUID + "=cryptroot",
+			"rd.luks.header=" + detachedHeaderLuksUUID + "=" + headerPath,
+			"root=/dev/mapper/cryptroot",
+		},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestLUKS2DetachedHeaderCmdlineRawDevice verifies that booster can unlock a LUKS2
+// volume whose detached header is stored on a separate raw block device, specified
+// via the rd.luks.header=<UUID>=/dev/vda kernel parameter.
+// This exercises the /dev/ prefix path in acquireHeader (waitForDeviceRef, no mount).
+func TestLUKS2DetachedHeaderCmdlineRawDevice(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.detached_header.img"))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:   "assets/luks2.detached_header.img",
+		params: []string{"-drive", "file=assets/luks2.detached_header.hdr,if=virtio,format=raw"},
+		kernelArgs: []string{
+			"rd.luks.name=" + detachedHeaderLuksUUID + "=cryptroot",
+			"rd.luks.header=" + detachedHeaderLuksUUID + "=/dev/vda",
+			"root=UUID=" + detachedHeaderFsUUID,
+		},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestLUKS2DetachedHeaderCmdlineOnDevice verifies that booster can unlock a LUKS2
+// volume whose detached header lives as a file on a separate block device, specified
+// via the rd.luks.header=<UUID>=/root.hdr:UUID=<devuuid> kernel parameter.
+// This exercises the headerDeviceRef != nil path in acquireHeader (mountKeyDevice).
+func TestLUKS2DetachedHeaderCmdlineOnDevice(t *testing.T) {
+	// checkAsset for the main image first — it also creates the .hdr file.
+	require.NoError(t, checkAsset("assets/luks2.detached_header.img"))
+	require.NoError(t, checkAsset("assets/luks2.detached_header.hdrdev.img"))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:   "assets/luks2.detached_header.img",
+		params: []string{"-drive", "file=assets/luks2.detached_header.hdrdev.img,if=virtio,format=raw"},
+		kernelArgs: []string{
+			"rd.luks.name=" + detachedHeaderLuksUUID + "=cryptroot",
+			"rd.luks.header=" + detachedHeaderLuksUUID + "=/root.hdr:UUID=" + detachedHeaderHdrdevUUID,
+			"root=UUID=" + detachedHeaderFsUUID,
+		},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+


### PR DESCRIPTION
Replaces and closes #319, narrowed to the `rd.luks.header=` kernel cmdline parameter only. Crypttab support is deferred to a follow-up PR.

## Summary

Adds `rd.luks.header=<UUID>=<path>` boot parameter to specify a detached LUKS header for the device identified by `<UUID>`. Three header path forms are supported:

| Form | Example | Description |
|------|---------|-------------|
| Initramfs file | `/etc/luks/root.hdr` | Header file bundled at build time via `extra_files` |
| Raw block device | `/dev/sdb` | Header at byte offset 0; booster waits for device to appear |
| File on separate device | `/root.hdr:UUID=<uuid>` | Booster mounts the device read-only, reads the header, then unmounts |

Uses `luks.OpenWithHeader` from anatol/luks.go.

## Changes

- `cmdline`: parse `rd.luks.header=` into `luksMapping.header` / `luksMapping.headerDeviceRef`
- `luks.go`: `acquireHeader()` resolves the header path at unlock time; `mountDeviceReadOnly()` handles temporary read-only mounts
- `main.go`: `waitForDeviceRef()` blocks until a device appears; `pendingDevices` + `retryPendingDevices()` handle data devices that arrive before their header device; `probeHeaderOnDevice()` for non-blocking header device checks

## Test plan

- [ ] `cd init && go test ./...`
- [ ] `cd tests && go test -v -run TestLUKS2DetachedHeaderCmdline`
- [ ] `cd tests && go test -v -run TestLUKS2DetachedHeaderCmdlineRawDevice`
- [ ] `cd tests && go test -v -run TestLUKS2DetachedHeaderCmdlineOnDevice`