### PR TITLE
crypttab: support /etc/crypttab for LUKS unlock at boot

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -125,6 +125,10 @@ Some parts of booster boot functionality can be modified with kernel boot parame
     * **File on a separate device** — `$path:$deviceref` where `$deviceref` is `UUID=...`, `LABEL=...`, `PARTUUID=...`, or `PARTLABEL=...`. Booster mounts the device read-only, reads the header file, then unmounts before unlocking.
  * `rd.luks.options=opt1,opt2` a comma-separated list of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`.
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
+
+Booster supports unlocking LUKS volumes declared in `/etc/crypttab` (see **crypttab(5)**).
+Only entries marked with the `x-initrd.attach` option are bundled into the initramfs at image build time. `rd.luks.*` kernel parameters take precedence — if a cmdline parameter already covers a device, its crypttab entry is skipped.
+
  * `rd.modules_force_load` a comma-separated list of extra kernel modules which should be force loaded.
  * `resume=$deviceref` device reference to suspend-to-disk device.
  * `zfs=$pool/$dataset` specifies what ZFS dataset needs to be used for root partition. This option is only used if ZFS config option is enabled. If ZFS filesystem is enabled then `root=` boot param is ignored.

--- a/generator/config.go
+++ b/generator/config.go
@@ -158,6 +158,7 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 		conf.vconsolePath = "/etc/vconsole.conf"
 		conf.localePath = "/etc/locale.conf"
 	}
+	conf.crypttabFile = opts.BuildCommand.CrypttabFile
 
 	return &conf, nil
 }

--- a/generator/crypttab.go
+++ b/generator/crypttab.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// isKeyfileOnDevice reports whether kf is a keyfile-on-device specifier of the
+// form "/path:UUID=xxx", "/path:LABEL=xxx", "/path:PARTUUID=xxx", or "/path:PARTLABEL=xxx".
+func isKeyfileOnDevice(kf string) bool {
+	idx := strings.Index(kf, ":")
+	if idx < 0 {
+		return false
+	}
+	r := kf[idx+1:]
+	return strings.HasPrefix(r, "UUID=") || strings.HasPrefix(r, "LABEL=") ||
+		strings.HasPrefix(r, "PARTUUID=") || strings.HasPrefix(r, "PARTLABEL=")
+}
+
+// appendCrypttab reads path, filters entries marked with x-initrd.attach,
+// and bundles the filtered content plus any referenced keyfiles into the image as
+// /etc/crypttab.  Returns nil if path does not exist.
+func (img *Image) appendCrypttab(path string) error {
+	content, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	type entry struct {
+		line    string // original line with x-initrd.attach stripped from options
+		keyfile string
+		optStr  string
+	}
+
+	var kept []entry
+
+	for _, line := range strings.Split(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		fields := strings.Fields(trimmed)
+		if len(fields) < 2 {
+			continue
+		}
+
+		var keyfile, optStr string
+		if len(fields) >= 3 {
+			keyfile = fields[2]
+		}
+		if len(fields) >= 4 {
+			optStr = fields[3]
+		}
+
+		// check for x-initrd.attach and build a cleaned options string
+		hasXInitrd := false
+		var cleanOpts []string
+		for _, opt := range strings.Split(optStr, ",") {
+			opt = strings.TrimSpace(opt)
+			if opt == "" {
+				continue
+			}
+			if opt == "x-initrd.attach" {
+				hasXInitrd = true
+			} else {
+				cleanOpts = append(cleanOpts, opt)
+			}
+		}
+
+		if !hasXInitrd {
+			continue
+		}
+
+		// rebuild the line with x-initrd.attach stripped
+		cleanOptStr := strings.Join(cleanOpts, ",")
+		var outFields []string
+		outFields = append(outFields, fields[0], fields[1])
+		if len(fields) >= 3 {
+			outFields = append(outFields, fields[2])
+		}
+		if cleanOptStr != "" {
+			outFields = append(outFields, cleanOptStr)
+		}
+
+		kept = append(kept, entry{
+			line:    strings.Join(outFields, "\t"),
+			keyfile: keyfile,
+			optStr:  cleanOptStr,
+		})
+	}
+
+	if len(kept) == 0 {
+		return nil
+	}
+
+	// write filtered crypttab into image
+	var buf strings.Builder
+	for _, e := range kept {
+		buf.WriteString(e.line)
+		buf.WriteByte('\n')
+	}
+	if err := img.AppendContent("/etc/crypttab", 0o600, []byte(buf.String())); err != nil {
+		return err
+	}
+
+	// bundle referenced assets for each kept entry
+	for _, e := range kept {
+		// skip asset bundling for entries that won't be processed as LUKS
+		skip := false
+		for _, opt := range strings.Split(e.optStr, ",") {
+			opt = strings.TrimSpace(opt)
+			if opt == "noauto" || opt == "swap" || opt == "tmp" || opt == "plain" || opt == "bitlk" || opt == "tcrypt" {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+
+		// bundle keyfile if it is an absolute path and not on a runtime device
+		kf := e.keyfile
+		if kf != "" && kf != "none" && kf != "-" && filepath.IsAbs(kf) {
+			if isKeyfileOnDevice(kf) {
+				// keyfile lives on a separate runtime device — nothing to bundle
+			} else if err := img.AppendFile(kf); err != nil {
+				return fmt.Errorf("crypttab: keyfile %s: %v", kf, err)
+			}
+		}
+
+		// header= bundling is handled by pr/crypttab-header; skip here
+	}
+
+	return nil
+}

--- a/generator/crypttab_test.go
+++ b/generator/crypttab_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cavaliergopher/cpio"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestImage creates a minimal in-memory Image for generator unit tests.
+func newTestImage(t *testing.T) (*Image, string) {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "test.img")
+	img, err := NewImage(f, "none", false)
+	require.NoError(t, err)
+	t.Cleanup(func() { img.Cleanup() })
+	return img, f
+}
+
+// readImageFile closes img, then reads and returns the content of name from the
+// uncompressed CPIO archive at imgPath.  Returns nil if the file is absent.
+func readImageFile(t *testing.T, img *Image, imgPath, name string) []byte {
+	t.Helper()
+	require.NoError(t, img.Close())
+
+	f, err := os.Open(imgPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	r := cpio.NewReader(f)
+	for {
+		hdr, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if hdr.Name == name || hdr.Name == "./"+name || strings.TrimPrefix(hdr.Name, "/") == strings.TrimPrefix(name, "/") {
+			data, err := io.ReadAll(r)
+			require.NoError(t, err)
+			return data
+		}
+	}
+	return nil
+}
+
+func TestAppendCrypttabAbsent(t *testing.T) {
+	img, _ := newTestImage(t)
+	require.NoError(t, img.appendCrypttab(filepath.Join(t.TempDir(), "no-such-file")))
+	require.False(t, img.contains["/etc/crypttab"])
+}
+
+func TestAppendCrypttabBundled(t *testing.T) {
+	dir := t.TempDir()
+	crypttab := filepath.Join(dir, "crypttab")
+	require.NoError(t, os.WriteFile(crypttab, []byte(
+		"cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none x-initrd.attach\n",
+	), 0o644))
+
+	img, _ := newTestImage(t)
+	require.NoError(t, img.appendCrypttab(crypttab))
+	require.True(t, img.contains["/etc/crypttab"])
+}
+
+// Entries without x-initrd.attach must not be included in the image.
+func TestAppendCrypttabXInitrdAttachRequired(t *testing.T) {
+	dir := t.TempDir()
+	crypttab := filepath.Join(dir, "crypttab")
+	require.NoError(t, os.WriteFile(crypttab, []byte(
+		"cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none discard\n",
+	), 0o644))
+
+	img, _ := newTestImage(t)
+	require.NoError(t, img.appendCrypttab(crypttab))
+	require.False(t, img.contains["/etc/crypttab"])
+}
+
+// x-initrd.attach must be stripped from options in the bundled content.
+func TestAppendCrypttabXInitrdAttachStripped(t *testing.T) {
+	dir := t.TempDir()
+	crypttab := filepath.Join(dir, "crypttab")
+	require.NoError(t, os.WriteFile(crypttab, []byte(
+		"cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none discard,x-initrd.attach\n",
+	), 0o644))
+
+	img, imgPath := newTestImage(t)
+	require.NoError(t, img.appendCrypttab(crypttab))
+	require.True(t, img.contains["/etc/crypttab"])
+
+	bundled := string(readImageFile(t, img, imgPath, "/etc/crypttab"))
+	require.NotContains(t, bundled, "x-initrd.attach")
+	require.Contains(t, bundled, "discard")
+}
+
+// noauto entries with x-initrd.attach are included in the crypttab but
+// their keyfiles are NOT bundled.
+func TestAppendCrypttabNoautoSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	kf := filepath.Join(dir, "secret.key")
+	require.NoError(t, os.WriteFile(kf, []byte("hunter2"), 0o600))
+
+	crypttab := filepath.Join(dir, "crypttab")
+	content := "cryptswap UUID=11111111-1111-1111-1111-111111111111 " + kf + " noauto,x-initrd.attach\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img, _ := newTestImage(t)
+	require.NoError(t, img.appendCrypttab(crypttab))
+	require.True(t, img.contains["/etc/crypttab"])
+	require.False(t, img.contains[kf])
+}
+
+func TestAppendCrypttabKeyfileBundled(t *testing.T) {
+	dir := t.TempDir()
+
+	kf := filepath.Join(dir, "root.key")
+	require.NoError(t, os.WriteFile(kf, []byte("supersecret"), 0o600))
+
+	crypttab := filepath.Join(dir, "crypttab")
+	content := "cryptroot UUID=22222222-2222-2222-2222-222222222222 " + kf + " x-initrd.attach\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img, _ := newTestImage(t)
+	require.NoError(t, img.appendCrypttab(crypttab))
+	require.True(t, img.contains[kf])
+}
+
+func TestAppendCrypttabKeyfileMissing(t *testing.T) {
+	dir := t.TempDir()
+
+	crypttab := filepath.Join(dir, "crypttab")
+	content := "cryptroot UUID=22222222-2222-2222-2222-222222222222 /nonexistent/key.file x-initrd.attach\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img, _ := newTestImage(t)
+	require.Error(t, img.appendCrypttab(crypttab))
+}
+
+func TestAppendCrypttabNoneKeyfileSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	crypttab := filepath.Join(dir, "crypttab")
+	require.NoError(t, os.WriteFile(crypttab, []byte(
+		"cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none x-initrd.attach\n",
+	), 0o644))
+
+	img, _ := newTestImage(t)
+	require.NoError(t, img.appendCrypttab(crypttab))
+	require.True(t, img.contains["/etc/crypttab"])
+}
+
+func TestAppendCrypttabKeyfileOnDeviceNotBundled(t *testing.T) {
+	dir := t.TempDir()
+
+	crypttab := filepath.Join(dir, "crypttab")
+	content := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /keyfile:UUID=f1e2d3c4-b5a6-4789-8abc-def123456789 x-initrd.attach\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img, _ := newTestImage(t)
+	require.NoError(t, img.appendCrypttab(crypttab))
+	require.True(t, img.contains["/etc/crypttab"])
+	require.False(t, img.contains["/keyfile"])
+}
+
+func TestAppendCrypttabCommentAndBlankLines(t *testing.T) {
+	dir := t.TempDir()
+
+	crypttab := filepath.Join(dir, "crypttab")
+	content := `
+# This is a comment
+
+cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none x-initrd.attach
+# another comment
+`
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img, _ := newTestImage(t)
+	require.NoError(t, img.appendCrypttab(crypttab))
+	require.True(t, img.contains["/etc/crypttab"])
+}
+
+// Only entries with x-initrd.attach are written; others are excluded.
+func TestAppendCrypttabMixedEntries(t *testing.T) {
+	dir := t.TempDir()
+
+	crypttab := filepath.Join(dir, "crypttab")
+	content := strings.Join([]string{
+		"cryptroot UUID=11111111-1111-1111-1111-111111111111 none x-initrd.attach",
+		"cryptdata UUID=22222222-2222-2222-2222-222222222222 none discard",
+		"cryptswap UUID=33333333-3333-3333-3333-333333333333 none x-initrd.attach,discard",
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
+
+	img, imgPath := newTestImage(t)
+	require.NoError(t, img.appendCrypttab(crypttab))
+	require.True(t, img.contains["/etc/crypttab"])
+
+	bundled := string(readImageFile(t, img, imgPath, "/etc/crypttab"))
+	require.Contains(t, bundled, "11111111")
+	require.NotContains(t, bundled, "22222222") // no x-initrd.attach
+	require.Contains(t, bundled, "33333333")
+}
+
+func TestIsKeyfileOnDeviceUUID(t *testing.T) {
+	require.True(t, isKeyfileOnDevice("/keyfile:UUID=f1e2d3c4-b5a6-4789-8abc-def123456789"))
+}
+
+func TestIsKeyfileOnDeviceLabel(t *testing.T) {
+	require.True(t, isKeyfileOnDevice("/keyfile:LABEL=myusbkey"))
+}
+
+func TestIsKeyfileOnDevicePartuuid(t *testing.T) {
+	require.True(t, isKeyfileOnDevice("/key:PARTUUID=f1e2d3c4-b5a6-4789-8abc-def123456789"))
+}
+
+func TestIsKeyfileOnDevicePartlabel(t *testing.T) {
+	require.True(t, isKeyfileOnDevice("/key:PARTLABEL=usbkeys"))
+}
+
+func TestIsKeyfileOnDevicePlainPath(t *testing.T) {
+	require.False(t, isKeyfileOnDevice("/etc/keys/root.key"))
+}
+
+func TestIsKeyfileOnDeviceColonNonDevice(t *testing.T) {
+	require.False(t, isKeyfileOnDevice("/path/key:something"))
+}
+
+func TestIsKeyfileOnDeviceEmpty(t *testing.T) {
+	require.False(t, isKeyfileOnDevice(""))
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -47,6 +47,8 @@ type generatorConfig struct {
 	// virtual console configs
 	enableVirtualConsole     bool
 	vconsolePath, localePath string
+
+	crypttabFile string // path to host crypttab; empty = use /etc/crypttab
 }
 
 type networkStaticConfig struct {
@@ -109,6 +111,14 @@ func generateInitRamfs(conf *generatorConfig) error {
 	}
 
 	if err := img.appendInitBinary(conf.initBinary); err != nil {
+		return err
+	}
+
+	crypttabPath := conf.crypttabFile
+	if crypttabPath == "" {
+		crypttabPath = "/etc/crypttab"
+	}
+	if err := img.appendCrypttab(crypttabPath); err != nil {
 		return err
 	}
 

--- a/generator/main.go
+++ b/generator/main.go
@@ -24,6 +24,7 @@ var opts struct {
 		ConfigFile       string `long:"config" default:"/etc/booster.yaml" description:"Configuration file path"`
 		Universal        bool   `long:"universal" description:"Add wide range of modules/tools to allow this image boot at different machines"`
 		Strip            bool   `long:"strip" description:"Strip ELF files (binaries, shared libraries and kernel modules) before adding it to the image"`
+		CrypttabFile     string `long:"crypttab" description:"Path to host crypttab file (default: /etc/crypttab)"`
 		Args             struct {
 			Output string `positional-arg-name:"output" required:"true"`
 		} `positional-args:"true"`

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// parseCrypttab reads /etc/crypttab from the image and returns LUKS mappings.
+// Silently succeeds if the file is absent.
+func parseCrypttab() ([]*luksMapping, error) {
+	f, err := os.Open("/etc/crypttab")
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return parseCrypttabReader(f)
+}
+
+// parseCrypttabReader is the testable core of parseCrypttab.
+func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
+	var mappings []*luksMapping
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		name := fields[0]
+		deviceStr := fields[1]
+		var keyfile, optStr string
+		if len(fields) >= 3 {
+			keyfile = fields[2]
+		}
+		if len(fields) >= 4 {
+			optStr = fields[3]
+		}
+
+		ref, err := parseDeviceRef(deviceStr)
+		if err != nil {
+			return nil, fmt.Errorf("crypttab: entry %q: invalid device %q: %v", name, deviceStr, err)
+		}
+
+		m := &luksMapping{
+			ref:     ref,
+			name:    name,
+			keySlot: -1,
+		}
+
+		// none/- means interactive passphrase
+		if keyfile != "" && keyfile != "none" && keyfile != "-" {
+			m.keyfile = keyfile
+		}
+
+		skip := false
+		for _, opt := range strings.Split(optStr, ",") {
+			opt = strings.TrimSpace(opt)
+			if opt == "" {
+				continue
+			}
+			switch opt {
+			case "x-initrd.attach":
+				// silently ignored — filtering was done by generator
+			case "noauto":
+				skip = true
+			case "nofail":
+				m.noFail = true
+			case "swap", "tmp", "plain", "bitlk", "tcrypt":
+				// unsupported modes — skip at boot
+				skip = true
+			case "luks":
+				// explicit LUKS marker — booster detects LUKS via blkinfo, nothing to do
+			case "discard", "same-cpu-crypt", "submit-from-crypt-cpus",
+				"no-read-workqueue", "no-write-workqueue":
+				if flag, ok := rdLuksOptions[opt]; ok {
+					m.options = append(m.options, flag)
+				}
+			default:
+				switch {
+				case strings.HasPrefix(opt, "tries="):
+					v, err := strconv.Atoi(opt[6:])
+					if err != nil {
+						return nil, fmt.Errorf("crypttab: entry %q: invalid tries= value %q", name, opt[6:])
+					}
+					m.tries = v
+				case strings.HasPrefix(opt, "key-slot="):
+					v, err := strconv.Atoi(opt[9:])
+					if err != nil {
+						return nil, fmt.Errorf("crypttab: entry %q: invalid key-slot= value %q", name, opt[9:])
+					}
+					m.keySlot = v
+				case strings.HasPrefix(opt, "keyfile-offset="):
+					v, err := strconv.ParseInt(opt[15:], 10, 64)
+					if err != nil {
+						return nil, fmt.Errorf("crypttab: entry %q: invalid keyfile-offset= value %q", name, opt[15:])
+					}
+					m.keyfileOffset = v
+				case strings.HasPrefix(opt, "keyfile-size="):
+					v, err := strconv.ParseInt(opt[13:], 10, 64)
+					if err != nil {
+						return nil, fmt.Errorf("crypttab: entry %q: invalid keyfile-size= value %q", name, opt[13:])
+					}
+					m.keyfileSize = v
+				case strings.HasPrefix(opt, "fido2-device="),
+					strings.HasPrefix(opt, "tpm2-device="),
+					strings.HasPrefix(opt, "token-timeout="),
+					strings.HasPrefix(opt, "header="),
+					strings.HasPrefix(opt, "keyfile-timeout="):
+					// silently ignored — deferred to follow-up PRs
+				default:
+					debug("crypttab: entry %q: unknown option %q, ignoring", name, opt)
+				}
+			}
+		}
+
+		if skip {
+			continue
+		}
+
+		mappings = append(mappings, m)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return mappings, nil
+}
+
+// luksMatchExists reports whether luksMappings already contains an entry for ref,
+// allowing rd.luks.* kernel parameters to take precedence over crypttab.
+func luksMatchExists(ref *deviceRef) bool {
+	for _, m := range luksMappings {
+		if deviceRefEqual(m.ref, ref) {
+			return true
+		}
+	}
+	return false
+}
+
+// deviceRefEqual reports whether two deviceRefs refer to the same device.
+func deviceRefEqual(a, b *deviceRef) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.format != b.format {
+		return false
+	}
+	switch a.format {
+	case refFsUUID, refGptType, refGptUUID:
+		return bytes.Equal(a.data.(UUID), b.data.(UUID))
+	case refPath, refFsLabel, refGptLabel, refHwPath, refWwID:
+		return a.data.(string) == b.data.(string)
+	default:
+		return false
+	}
+}

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCrypttabEmpty(t *testing.T) {
+	mappings, err := parseCrypttabReader(strings.NewReader(""))
+	require.NoError(t, err)
+	require.Empty(t, mappings)
+}
+
+func TestParseCrypttabCommentAndBlank(t *testing.T) {
+	input := `
+# This is a comment
+
+# another comment
+`
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Empty(t, mappings)
+}
+
+func TestParseCrypttabBasic(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	m := mappings[0]
+	require.Equal(t, "cryptroot", m.name)
+	require.Equal(t, "", m.keyfile)
+	require.Equal(t, -1, m.keySlot)
+}
+
+func TestParseCrypttabKeyfileDash(t *testing.T) {
+	for _, kf := range []string{"none", "-"} {
+		input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e " + kf + "\n"
+		mappings, err := parseCrypttabReader(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Len(t, mappings, 1)
+		require.Equal(t, "", mappings[0].keyfile, "keyfile for %q should be empty", kf)
+	}
+}
+
+func TestParseCrypttabKeyfile(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /etc/keys/root.key\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, "/etc/keys/root.key", mappings[0].keyfile)
+}
+
+// noauto entries should be silently excluded — not auto-unlocked at boot.
+func TestParseCrypttabNoauto(t *testing.T) {
+	input := "cryptswap UUID=11111111-1111-1111-1111-111111111111 none noauto\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Empty(t, mappings)
+}
+
+// Non-LUKS modes (swap, tmp, plain, bitlk, tcrypt) are not processed at boot.
+func TestParseCrypttabNonLuksModes(t *testing.T) {
+	for _, mode := range []string{"swap", "tmp", "plain", "bitlk", "tcrypt"} {
+		input := "crypt1 UUID=22222222-2222-2222-2222-222222222222 none " + mode + "\n"
+		mappings, err := parseCrypttabReader(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Empty(t, mappings, "mode %q should be skipped", mode)
+	}
+}
+
+func TestParseCrypttabDmCryptFlags(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none discard,no-read-workqueue\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Contains(t, mappings[0].options, "allow-discards")
+	require.Contains(t, mappings[0].options, "no-read-workqueue")
+}
+
+func TestParseCrypttabLuksOption(t *testing.T) {
+	// "luks" is a standard crypttab marker for LUKS format; booster detects LUKS
+	// via blkinfo so it accepts the option without error and without any action.
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none luks\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Empty(t, mappings[0].options)
+}
+
+func TestParseCrypttabKeySlot(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none key-slot=2\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, 2, mappings[0].keySlot)
+}
+
+func TestParseCrypttabKeySlotDefault(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, -1, mappings[0].keySlot)
+}
+
+func TestParseCrypttabKeySlotInvalid(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none key-slot=bad\n"
+	_, err := parseCrypttabReader(strings.NewReader(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "key-slot=")
+}
+
+func TestParseCrypttabNofail(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none nofail\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.True(t, mappings[0].noFail)
+}
+
+func TestParseCrypttabNofailDefault(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.False(t, mappings[0].noFail)
+}
+
+func TestParseCrypttabTries(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tries=5\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, 5, mappings[0].tries)
+}
+
+// tries=0 means unlimited attempts.
+func TestParseCrypttabTriesZero(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tries=0\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, 0, mappings[0].tries)
+}
+
+func TestParseCrypttabTriesInvalid(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tries=bad\n"
+	_, err := parseCrypttabReader(strings.NewReader(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tries=")
+}
+
+func TestParseCrypttabKeyfileOffset(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /key.bin keyfile-offset=512\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, int64(512), mappings[0].keyfileOffset)
+}
+
+func TestParseCrypttabKeyfileSize(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /key.bin keyfile-size=64\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, int64(64), mappings[0].keyfileSize)
+}
+
+func TestParseCrypttabKeyfileOffsetAndSize(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /key.bin keyfile-offset=128,keyfile-size=32\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, int64(128), mappings[0].keyfileOffset)
+	require.Equal(t, int64(32), mappings[0].keyfileSize)
+}
+
+func TestParseCrypttabKeyfileOffsetInvalid(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /key.bin keyfile-offset=bad\n"
+	_, err := parseCrypttabReader(strings.NewReader(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "keyfile-offset=")
+}
+
+func TestParseCrypttabKeyfileSizeInvalid(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e /key.bin keyfile-size=bad\n"
+	_, err := parseCrypttabReader(strings.NewReader(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "keyfile-size=")
+}
+
+func TestParseCrypttabDevicePath(t *testing.T) {
+	input := "cryptroot /dev/sda2 none\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, refPath, mappings[0].ref.format)
+}
+
+func TestParseCrypttabLabelDevice(t *testing.T) {
+	input := "cryptroot LABEL=cryptdisk none\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, refFsLabel, mappings[0].ref.format)
+	require.Equal(t, "cryptdisk", mappings[0].ref.data.(string))
+}
+
+func TestParseCrypttabMultipleEntries(t *testing.T) {
+	input := strings.Join([]string{
+		"cryptroot UUID=11111111-1111-1111-1111-111111111111 none",
+		"cryptdata UUID=22222222-2222-2222-2222-222222222222 /etc/keys/data.key",
+		"cryptswap UUID=33333333-3333-3333-3333-333333333333 none noauto",
+	}, "\n") + "\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 2) // noauto entry excluded
+	require.Equal(t, "cryptroot", mappings[0].name)
+	require.Equal(t, "cryptdata", mappings[1].name)
+}
+
+func TestParseCrypttabUnknownOptionsIgnored(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none future-option=value\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+}
+
+// x-initrd.attach is silently ignored by init (generator already filtered to only
+// bundle entries with this option; init processes everything in the bundled crypttab).
+func TestParseCrypttabXInitrdAttachIgnored(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none x-initrd.attach,discard\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	// x-initrd.attach must not appear in options
+	for _, o := range mappings[0].options {
+		require.NotEqual(t, "x-initrd.attach", o)
+	}
+}
+
+// fido2-device= is silently ignored — deferred to pr/crypttab-fido2.
+func TestParseCrypttabFido2DeviceIgnored(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none fido2-device=auto\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+}
+
+// header= is silently ignored — deferred to pr/crypttab-header.
+func TestParseCrypttabHeaderIgnored(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none header=/etc/headers/root.img\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+}
+
+func TestDeviceRefEqualUUID(t *testing.T) {
+	a := &deviceRef{format: refFsUUID, data: UUID{0xab, 0x6d, 0x7d, 0x78}}
+	b := &deviceRef{format: refFsUUID, data: UUID{0xab, 0x6d, 0x7d, 0x78}}
+	c := &deviceRef{format: refFsUUID, data: UUID{0x00, 0x00, 0x00, 0x00}}
+	require.True(t, deviceRefEqual(a, b))
+	require.False(t, deviceRefEqual(a, c))
+}
+
+func TestDeviceRefEqualLabel(t *testing.T) {
+	a := &deviceRef{format: refFsLabel, data: "myroot"}
+	b := &deviceRef{format: refFsLabel, data: "myroot"}
+	c := &deviceRef{format: refFsLabel, data: "other"}
+	require.True(t, deviceRefEqual(a, b))
+	require.False(t, deviceRefEqual(a, c))
+}
+
+func TestDeviceRefEqualDifferentFormat(t *testing.T) {
+	a := &deviceRef{format: refFsLabel, data: "same"}
+	b := &deviceRef{format: refPath, data: "same"}
+	require.False(t, deviceRefEqual(a, b))
+}
+
+func TestDeviceRefEqualNil(t *testing.T) {
+	a := &deviceRef{format: refFsLabel, data: "x"}
+	require.False(t, deviceRefEqual(a, nil))
+	require.False(t, deviceRefEqual(nil, a))
+	require.True(t, deviceRefEqual(nil, nil))
+}
+
+func writeTestKeyfile(t *testing.T, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "key.bin")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func TestReadKeyfileEntire(t *testing.T) {
+	path := writeTestKeyfile(t, []byte("secretkey"))
+	data, err := readKeyfile(path, 0, 0)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secretkey"), data)
+}
+
+func TestReadKeyfileWithOffset(t *testing.T) {
+	path := writeTestKeyfile(t, []byte("XXXsecretkey"))
+	data, err := readKeyfile(path, 3, 0)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secretkey"), data)
+}
+
+func TestReadKeyfileWithSize(t *testing.T) {
+	path := writeTestKeyfile(t, []byte("secretkeyXXX"))
+	data, err := readKeyfile(path, 0, 9)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secretkey"), data)
+}
+
+func TestReadKeyfileWithOffsetAndSize(t *testing.T) {
+	path := writeTestKeyfile(t, []byte("XXXsecretkeyXXX"))
+	data, err := readKeyfile(path, 3, 9)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secretkey"), data)
+}
+
+func TestReadKeyfileNotFound(t *testing.T) {
+	_, err := readKeyfile(filepath.Join(t.TempDir(), "nonexistent.key"), 0, 0)
+	require.Error(t, err)
+}

--- a/init/luks.go
+++ b/init/luks.go
@@ -15,8 +15,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/anatol/clevis.go"
@@ -33,6 +33,32 @@ type luksMapping struct {
 	options         []string
 	header          string     // detached LUKS header path (empty = embedded header)
 	headerDeviceRef *deviceRef // non-nil when header is a file on a separate device
+
+	keySlot       int   // -1 = all slots; >=0 restricts unlock to that slot
+	tries         int   // 0 = unlimited keyboard retries; >0 = max attempts
+	noFail        bool  // non-fatal unlock failure — boot continues on error
+	keyfileOffset int64 // bytes to skip at start of keyfile
+	keyfileSize   int64 // max bytes to read from keyfile (0 = all)
+}
+
+// tryPassphraseAgainstSlots tries password against each slot, sending the opened
+// volume on volumes if successful.  Returns true on success.
+func tryPassphraseAgainstSlots(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, checkSlots []int, password []byte) bool {
+	for _, s := range checkSlots {
+		v, err := d.UnsealVolume(s, password)
+		if err == luks.ErrPassphraseDoesNotMatch {
+			continue
+		} else if err != nil {
+			warning("unlocking slot %v: %v", s, err)
+			continue
+		}
+		select {
+		case volumes <- v:
+		case <-done:
+		}
+		return true
+	}
+	return false
 }
 
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
@@ -324,95 +350,65 @@ func recoverSystemdTPM2Password(t luks.Token) ([]byte, error) {
 	return []byte(base64.StdEncoding.EncodeToString(password)), nil
 }
 
-func recoverTokenPassword(volumes chan *luks.Volume, d luks.Device, t luks.Token) {
-	var password []byte
-	var err error
 
-	switch t.Type {
-	case "clevis":
-		password, err = recoverClevisPassword(t, d.Version())
-	case "systemd-fido2":
-		password, err = recoverSystemdFido2Password(t)
-	case "systemd-tpm2":
-		password, err = recoverSystemdTPM2Password(t)
-	default:
-		info("token #%d has unknown type: %s", t.ID, t.Type)
-		return
-	}
-
+// readKeyfile reads a keyfile at path, skipping offset bytes and reading at most
+// size bytes (0 means read until EOF).
+func readKeyfile(path string, offset, size int64) ([]byte, error) {
+	f, err := os.Open(path)
 	if err != nil {
-		warning("recovering %s token #%d failed: %v", t.Type, t.ID, err)
-		return
+		return nil, err
 	}
+	defer f.Close()
 
-	info("recovered password from %s token #%d", t.Type, t.ID)
-
-	for _, s := range t.Slots {
-		v, err := d.UnsealVolume(s, password)
-		if err == luks.ErrPassphraseDoesNotMatch {
-			continue
-		} else if err != nil {
-			warning("unlocking slot %v: %v", s, err)
-			continue
+	if offset > 0 {
+		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			return nil, fmt.Errorf("seeking keyfile %s: %v", path, err)
 		}
-		info("password from %s token #%d matches", t.Type, t.ID)
-		volumes <- v
-		return
 	}
-	info("password from %s token #%d does not match", t.Type, t.ID)
+
+	if size > 0 {
+		return io.ReadAll(io.LimitReader(f, size))
+	}
+	return io.ReadAll(f)
 }
 
-func recoverKeyfilePassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, keyfile string) {
-	var err error
-	var password []byte
+// acquireKeyfilePassword reads the keyfile referenced by mapping, applying any
+// configured offset and size restrictions.
+func acquireKeyfilePassword(mapping *luksMapping) ([]byte, error) {
+	return readKeyfile(mapping.keyfile, mapping.keyfileOffset, mapping.keyfileSize)
+}
 
-	// keyfile might be in the format /path:UUID=<DEV UUID> to indicate the keyfile lives on another device
-	parts := regexp.MustCompile("(?i):UUID=").Split(keyfile, 2)
-
-	if len(parts) == 1 {
-		password, err = os.ReadFile(parts[0])
-
-		if err != nil {
-			warning("reading password: %v", err)
-		}
-	} else {
-		// read password from device matching uuid
-		uuid, err := parseUUID(parts[1])
-		if err != nil {
-			warning("invalid UUID %s in rd.luks.key boot param: %s", uuid, keyfile)
-		} else {
-			// TODO: access path on uuid device, read password
-			warning("user wants keyfile from device %s, but I don't know how to do that", uuid)
-		}
+func recoverKeyfilePassword(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, checkSlots []int, mapping *luksMapping) {
+	password, err := acquireKeyfilePassword(mapping)
+	if err != nil {
+		warning("reading keyfile %s: %v", mapping.keyfile, err)
 	}
 
 	if len(password) > 0 {
-		for _, s := range checkSlots {
-			v, err := d.UnsealVolume(s, password)
-			if err == luks.ErrPassphraseDoesNotMatch {
-				continue
-			} else if err != nil {
-				warning("unlocking slot %v: %v", s, err)
-				continue
-			}
-			volumes <- v
+		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, password) {
 			return
 		}
 	}
 
-	warning("password in keyfile %s was unable to unseal %s", keyfile, mappingName)
+	warning("password in keyfile %s was unable to unseal %s", mapping.keyfile, mapping.name)
 
-	// have to use keyboard password
-	requestKeyboardPassword(volumes, d, checkSlots, mappingName)
+	// fall back to keyboard
+	requestKeyboardPassword(volumes, done, d, checkSlots, mapping.name, mapping.tries)
 }
 
-func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string) {
+func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, checkSlots []int, mappingName string, maxTries int) {
 	// Wait for plymouth initialization to complete before attempting to use
 	// it. Without this, udev events can trigger LUKS password prompts while
 	// plymouthd is still starting, causing the graphical prompt to fail.
 	waitForPlymouthInit()
 
+	attempts := 0
 	for {
+		if maxTries > 0 && attempts >= maxTries {
+			warning("maximum passphrase attempts (%d) reached for %s", maxTries, mappingName)
+			return
+		}
+
 		prompt := fmt.Sprintf("Enter passphrase for %s:", mappingName)
 
 		var password []byte
@@ -435,16 +431,9 @@ func requestKeyboardPassword(volumes chan *luks.Volume, d luks.Device, checkSlot
 		if len(password) == 0 {
 			continue
 		}
+		attempts++
 
-		for _, s := range checkSlots {
-			v, err := d.UnsealVolume(s, password)
-			if err == luks.ErrPassphraseDoesNotMatch {
-				continue
-			} else if err != nil {
-				warning("unlocking slot %v: %v", s, err)
-				continue
-			}
-			volumes <- v
+		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, password) {
 			return
 		}
 
@@ -529,8 +518,23 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	}
 	defer d.Close()
 
-	if len(d.Slots()) == 0 {
+	availableSlots := d.Slots()
+	if len(availableSlots) == 0 {
 		return fmt.Errorf("device %s has no slots to unlock", dev)
+	}
+
+	// Restrict to the requested key slot if specified.
+	if mapping.keySlot >= 0 {
+		var filtered []int
+		for _, s := range availableSlots {
+			if s == mapping.keySlot {
+				filtered = append(filtered, s)
+			}
+		}
+		if len(filtered) == 0 {
+			return fmt.Errorf("device %s: key-slot=%d not found in available slots", dev, mapping.keySlot)
+		}
+		availableSlots = filtered
 	}
 
 	if err := d.FlagsAdd(mapping.options...); err != nil {
@@ -538,6 +542,28 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	}
 
 	volumes := make(chan *luks.Volume)
+	done := make(chan struct{})
+	var senderWg sync.WaitGroup
+	var keyboardOnce sync.Once
+
+	// startKeyboard launches the keyboard (or keyfile) unlock goroutine at most once.
+	startKeyboard := func() {
+		senderWg.Add(1)
+		go func() {
+			defer senderWg.Done()
+			if mapping.keyfile != "" {
+				recoverKeyfilePassword(volumes, done, d, availableSlots, mapping)
+			} else {
+				requestKeyboardPassword(volumes, done, d, availableSlots, mapping.name, mapping.tries)
+			}
+		}()
+	}
+
+	// Watcher: close volumes once all senders are done so the receiver unblocks.
+	go func() {
+		senderWg.Wait()
+		close(volumes)
+	}()
 
 	slotsWithTokens := make(map[int]bool)
 	tokens, err := d.Tokens()
@@ -546,32 +572,72 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	}
 	for _, t := range tokens {
 		if t.Type == "systemd-recovery" {
-			continue // skip systemd-recovery tokens as they are supposed to be entered by a keyboard later
+			continue // skipped: entered via keyboard later
 		}
-		go recoverTokenPassword(volumes, d, t)
+		t := t
+		senderWg.Add(1)
+		go func() {
+			defer senderWg.Done()
+			var password []byte
+			var err error
+			switch t.Type {
+			case "clevis":
+				password, err = recoverClevisPassword(t, d.Version())
+			case "systemd-fido2":
+				password, err = recoverSystemdFido2Password(t)
+			case "systemd-tpm2":
+				password, err = recoverSystemdTPM2Password(t)
+			default:
+				info("token #%d has unknown type: %s", t.ID, t.Type)
+				keyboardOnce.Do(startKeyboard)
+				return
+			}
+			if err != nil {
+				warning("recovering %s token #%d failed: %v", t.Type, t.ID, err)
+				keyboardOnce.Do(startKeyboard)
+				return
+			}
+			info("recovered password from %s token #%d", t.Type, t.ID)
+			for _, s := range t.Slots {
+				v, err := d.UnsealVolume(s, password)
+				if err == luks.ErrPassphraseDoesNotMatch {
+					continue
+				} else if err != nil {
+					warning("unlocking slot %v: %v", s, err)
+					continue
+				}
+				info("password from %s token #%d matches", t.Type, t.ID)
+				select {
+				case volumes <- v:
+				case <-done:
+				}
+				return
+			}
+			info("password from %s token #%d does not match", t.Type, t.ID)
+			keyboardOnce.Do(startKeyboard)
+		}()
 		for _, s := range t.Slots {
 			slotsWithTokens[s] = true
 		}
 	}
 
-	var checkSlotsWithPassword []int
-	for _, s := range d.Slots() {
+	// Start keyboard/keyfile unlock for any slots that have no tokens.
+	var passwordSlots []int
+	for _, s := range availableSlots {
 		if !slotsWithTokens[s] {
-			// only slots that do not have tokens will be checked with keyboard password
-			checkSlotsWithPassword = append(checkSlotsWithPassword, s)
+			passwordSlots = append(passwordSlots, s)
 		}
 	}
-	if len(checkSlotsWithPassword) > 0 {
-		// is there a keyfile defined for the password for this volume?
-		if len(mapping.keyfile) > 0 {
-			// if the keyfile doesn't work we will fallback to password
-			go recoverKeyfilePassword(volumes, d, checkSlotsWithPassword, mapping.name, mapping.keyfile)
-		} else {
-			go requestKeyboardPassword(volumes, d, checkSlotsWithPassword, mapping.name)
-		}
+	if len(passwordSlots) > 0 {
+		keyboardOnce.Do(startKeyboard)
 	}
 
-	v := <-volumes
+	v, ok := <-volumes
+	close(done)
+
+	if !ok {
+		return fmt.Errorf("failed to unlock %s: all unlock attempts exhausted", dev)
+	}
 
 	if err := loadRequiredCryptoModules(v.StorageEncryption); err != nil {
 		return err
@@ -621,8 +687,9 @@ func matchLuksMapping(blk *blkInfo) *luksMapping {
 	if blk.matchesRef(cmdRoot) {
 		info("LUKS device %s matches root=, unlock this device", blk.path)
 		m := &luksMapping{
-			ref:  cmdRoot,
-			name: "root",
+			ref:     cmdRoot,
+			name:    "root",
+			keySlot: -1,
 		}
 		cmdRoot = &deviceRef{format: refPath, data: "/dev/mapper/root"}
 		return m
@@ -639,7 +706,12 @@ func handleLuksBlockDevice(blk *blkInfo) error {
 	}
 	info("a mapping for LUKS device %s has been found", blk.path)
 
-	return luksOpen(blk.path, m)
+	err := luksOpen(blk.path, m)
+	if err != nil && m.noFail {
+		warning("ignoring error unlocking LUKS device %s (nofail): %v", blk.path, err)
+		return nil
+	}
+	return err
 }
 
 func findOrCreateLuksMapping(uuid UUID) *luksMapping {
@@ -655,8 +727,9 @@ func findOrCreateLuksMapping(uuid UUID) *luksMapping {
 
 	// didn't locate the device make a new one
 	m := &luksMapping{
-		ref:  &deviceRef{refFsUUID, uuid},
-		name: "luks-" + uuid.toString(),
+		ref:     &deviceRef{refFsUUID, uuid},
+		name:    "luks-" + uuid.toString(),
+		keySlot: -1,
 	}
 	luksMappings = append(luksMappings, m)
 

--- a/init/main.go
+++ b/init/main.go
@@ -1054,6 +1054,18 @@ func boost() error {
 		return err
 	}
 
+	// Merge /etc/crypttab entries for devices not already covered by rd.luks.* params.
+	// rd.luks.* kernel parameters take precedence over crypttab.
+	if ctMappings, err := parseCrypttab(); err != nil {
+		warning("crypttab: %v", err)
+	} else {
+		for _, cm := range ctMappings {
+			if !luksMatchExists(cm.ref) {
+				luksMappings = append(luksMappings, cm)
+			}
+		}
+	}
+
 	// Check if plymouth should be enabled: needs both config and "splash" kernel param
 	if config.EnablePlymouth {
 		cmdlineBytes, err := os.ReadFile("/proc/cmdline")

--- a/tests/crypttab_test.go
+++ b/tests/crypttab_test.go
@@ -1,0 +1,145 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCrypttabPassphrase verifies that a crypttab entry drives LUKS unlock
+// without any rd.luks.* kernel parameters.
+func TestCrypttabPassphrase(t *testing.T) {
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptroot UUID=639b8fdd-36ba-443e-be3e-e5b335935502 none x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.img",
+		crypttabFile: crypttabPath,
+		kernelArgs:   []string{"root=/dev/mapper/cryptroot"},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestCrypttabNofail verifies that a nofail entry for an absent device does
+// not prevent the system from booting.
+func TestCrypttabNofail(t *testing.T) {
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptfake UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee none nofail,x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/ext4.img",
+		crypttabFile: crypttabPath,
+		kernelArgs:   []string{"root=UUID=5c92fc66-7315-408b-b652-176dc554d370"},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestCrypttabKeyfileOffsetSize verifies that keyfile-offset= and keyfile-size=
+// correctly slice a keyfile embedded in the initramfs.
+// The luks2 password "1234" is stored at offset 8 of a padded keyfile.
+func TestCrypttabKeyfileOffsetSize(t *testing.T) {
+	keyfilePath := filepath.Join(t.TempDir(), "luks2.key")
+	require.NoError(t, os.WriteFile(keyfilePath, []byte("PADDINGx1234"), 0o600))
+
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(fmt.Sprintf(
+		"cryptroot UUID=639b8fdd-36ba-443e-be3e-e5b335935502 %s keyfile-offset=8,keyfile-size=4,x-initrd.attach\n",
+		keyfilePath,
+	)), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.img",
+		crypttabFile: crypttabPath,
+		kernelArgs:   []string{"root=/dev/mapper/cryptroot"},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestCrypttabTries verifies that tries=N allows up to N passphrase attempts.
+// Root is on the LUKS device so there is no concurrent root-mount race: the
+// first attempt is wrong, the second (within the tries=2 budget) is correct.
+func TestCrypttabTries(t *testing.T) {
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptroot UUID=639b8fdd-36ba-443e-be3e-e5b335935502 none tries=2,x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.img",
+		crypttabFile: crypttabPath,
+		kernelArgs:   []string{"root=/dev/mapper/cryptroot"},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("wrong\n"))
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestCrypttabKeySlot verifies that key-slot= restricts unlock to the specified
+// keyslot. Uses slot 0 which holds the "1234" password in luks2.img.
+func TestCrypttabKeySlot(t *testing.T) {
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptroot UUID=639b8fdd-36ba-443e-be3e-e5b335935502 none key-slot=0,x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.img",
+		crypttabFile: crypttabPath,
+		kernelArgs:   []string{"root=/dev/mapper/cryptroot"},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestCrypttabCmdlinePrecedence verifies that rd.luks.* kernel parameters take
+// precedence over crypttab entries for the same device. The crypttab names the
+// device "cryptroot" but the cmdline overrides it to "cmdroot"; the passphrase
+// prompt should name the device "cmdroot" confirming the crypttab entry was skipped.
+func TestCrypttabCmdlinePrecedence(t *testing.T) {
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptroot UUID=639b8fdd-36ba-443e-be3e-e5b335935502 none x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.img",
+		crypttabFile: crypttabPath,
+		kernelArgs: []string{
+			"rd.luks.name=639b8fdd-36ba-443e-be3e-e5b335935502=cmdroot",
+			"root=/dev/mapper/cmdroot",
+		},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cmdroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}

--- a/tests/util.go
+++ b/tests/util.go
@@ -181,6 +181,9 @@ func generateInitRamfs(workDir string, opts Opts) (string, error) {
 	if opts.modulesDirectory != "" {
 		generatorArgs = append(generatorArgs, "--modules-dir", opts.modulesDirectory)
 	}
+	if opts.crypttabFile != "" {
+		generatorArgs = append(generatorArgs, "--crypttab", opts.crypttabFile)
+	}
 	generatorArgs = append(generatorArgs, output)
 	cmd := exec.Command(binariesDir+"/generator", generatorArgs...)
 	if testing.Verbose() {
@@ -317,6 +320,7 @@ type Opts struct {
 	enableZfs            bool
 	zfsImportParams      string
 	zfsCachePath         string // TODO: do we need any of these parameters?
+	crypttabFile         string // path to host crypttab to bundle; overrides /etc/crypttab
 }
 
 func buildVmInstance(t *testing.T, opts Opts) (*vmtest.Qemu, error) {
@@ -337,6 +341,12 @@ func buildVmInstance(t *testing.T, opts Opts) (*vmtest.Qemu, error) {
 	if opts.kernelVersion == "" {
 		if kernel, ok := kernelVersions["linux"]; ok {
 			opts.kernelVersion = kernel
+		} else if len(kernelVersions) > 0 {
+			// Fall back to any available kernel (e.g. linux-cachyos on CachyOS systems).
+			for _, ver := range kernelVersions {
+				opts.kernelVersion = ver
+				break
+			}
 		} else {
 			require.Fail(t, "System does not have 'linux' package installed needed for the integration tests")
 		}


### PR DESCRIPTION
Independent split of #318. `fido2-device=`, `tpm2-device=`, and `header=` are not supported in this crypttab implementation — they depend on #322 and #323 respectively and will be added in follow-up PRs as discussed in #318.

## What this adds

Support for `/etc/crypttab` as an alternative to `rd.luks.*` kernel parameters for LUKS unlock at boot.

**Generator** reads the host `/etc/crypttab` at image build time and bundles only entries marked with the `x-initrd.attach` option. Entries without it are silently excluded. Any referenced keyfiles (absolute paths, not device-specifier form) are bundled alongside. `x-initrd.attach` is stripped from the options field before writing so the init parser never sees it.

A `--crypttab` flag is added to the `build` subcommand to override the default `/etc/crypttab` path — used by the integration tests, but also a useful user-facing flag.

**Init** parses `/etc/crypttab` at boot and merges entries into `luksMappings`. `rd.luks.*` kernel parameters always take precedence — if a parameter already covers a device, its crypttab entry is skipped.

Supported options:
- `nofail` — failed unlock does not abort boot
- `tries=N` — limit keyboard passphrase attempts (0 = unlimited)
- `key-slot=N` — restrict unlock to a specific keyslot
- `keyfile-offset=N`, `keyfile-size=N` — slice a keyfile at a byte offset/length
- `luks` — accepted and ignored (booster detects LUKS via blkinfo)
- `noauto` — entry skipped at boot
- `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue` — passed through to dm-crypt
- `swap`, `tmp`, `plain`, `bitlk`, `tcrypt` — treated as noauto (not handled in initramfs)

## Tests

Six QEMU integration tests in `tests/crypttab_test.go`:
- Passphrase unlock driven entirely by crypttab (no `rd.luks.*`)
- `nofail` with absent device does not block boot
- `keyfile-offset=` + `keyfile-size=` slicing
- `tries=2` allows a second attempt after one wrong passphrase
- `key-slot=0` restricts to the specified keyslot
- `rd.luks.name` cmdline overrides crypttab device name

Closes #318