### PR TITLE
generator: skip default /etc/crypttab silently when inaccessible

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -75,6 +75,8 @@ Booster advantages:
 
  * `enable_zfs` is a flag that enables ZFS filesystem as root filesystem. This flag also makes sure all the required modules/binaries are added to the image. Note that if ZFS is enabled then `zfs=` boot option must be used instead of `root=` boot option.
 
+ * `crypttab_path` path to the crypttab file to read at image build time. Defaults to `/etc/crypttab` if not set. Can be overridden by the `--crypttab` flag. If set, any read error is reported as a failure.
+
  * `enable_plymouth` is a flag that enables Plymouth boot splash support. When enabled, booster bundles the Plymouth daemon, plugins, theme, and fonts into the initramfs. GPU driver must be included in `modules_force_load`. The `splash` kernel parameter is also required. Note that `booster.log=console` conflicts with Plymouth's graphical display; when console logging is active, Plymouth reverts to the details plugin (text-based fallback).
 
 Once you are done modifying your config file and want to regenerate booster images under `/boot` please use `/usr/lib/booster/regenerate_images`.
@@ -98,6 +100,7 @@ Build initrd image. Usage: `booster [OPTIONS] build [build-OPTIONS] output`
 * `--config` <default: _/etc/booster.yaml_> Configuration file path.
 * `--universal` Add wide range of modules/tools to allow this image boot at different machines.
 * `--strip` Strip ELF files (binaries, shared libraries and kernel modules) before adding it to the image.
+* `--crypttab` <default: _/etc/crypttab_> Path to the crypttab file to read at image build time. Overrides `crypttab_path` from the config file. If neither is set, booster reads `/etc/crypttab` and silently skips it if the file is absent or unreadable. If specified explicitly, any read error is reported as a failure.
 
 ### cat
 Show content of the file inside the image. Usage: `booster [OPTIONS] cat image file-in-image`

--- a/generator/config.go
+++ b/generator/config.go
@@ -40,6 +40,7 @@ type UserConfig struct {
 	ZfsImportParams      string `yaml:"zfs_import_params"`
 	ZfsCachePath         string `yaml:"zfs_cache_path"`
 	EnablePlymouth       bool   `yaml:"enable_plymouth"`
+	CrypttabPath         string `yaml:"crypttab_path,omitempty"` // path to crypttab file, defaults to /etc/crypttab
 }
 
 // read user config from the specified file. If file parameter is empty string then "empty" configuration is considered
@@ -159,6 +160,9 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 		conf.localePath = "/etc/locale.conf"
 	}
 	conf.crypttabFile = opts.BuildCommand.CrypttabFile
+	if conf.crypttabFile == "" {
+		conf.crypttabFile = u.CrypttabPath
+	}
 
 	return &conf, nil
 }

--- a/generator/crypttab.go
+++ b/generator/crypttab.go
@@ -24,9 +24,6 @@ func isKeyfileOnDevice(kf string) bool {
 // /etc/crypttab.  Returns nil if path does not exist.
 func (img *Image) appendCrypttab(path string) error {
 	content, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return nil
-	}
 	if err != nil {
 		return err
 	}

--- a/generator/crypttab_test.go
+++ b/generator/crypttab_test.go
@@ -49,8 +49,7 @@ func readImageFile(t *testing.T, img *Image, imgPath, name string) []byte {
 
 func TestAppendCrypttabAbsent(t *testing.T) {
 	img, _ := newTestImage(t)
-	require.NoError(t, img.appendCrypttab(filepath.Join(t.TempDir(), "no-such-file")))
-	require.False(t, img.contains["/etc/crypttab"])
+	require.Error(t, img.appendCrypttab(filepath.Join(t.TempDir(), "no-such-file")))
 }
 
 func TestAppendCrypttabBundled(t *testing.T) {

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -115,11 +115,16 @@ func generateInitRamfs(conf *generatorConfig) error {
 	}
 
 	crypttabPath := conf.crypttabFile
-	if crypttabPath == "" {
+	explicitCrypttab := crypttabPath != ""
+	if !explicitCrypttab {
 		crypttabPath = "/etc/crypttab"
 	}
 	if err := img.appendCrypttab(crypttabPath); err != nil {
-		return err
+		if !explicitCrypttab && (os.IsNotExist(err) || os.IsPermission(err)) {
+			// default path unavailable — crypttab is optional, skip silently
+		} else {
+			return err
+		}
 	}
 
 	if err := img.appendExtraFiles(conf.extraFiles...); err != nil {


### PR DESCRIPTION
Running \`booster build\` as a non-root user fails with \`open /etc/crypttab: permission denied\` (reported in #325).

\`appendCrypttab\` previously swallowed not-found errors, but permission denied fell through to a hard failure. The fix moves availability handling to the call site so behavior can differ by context: the default \`/etc/crypttab\` path is optional — not-found and permission denied are silently skipped. If \`--crypttab\` is set, any read error is surfaced as a failure.

A \`crypttab_path\` option is also added to \`/etc/booster.yaml\` so the path can be set persistently without using the CLI flag. The \`--crypttab\` flag takes precedence when both are set. As with \`--crypttab\`, any read error on an explicit \`crypttab_path\` is reported as a failure.

Fixes the case reported in #325.