### PR TITLE
tests: use LLVM toolchain when building out-of-tree test module on clang-built kernels

### DIFF
--- a/generator/assets/Makefile
+++ b/generator/assets/Makefile
@@ -1,7 +1,18 @@
 obj-m += test_module.o
 
+KVER   ?= $(shell uname -r)
+KBUILD := /lib/modules/$(KVER)/build
+
+# Match the compiler used to build the kernel — avoids flag incompatibilities
+# on clang-built kernels (e.g. CachyOS, Arch linux-zen with LLVM).
+ifneq (,$(wildcard $(KBUILD)/.config))
+  ifeq ($(shell grep -c 'CONFIG_CC_IS_CLANG=y' $(KBUILD)/.config),1)
+    KBUILD_CC := LLVM=1
+  endif
+endif
+
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(CURDIR) modules
+	make $(KBUILD_CC) -C $(KBUILD) M=$(CURDIR) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(CURDIR) clean
+	make $(KBUILD_CC) -C $(KBUILD) M=$(CURDIR) clean


### PR DESCRIPTION
Out-of-tree module builds inherit the system default compiler (gcc), but kernels built with clang pass clang-specific flags that gcc does not understand. Detect `CONFIG_CC_IS_CLANG=y` in the kernel `.config` and set `LLVM=1` when building the test module, so the full LLVM toolchain (clang + lld + llvm-ar) is used to match the kernel.

`CC=clang` alone is insufficient — the linker must also be `ld.lld`; `LLVM=1` switches the entire toolchain at once.

Falls back to gcc on gcc-built kernels with no change in behavior.

Motivated by CachyOS (and similar Arch-based distros) which build kernels with clang/LLVM by default — previously required manually patching the Makefile locally before running tests.