### PR TITLE
crypttab: keyfile-on-device, header=, fido2-device=, tpm2-device=

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -134,6 +134,13 @@ Some parts of booster boot functionality can be modified with kernel boot parame
 Booster supports unlocking LUKS volumes declared in `/etc/crypttab` (see **crypttab(5)**).
 Only entries marked with the `x-initrd.attach` option are bundled into the initramfs at image build time. `rd.luks.*` kernel parameters take precedence — if a cmdline parameter already covers a device, its crypttab entry is skipped.
 
+Booster-specific behaviour for selected options:
+ * **keyfile** `/path:UUID=xxx` (or `LABEL=`, `PARTUUID=`, `PARTLABEL=`) — keyfile on a separate device. Booster mounts the device read-only at boot, reads the key, then unmounts. The file is not bundled into the initramfs.
+ * **`header=`** — if the path is a plain absolute path the generator bundles the file into the initramfs automatically. The `/path:deviceref` form mounts the device at boot; `/dev/...` uses the raw block device directly.
+ * **`fido2-device=auto`** — when present the generator automatically bundles `fido2plugin.so`; no `enable_fido2: true` in the config file is required.
+ * **`fido2-device=auto`** / **`tpm2-device=auto`** — Booster defers the keyboard passphrase prompt until the token attempt fails or `token-timeout=` elapses (default: 30 s).
+ * **`keyfile-timeout=`** / **`token-timeout=`** — accept a bare integer (seconds) or any duration string accepted by Go's `time.ParseDuration` (e.g. `30s`, `2m`).
+
  * `rd.modules_force_load` a comma-separated list of extra kernel modules which should be force loaded.
  * `resume=$deviceref` device reference to suspend-to-disk device.
  * `zfs=$pool/$dataset` specifies what ZFS dataset needs to be used for root partition. This option is only used if ZFS config option is enabled. If ZFS filesystem is enabled then `root=` boot param is ignored.

--- a/generator/crypttab.go
+++ b/generator/crypttab.go
@@ -21,11 +21,13 @@ func isKeyfileOnDevice(kf string) bool {
 
 // appendCrypttab reads path, filters entries marked with x-initrd.attach,
 // and bundles the filtered content plus any referenced keyfiles into the image as
-// /etc/crypttab.  Returns nil if path does not exist.
-func (img *Image) appendCrypttab(path string) error {
+// /etc/crypttab.  Returns hasFido2=true if any kept entry has fido2-device= set
+// (so the caller can auto-enable the fido2 plugin).  Returns nil error if path
+// does not exist.
+func (img *Image) appendCrypttab(path string) (hasFido2 bool, err error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	type entry struct {
@@ -93,7 +95,7 @@ func (img *Image) appendCrypttab(path string) error {
 	}
 
 	if len(kept) == 0 {
-		return nil
+		return false, nil
 	}
 
 	// write filtered crypttab into image
@@ -103,7 +105,7 @@ func (img *Image) appendCrypttab(path string) error {
 		buf.WriteByte('\n')
 	}
 	if err := img.AppendContent("/etc/crypttab", 0o600, []byte(buf.String())); err != nil {
-		return err
+		return false, err
 	}
 
 	// bundle referenced assets for each kept entry
@@ -116,6 +118,9 @@ func (img *Image) appendCrypttab(path string) error {
 				skip = true
 				break
 			}
+			if strings.HasPrefix(opt, "fido2-device=") {
+				hasFido2 = true
+			}
 		}
 		if skip {
 			continue
@@ -127,7 +132,7 @@ func (img *Image) appendCrypttab(path string) error {
 			if isKeyfileOnDevice(kf) {
 				// keyfile lives on a separate runtime device — nothing to bundle
 			} else if err := img.AppendFile(kf); err != nil {
-				return fmt.Errorf("crypttab: keyfile %s: %v", kf, err)
+				return false, fmt.Errorf("crypttab: keyfile %s: %v", kf, err)
 			}
 		}
 
@@ -150,11 +155,11 @@ func (img *Image) appendCrypttab(path string) error {
 				break
 			}
 			if err := img.AppendFile(hdr); err != nil {
-				return fmt.Errorf("crypttab: header %s: %v", hdr, err)
+				return false, fmt.Errorf("crypttab: header %s: %v", hdr, err)
 			}
 			break
 		}
 	}
 
-	return nil
+	return hasFido2, nil
 }

--- a/generator/crypttab.go
+++ b/generator/crypttab.go
@@ -131,7 +131,29 @@ func (img *Image) appendCrypttab(path string) error {
 			}
 		}
 
-		// header= bundling is handled by pr/crypttab-header; skip here
+		// bundle header file if specified as an absolute path and not on a runtime device
+		for _, opt := range strings.Split(e.optStr, ",") {
+			opt = strings.TrimSpace(opt)
+			if !strings.HasPrefix(opt, "header=") {
+				continue
+			}
+			hdr := opt[7:]
+			if hdr == "" || !filepath.IsAbs(hdr) {
+				break
+			}
+			if isKeyfileOnDevice(hdr) {
+				// header lives on a separate runtime device — nothing to bundle
+				break
+			}
+			if strings.HasPrefix(hdr, "/dev/") {
+				// raw block device — runtime, nothing to bundle
+				break
+			}
+			if err := img.AppendFile(hdr); err != nil {
+				return fmt.Errorf("crypttab: header %s: %v", hdr, err)
+			}
+			break
+		}
 	}
 
 	return nil

--- a/generator/crypttab_test.go
+++ b/generator/crypttab_test.go
@@ -214,6 +214,48 @@ func TestAppendCrypttabMixedEntries(t *testing.T) {
 	require.Contains(t, bundled, "33333333")
 }
 
+// fido2-device= in a kept entry must cause hasFido2=true.
+func TestAppendCrypttabFido2Detected(t *testing.T) {
+	dir := t.TempDir()
+	crypttab := filepath.Join(dir, "crypttab")
+	require.NoError(t, os.WriteFile(crypttab, []byte(
+		"cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none fido2-device=auto,x-initrd.attach\n",
+	), 0o644))
+
+	img, _ := newTestImage(t)
+	hasFido2, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
+	require.True(t, hasFido2)
+}
+
+// fido2-device= in an entry without x-initrd.attach must not set hasFido2.
+func TestAppendCrypttabFido2NotDetectedWithoutXInitrd(t *testing.T) {
+	dir := t.TempDir()
+	crypttab := filepath.Join(dir, "crypttab")
+	require.NoError(t, os.WriteFile(crypttab, []byte(
+		"cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none fido2-device=auto\n",
+	), 0o644))
+
+	img, _ := newTestImage(t)
+	hasFido2, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
+	require.False(t, hasFido2)
+}
+
+// An entry without fido2-device= must leave hasFido2 false.
+func TestAppendCrypttabNoFido2(t *testing.T) {
+	dir := t.TempDir()
+	crypttab := filepath.Join(dir, "crypttab")
+	require.NoError(t, os.WriteFile(crypttab, []byte(
+		"cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none x-initrd.attach\n",
+	), 0o644))
+
+	img, _ := newTestImage(t)
+	hasFido2, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
+	require.False(t, hasFido2)
+}
+
 func TestIsKeyfileOnDeviceUUID(t *testing.T) {
 	require.True(t, isKeyfileOnDevice("/keyfile:UUID=f1e2d3c4-b5a6-4789-8abc-def123456789"))
 }

--- a/generator/crypttab_test.go
+++ b/generator/crypttab_test.go
@@ -49,7 +49,8 @@ func readImageFile(t *testing.T, img *Image, imgPath, name string) []byte {
 
 func TestAppendCrypttabAbsent(t *testing.T) {
 	img, _ := newTestImage(t)
-	require.Error(t, img.appendCrypttab(filepath.Join(t.TempDir(), "no-such-file")))
+	_, err := img.appendCrypttab(filepath.Join(t.TempDir(), "no-such-file"))
+	require.Error(t, err)
 }
 
 func TestAppendCrypttabBundled(t *testing.T) {
@@ -60,7 +61,8 @@ func TestAppendCrypttabBundled(t *testing.T) {
 	), 0o644))
 
 	img, _ := newTestImage(t)
-	require.NoError(t, img.appendCrypttab(crypttab))
+	_, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
 	require.True(t, img.contains["/etc/crypttab"])
 }
 
@@ -73,7 +75,8 @@ func TestAppendCrypttabXInitrdAttachRequired(t *testing.T) {
 	), 0o644))
 
 	img, _ := newTestImage(t)
-	require.NoError(t, img.appendCrypttab(crypttab))
+	_, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
 	require.False(t, img.contains["/etc/crypttab"])
 }
 
@@ -86,7 +89,8 @@ func TestAppendCrypttabXInitrdAttachStripped(t *testing.T) {
 	), 0o644))
 
 	img, imgPath := newTestImage(t)
-	require.NoError(t, img.appendCrypttab(crypttab))
+	_, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
 	require.True(t, img.contains["/etc/crypttab"])
 
 	bundled := string(readImageFile(t, img, imgPath, "/etc/crypttab"))
@@ -107,7 +111,8 @@ func TestAppendCrypttabNoautoSkipped(t *testing.T) {
 	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
 
 	img, _ := newTestImage(t)
-	require.NoError(t, img.appendCrypttab(crypttab))
+	_, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
 	require.True(t, img.contains["/etc/crypttab"])
 	require.False(t, img.contains[kf])
 }
@@ -123,7 +128,8 @@ func TestAppendCrypttabKeyfileBundled(t *testing.T) {
 	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
 
 	img, _ := newTestImage(t)
-	require.NoError(t, img.appendCrypttab(crypttab))
+	_, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
 	require.True(t, img.contains[kf])
 }
 
@@ -135,7 +141,8 @@ func TestAppendCrypttabKeyfileMissing(t *testing.T) {
 	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
 
 	img, _ := newTestImage(t)
-	require.Error(t, img.appendCrypttab(crypttab))
+	_, err := img.appendCrypttab(crypttab)
+	require.Error(t, err)
 }
 
 func TestAppendCrypttabNoneKeyfileSkipped(t *testing.T) {
@@ -147,7 +154,8 @@ func TestAppendCrypttabNoneKeyfileSkipped(t *testing.T) {
 	), 0o644))
 
 	img, _ := newTestImage(t)
-	require.NoError(t, img.appendCrypttab(crypttab))
+	_, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
 	require.True(t, img.contains["/etc/crypttab"])
 }
 
@@ -159,7 +167,8 @@ func TestAppendCrypttabKeyfileOnDeviceNotBundled(t *testing.T) {
 	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
 
 	img, _ := newTestImage(t)
-	require.NoError(t, img.appendCrypttab(crypttab))
+	_, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
 	require.True(t, img.contains["/etc/crypttab"])
 	require.False(t, img.contains["/keyfile"])
 }
@@ -177,7 +186,8 @@ cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none x-initrd.attach
 	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
 
 	img, _ := newTestImage(t)
-	require.NoError(t, img.appendCrypttab(crypttab))
+	_, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
 	require.True(t, img.contains["/etc/crypttab"])
 }
 
@@ -194,7 +204,8 @@ func TestAppendCrypttabMixedEntries(t *testing.T) {
 	require.NoError(t, os.WriteFile(crypttab, []byte(content), 0o644))
 
 	img, imgPath := newTestImage(t)
-	require.NoError(t, img.appendCrypttab(crypttab))
+	_, err := img.appendCrypttab(crypttab)
+	require.NoError(t, err)
 	require.True(t, img.contains["/etc/crypttab"])
 
 	bundled := string(readImageFile(t, img, imgPath, "/etc/crypttab"))

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -120,12 +120,15 @@ func generateInitRamfs(conf *generatorConfig) error {
 	if !explicitCrypttab {
 		crypttabPath = "/etc/crypttab"
 	}
-	if err := img.appendCrypttab(crypttabPath); err != nil {
+	if hasFido2, err := img.appendCrypttab(crypttabPath); err != nil {
 		if !explicitCrypttab && (os.IsNotExist(err) || os.IsPermission(err)) {
 			// default path unavailable — crypttab is optional, skip silently
 		} else {
 			return err
 		}
+	} else if hasFido2 {
+		// auto-enable fido2 plugin when any crypttab entry uses fido2-device=
+		conf.enableFido2 = true
 	}
 
 	for _, f := range conf.extraFiles {

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -125,10 +125,16 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 						return nil, fmt.Errorf("crypttab: entry %q: invalid keyfile-timeout= value %q", name, opt[16:])
 					}
 					m.keyfileTimeout = d
+				case strings.HasPrefix(opt, "header="):
+					hdrPath, hdrRef, err := parsePathWithDeviceRef(opt[7:], "header")
+					if err != nil {
+						return nil, fmt.Errorf("crypttab: entry %q: %v", name, err)
+					}
+					m.header = hdrPath
+					m.headerDeviceRef = hdrRef
 				case strings.HasPrefix(opt, "fido2-device="),
 					strings.HasPrefix(opt, "tpm2-device="),
-					strings.HasPrefix(opt, "token-timeout="),
-					strings.HasPrefix(opt, "header="):
+					strings.HasPrefix(opt, "token-timeout="):
 					// silently ignored — deferred to follow-up PRs
 				default:
 					debug("crypttab: entry %q: unknown option %q, ignoring", name, opt)

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // parseCrypttab reads /etc/crypttab from the image and returns LUKS mappings.
@@ -61,7 +62,12 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 
 		// none/- means interactive passphrase
 		if keyfile != "" && keyfile != "none" && keyfile != "-" {
-			m.keyfile = keyfile
+			kfPath, kfRef, err := parsePathWithDeviceRef(keyfile, "keyfile")
+			if err != nil {
+				return nil, fmt.Errorf("crypttab: entry %q: %v", name, err)
+			}
+			m.keyfile = kfPath
+			m.keyfileDeviceRef = kfRef
 		}
 
 		skip := false
@@ -113,11 +119,16 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 						return nil, fmt.Errorf("crypttab: entry %q: invalid keyfile-size= value %q", name, opt[13:])
 					}
 					m.keyfileSize = v
+				case strings.HasPrefix(opt, "keyfile-timeout="):
+					d, err := parseCrypttabDuration(opt[16:])
+					if err != nil {
+						return nil, fmt.Errorf("crypttab: entry %q: invalid keyfile-timeout= value %q", name, opt[16:])
+					}
+					m.keyfileTimeout = d
 				case strings.HasPrefix(opt, "fido2-device="),
 					strings.HasPrefix(opt, "tpm2-device="),
 					strings.HasPrefix(opt, "token-timeout="),
-					strings.HasPrefix(opt, "header="),
-					strings.HasPrefix(opt, "keyfile-timeout="):
+					strings.HasPrefix(opt, "header="):
 					// silently ignored — deferred to follow-up PRs
 				default:
 					debug("crypttab: entry %q: unknown option %q, ignoring", name, opt)
@@ -135,6 +146,16 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 		return nil, err
 	}
 	return mappings, nil
+}
+
+// parseCrypttabDuration parses a duration string for crypttab options such as
+// keyfile-timeout=. Accepts a bare integer (treated as seconds) or any string
+// accepted by time.ParseDuration (e.g. "30s", "2m").
+func parseCrypttabDuration(s string) (time.Duration, error) {
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return time.Duration(n) * time.Second, nil
+	}
+	return time.ParseDuration(s)
 }
 
 // luksMatchExists reports whether luksMappings already contains an entry for ref,

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -71,6 +71,7 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 		}
 
 		skip := false
+		tokenTimeoutExplicit := false
 		for opt := range strings.SplitSeq(optStr, ",") {
 			opt = strings.TrimSpace(opt)
 			if opt == "" {
@@ -132,10 +133,17 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 					}
 					m.header = hdrPath
 					m.headerDeviceRef = hdrRef
-				case strings.HasPrefix(opt, "fido2-device="),
-					strings.HasPrefix(opt, "tpm2-device="),
-					strings.HasPrefix(opt, "token-timeout="):
-					// silently ignored — deferred to follow-up PRs
+				case strings.HasPrefix(opt, "fido2-device="):
+					m.tokenFido2 = true // value ("auto") ignored — booster auto-detects enrolled tokens
+				case strings.HasPrefix(opt, "tpm2-device="):
+					m.tokenTpm2 = true // value ("auto") ignored — booster auto-detects enrolled tokens
+				case strings.HasPrefix(opt, "token-timeout="):
+					d, err := parseTokenTimeout(opt[14:])
+					if err != nil {
+						return nil, fmt.Errorf("crypttab: entry %q: invalid token-timeout= value %q", name, opt[14:])
+					}
+					m.tokenTimeout = d
+					tokenTimeoutExplicit = true
 				default:
 					debug("crypttab: entry %q: unknown option %q, ignoring", name, opt)
 				}
@@ -144,6 +152,10 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 
 		if skip {
 			continue
+		}
+
+		if (m.tokenFido2 || m.tokenTpm2) && !tokenTimeoutExplicit {
+			m.tokenTimeout = 30 * time.Second // systemd default: wait 30s for tokens before also prompting keyboard
 		}
 
 		mappings = append(mappings, m)

--- a/init/fido2_cgo.go
+++ b/init/fido2_cgo.go
@@ -63,3 +63,11 @@ func isFido2PinAuthBlockedError(err error) bool {
 	}
 	return fido2plugin.IsFido2PinAuthBlocked(err)
 }
+
+func isFido2PinBlockedError(err error) bool {
+	loadFido2Plugin()
+	if fido2plugin == nil {
+		return false
+	}
+	return fido2plugin.IsFido2PinBlocked(err)
+}

--- a/init/fido2_nocgo.go
+++ b/init/fido2_nocgo.go
@@ -15,3 +15,7 @@ func isFido2PinInvalidError(err error) bool {
 func isFido2PinAuthBlockedError(err error) bool {
 	return false
 }
+
+func isFido2PinBlockedError(err error) bool {
+	return false
+}

--- a/init/fido2iface/fido2iface.go
+++ b/init/fido2iface/fido2iface.go
@@ -9,4 +9,5 @@ type Fido2Plugin interface {
 	Fido2Assertion(devPath string, credID, saltBytes []byte, relyingParty, pin string, pinRequired, userPresenceRequired, userVerificationRequired bool, notifyTouch func()) ([]byte, error)
 	IsFido2PinInvalid(err error) bool
 	IsFido2PinAuthBlocked(err error) bool
+	IsFido2PinBlocked(err error) bool
 }

--- a/init/fido2plugin/main.go
+++ b/init/fido2plugin/main.go
@@ -11,6 +11,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/anatol/booster/init/fido2iface"
 	libfido2 "github.com/keys-pub/go-libfido2"
@@ -42,9 +44,6 @@ func (f *fido2Impl) Fido2Assertion(devPath string, credID, saltBytes []byte, rel
 	}
 	if userPresenceRequired {
 		opts.UP = libfido2.True
-		if notifyTouch != nil && !pinRequired {
-			notifyTouch()
-		}
 	}
 	if userVerificationRequired {
 		opts.UV = libfido2.True
@@ -52,15 +51,53 @@ func (f *fido2Impl) Fido2Assertion(devPath string, credID, saltBytes []byte, rel
 
 	var clientDataHash [32]byte
 
-	assertion, err := dev.Assertion(relyingParty, clientDataHash[:], [][]byte{credID}, pin, opts)
-	if err != nil {
-		return nil, err
+	type assertResult struct {
+		assertion *libfido2.Assertion
+		err       error
 	}
-	if len(assertion.HMACSecret) == 0 {
+	ch := make(chan assertResult, 1)
+	go func() {
+		a, e := dev.Assertion(relyingParty, clientDataHash[:], [][]byte{credID}, pin, opts)
+		ch <- assertResult{a, e}
+	}()
+
+	var res assertResult
+	if userPresenceRequired {
+		// Give the device a moment to return a quick error (e.g. wrong PIN).
+		// If it's still running after 500ms the device is waiting for touch.
+		timer := time.NewTimer(500 * time.Millisecond)
+		select {
+		case res = <-ch:
+			timer.Stop()
+		case <-timer.C:
+			if notifyTouch != nil {
+				notifyTouch()
+			}
+			res = <-ch
+		}
+	} else {
+		res = <-ch
+	}
+
+	// CTAP2.1 throttling: after a wrong PIN the device may require touch before
+	// accepting another PIN attempt. It signals this by returning ErrUPRequired
+	// immediately (not blocking). Notify the user and retry; the retry blocks
+	// until the device detects touch, then verifies the PIN.
+	if errors.Is(res.err, libfido2.ErrUPRequired) {
+		if notifyTouch != nil {
+			notifyTouch()
+		}
+		res.assertion, res.err = dev.Assertion(relyingParty, clientDataHash[:], [][]byte{credID}, pin, opts)
+	}
+
+	if res.err != nil {
+		return nil, res.err
+	}
+	if len(res.assertion.HMACSecret) == 0 {
 		return nil, fmt.Errorf("no HMAC secret in assertion")
 	}
 
-	return []byte(base64.StdEncoding.EncodeToString(assertion.HMACSecret)), nil
+	return []byte(base64.StdEncoding.EncodeToString(res.assertion.HMACSecret)), nil
 }
 
 func (f *fido2Impl) IsFido2PinInvalid(err error) bool {
@@ -69,4 +106,12 @@ func (f *fido2Impl) IsFido2PinInvalid(err error) bool {
 
 func (f *fido2Impl) IsFido2PinAuthBlocked(err error) bool {
 	return errors.Is(err, libfido2.ErrPinAuthBlocked)
+}
+
+func (f *fido2Impl) IsFido2PinBlocked(err error) bool {
+	// FIDO_ERR_PIN_BLOCKED (0x32 = 50) means the PIN retry counter reached zero
+	// and the PIN must be reset before any FIDO2 operations can proceed.
+	// go-libfido2 does not expose this as a named error; detect it by its generic
+	// error string from errFromCode's default case.
+	return err != nil && strings.Contains(err.Error(), "libfido2 error 50")
 }

--- a/init/luks.go
+++ b/init/luks.go
@@ -32,6 +32,8 @@ type luksMapping struct {
 	header          string        // detached LUKS header path (empty = embedded header)
 	headerDeviceRef *deviceRef    // non-nil when header is a file on a separate device
 	tokenTimeout    time.Duration // how long to wait for tokens before also starting keyboard; 0 = wait forever
+	tokenFido2      bool          // fido2-device= was set in crypttab — attempt FIDO2 token unlock
+	tokenTpm2       bool          // tpm2-device= was set in crypttab — attempt TPM2 token unlock
 
 	keyfileDeviceRef *deviceRef    // non-nil when keyfile is on a separate device
 	keyfileTimeout   time.Duration // device wait timeout for keyfile device (0 = use MountTimeout)

--- a/init/luks.go
+++ b/init/luks.go
@@ -566,13 +566,8 @@ func acquireHeader(m *luksMapping) (path string, cleanup func(), err error) {
 	}
 	timeout := time.Duration(config.MountTimeout) * time.Second
 	if m.headerDeviceRef != nil {
-		// Header is a file on a separate filesystem device.
-		mp := "/run/booster/hdrdev-" + m.name
-		unmount, err := mountDeviceReadOnly(m.headerDeviceRef, mp, timeout)
-		if err != nil {
-			return "", nil, err
-		}
-		return filepath.Join(mp, m.header), unmount, nil
+		// Header is a file on a separate filesystem device — use shared acquireFile.
+		return acquireFile(m.headerDeviceRef, "/run/booster/hdrdev-"+m.name, m.header, timeout)
 	}
 	if strings.HasPrefix(m.header, "/dev/") {
 		// Header is a raw block device — wait for it to appear.

--- a/init/luks.go
+++ b/init/luks.go
@@ -150,7 +150,7 @@ func isHidRawFido2(devName string) (bool, error) {
 	return false, nil
 }
 
-func recoverFido2Password(devName string, credential string, salt string, relyingParty string, pinRequired bool, userPresenceRequired bool, userVerificationRequired bool, mappingName string) ([]byte, error) {
+func recoverFido2Password(devName string, credential string, salt string, relyingParty string, pinRequired bool, userPresenceRequired bool, userVerificationRequired bool, mappingName string, promptPrefix string) ([]byte, error) {
 	usbhidWg.Wait()
 
 	isFido2, err := isHidRawFido2(devName)
@@ -181,7 +181,7 @@ func recoverFido2Password(devName string, credential string, salt string, relyin
 
 	var pin string
 	if pinRequired {
-		prompt := "Enter FIDO2 PIN for " + mappingName + " (empty to skip to passphrase):"
+		prompt := promptPrefix + "Enter FIDO2 PIN for " + mappingName + " (empty to skip to passphrase):"
 		if plymouthEnabled {
 			pinBytes, err := plymouthAskPassword(prompt)
 			if err != nil {
@@ -208,17 +208,15 @@ func recoverFido2Password(devName string, credential string, salt string, relyin
 	}
 
 	notifyTouch := func() {
-		msg := "Please touch the FIDO2 key for " + mappingName
-		if plymouthEnabled {
-			plymouthMessage(msg)
-		} else {
-			console(msg + "\n")
-		}
+		statusMessage("Please touch the FIDO2 key for " + mappingName)
 	}
 
 	result, err := fido2Assertion("/dev/"+devName, credID, saltBytes, relyingParty, pin, pinRequired, userPresenceRequired, userVerificationRequired, notifyTouch)
 	if err != nil && isFido2PinInvalidError(err) {
 		return nil, errFido2PinInvalid
+	}
+	if err == nil {
+		statusMessage("")
 	}
 	return result, err
 }
@@ -233,6 +231,7 @@ var fido2Mu sync.Mutex
 
 var errFido2Skipped = errors.New("FIDO2 skipped by user")
 var errFido2PinInvalid = errors.New("FIDO2 PIN invalid")
+var errFido2FallbackToKeyboard = errors.New("FIDO2 falling back to keyboard")
 
 func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, error) {
 	var node struct {
@@ -251,11 +250,7 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 		node.RelyingParty = "io.systemd.cryptsetup"
 	}
 
-	if plymouthEnabled {
-		plymouthMessage("Waiting for FIDO2 security key for " + mappingName + "...")
-	} else {
-		console("Waiting for FIDO2 security key for " + mappingName + "...\n")
-	}
+	statusMessage("Waiting for FIDO2 security key for " + mappingName + "...")
 
 	usbhidWg.Wait()
 
@@ -265,17 +260,18 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 	}
 
 	if len(dir) == 0 {
-		msg := "No FIDO2 device found for " + mappingName + ", insert security key or wait for passphrase prompt"
-		if plymouthEnabled {
-			plymouthMessage(msg)
-		} else {
-			console(msg + "\n")
-		}
+		statusMessage("No FIDO2 device found for " + mappingName + ", insert security key or wait for passphrase prompt")
 	}
 
+	stopSeeding := make(chan struct{})
+	defer close(stopSeeding)
 	go func() {
 		for _, d := range dir {
-			hidrawDevices <- d.Name()
+			select {
+			case hidrawDevices <- d.Name():
+			case <-stopSeeding:
+				return
+			}
 		}
 	}()
 
@@ -294,8 +290,9 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 		var password []byte
 		var err error
 		pinExhausted := false
+		promptPrefix := ""
 		for attempt := 0; attempt < maxAttempts; attempt++ {
-			password, err = recoverFido2Password(devName, node.Credential, node.Salt, node.RelyingParty, node.PinRequired, node.UserPresenceRequired, node.UserVerificationRequired, mappingName)
+			password, err = recoverFido2Password(devName, node.Credential, node.Salt, node.RelyingParty, node.PinRequired, node.UserPresenceRequired, node.UserVerificationRequired, mappingName, promptPrefix)
 			if err == nil {
 				break
 			}
@@ -303,12 +300,7 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 				break
 			}
 			if attempt < maxAttempts-1 {
-				msg := "FIDO2 PIN incorrect, please try again"
-				if plymouthEnabled {
-					plymouthMessage(msg)
-				} else {
-					warning(msg)
-				}
+				promptPrefix = "FIDO2 PIN incorrect — "
 			} else {
 				pinExhausted = true
 			}
@@ -316,11 +308,15 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 
 		if err != nil {
 			if errors.Is(err, errFido2Skipped) || pinExhausted {
-				info("FIDO2 skipped, falling back to passphrase")
+				statusMessage("FIDO2 skipped, falling back to passphrase")
 				break
 			}
 			if isFido2PinAuthBlockedError(err) {
-				warning("FIDO2 PIN auth blocked (too many wrong attempts), falling back to passphrase")
+				statusMessage("FIDO2 PIN auth blocked (too many wrong attempts), falling back to passphrase")
+				break
+			}
+			if isFido2PinBlockedError(err) {
+				statusMessage("FIDO2 PIN is blocked (reset required), falling back to passphrase")
 				break
 			}
 			info("%v", err)
@@ -329,10 +325,7 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 		return password, nil
 	}
 
-	if plymouthEnabled {
-		plymouthMessage("") // clear any FIDO2 status message before keyboard fallback
-	}
-	return nil, fmt.Errorf("no matching fido2 devices available")
+	return nil, errFido2FallbackToKeyboard
 }
 
 func recoverSystemdTPM2Password(t luks.Token) ([]byte, error) {
@@ -374,11 +367,18 @@ func recoverSystemdTPM2Password(t luks.Token) ([]byte, error) {
 
 	var authValue []byte
 	if node.Pin {
-		// TODO: route TPM PIN through Plymouth when plymouthEnabled, matching how
-		// FIDO2 PIN and keyboard passphrase are handled (plymouthAskPassword with
-		// console fallback).
-		prompt := fmt.Sprintf("Please enter TPM pin: ")
-		pin, err := readPassword(prompt, "")
+		prompt := "Please enter TPM pin: "
+		var pin []byte
+		var err error
+		if plymouthEnabled {
+			pin, err = plymouthAskPassword(prompt)
+			if err != nil {
+				warning("Plymouth password prompt failed: %v, falling back to console", err)
+				pin, err = readPassword(prompt, "")
+			}
+		} else {
+			pin, err = readPassword(prompt, "")
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -410,6 +410,9 @@ func recoverTokenPassword(volumes chan *luks.Volume, done <-chan struct{}, d luk
 		return false
 	}
 
+	if errors.Is(err, errFido2FallbackToKeyboard) {
+		return false // intentional fallback; message already logged in recoverSystemdFido2Password
+	}
 	if err != nil {
 		warning("recovering %s token #%d failed: %v", t.Type, t.ID, err)
 		return false
@@ -494,13 +497,14 @@ func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d 
 	waitForPlymouthInit()
 
 	attempts := 0
+	promptPrefix := ""
 	for {
 		if maxTries > 0 && attempts >= maxTries {
 			warning("maximum passphrase attempts (%d) reached for %s", maxTries, mappingName)
 			return
 		}
 
-		prompt := fmt.Sprintf("Enter passphrase for %s:", mappingName)
+		prompt := promptPrefix + fmt.Sprintf("Enter passphrase for %s:", mappingName)
 
 		var password []byte
 		var err error
@@ -519,19 +523,15 @@ func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d 
 			warning("reading password: %v", err)
 			return
 		}
-		if len(password) == 0 {
-			continue
-		}
 		attempts++
 
 		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, password) {
+			statusMessage("") // clear any error message before Plymouth quits
 			return
 		}
 
-		// retry password
-		if plymouthEnabled {
-			plymouthMessage("Incorrect passphrase, please try again")
-		} else {
+		promptPrefix = "Incorrect passphrase — "
+		if !plymouthEnabled {
 			console("   Incorrect passphrase, please try again\n")
 		}
 	}
@@ -629,26 +629,35 @@ func luksOpen(dev string, mapping *luksMapping) error {
 
 	volumes := make(chan *luks.Volume)
 	done := make(chan struct{})
+	var closeDone sync.Once
 	var senderWg sync.WaitGroup
 	var tokenWg sync.WaitGroup
 	var keyboardOnce sync.Once
 
+	// priorityTypes holds token types that should delay the keyboard prompt.
+	// When non-empty, keyboard unlock is deferred until these tokens finish
+	// (or tokenTimeout elapses), matching systemd-cryptsetup fido2-device= behavior.
+	priorityTypes := make(map[string]bool)
+	if mapping.tokenFido2 {
+		priorityTypes["systemd-fido2"] = true
+	}
+	if mapping.tokenTpm2 {
+		priorityTypes["systemd-tpm2"] = true
+	}
+	hasPriority := len(priorityTypes) > 0
+
 	// startKeyboard launches the keyboard (or keyfile) unlock goroutine at most once.
-	startKeyboard := func() {
-		senderWg.Go(func() {
-			if mapping.keyfile != "" {
-				recoverKeyfilePassword(volumes, done, d, availableSlots, mapping)
-			} else {
-				requestKeyboardPassword(volumes, done, d, availableSlots, mapping.name, mapping.tries)
-			}
+	startKeyboard := func(checkSlots []int) {
+		keyboardOnce.Do(func() {
+			senderWg.Go(func() {
+				if mapping.keyfile != "" {
+					recoverKeyfilePassword(volumes, done, d, checkSlots, mapping)
+				} else {
+					requestKeyboardPassword(volumes, done, d, checkSlots, mapping.name, mapping.tries)
+				}
+			})
 		})
 	}
-
-	// Watcher: close volumes once all senders are done so the receiver unblocks.
-	go func() {
-		senderWg.Wait()
-		close(volumes)
-	}()
 
 	slotsWithTokens := make(map[int]bool)
 	tokens, err := d.Tokens()
@@ -660,22 +669,52 @@ func luksOpen(dev string, mapping *luksMapping) error {
 			continue // skipped: entered via keyboard later
 		}
 		t := t
-		senderWg.Add(1)
-		tokenWg.Add(1)
-		go func() {
-			defer senderWg.Done()
-			defer tokenWg.Done()
-			recoverTokenPassword(volumes, done, d, t, mapping.name)
-		}()
+		if hasPriority && priorityTypes[t.Type] {
+			// Priority token: track in tokenWg so keyboard waits for it.
+			senderWg.Add(1)
+			tokenWg.Add(1)
+			go func() {
+				defer senderWg.Done()
+				defer tokenWg.Done()
+				if recoverTokenPassword(volumes, done, d, t, mapping.name) {
+					closeDone.Do(func() { close(done) })
+				}
+			}()
+		} else {
+			// Non-priority token (or no priority mode): fire-and-forget w.r.t. keyboard timing.
+			senderWg.Add(1)
+			tokenWg.Add(1)
+			go func() {
+				defer senderWg.Done()
+				defer tokenWg.Done()
+				recoverTokenPassword(volumes, done, d, t, mapping.name)
+			}()
+		}
 		for _, s := range t.Slots {
 			slotsWithTokens[s] = true
 		}
 	}
 
+	// checkSlotsWithPassword = slots not covered by any token; these are tried by
+	// the keyboard/keyfile goroutine.  When hasPriority is false we pass all
+	// available slots so the keyboard can try token slots too (existing behavior).
+	var checkSlotsWithPassword []int
+	if hasPriority {
+		for _, s := range availableSlots {
+			if !slotsWithTokens[s] {
+				checkSlotsWithPassword = append(checkSlotsWithPassword, s)
+			}
+		}
+		if len(checkSlotsWithPassword) == 0 {
+			checkSlotsWithPassword = availableSlots
+		}
+	} else {
+		checkSlotsWithPassword = availableSlots
+	}
+
 	// Start keyboard/keyfile unlock after all token goroutines finish (or tokenTimeout
-	// elapses). This gives hardware tokens priority over the keyboard prompt, matching
-	// systemd-cryptsetup behavior. senderWg ensures volumes is closed if this goroutine
-	// is the last sender and nobody unlocked.
+	// elapses). This gives hardware tokens priority over the keyboard prompt.
+	// senderWg ensures volumes is closed if this goroutine is the last sender.
 	senderWg.Go(func() {
 		if mapping.tokenTimeout > 0 {
 			waitTimeout(&tokenWg, mapping.tokenTimeout)
@@ -687,11 +726,26 @@ func luksOpen(dev string, mapping *luksMapping) error {
 			return // already unlocked by a token
 		default:
 		}
-		keyboardOnce.Do(startKeyboard)
+		if len(checkSlotsWithPassword) > 0 {
+			startKeyboard(checkSlotsWithPassword)
+		}
 	})
 
+	// Watcher: when every unlock goroutine has given up, close volumes so luksOpen
+	// unblocks rather than hanging forever. Check done first to avoid closing volumes
+	// after a priority token already signalled success.
+	go func() {
+		senderWg.Wait()
+		select {
+		case <-done:
+			// Already unlocked — volumes will drain naturally.
+		default:
+			close(volumes)
+		}
+	}()
+
 	v, ok := <-volumes
-	close(done)
+	closeDone.Do(func() { close(done) })
 
 	if !ok {
 		return fmt.Errorf("failed to unlock %s: all unlock attempts exhausted", dev)
@@ -745,9 +799,10 @@ func matchLuksMapping(blk *blkInfo) *luksMapping {
 	if blk.matchesRef(cmdRoot) {
 		info("LUKS device %s matches root=, unlock this device", blk.path)
 		m := &luksMapping{
-			ref:     cmdRoot,
-			name:    "root",
-			keySlot: -1,
+			ref:          cmdRoot,
+			name:         "root",
+			keySlot:      -1,
+			tokenTimeout: 30 * time.Second, // systemd default: wait 30s for tokens before also prompting keyboard
 		}
 		cmdRoot = &deviceRef{format: refPath, data: "/dev/mapper/root"}
 		return m

--- a/init/luks.go
+++ b/init/luks.go
@@ -33,6 +33,9 @@ type luksMapping struct {
 	headerDeviceRef *deviceRef    // non-nil when header is a file on a separate device
 	tokenTimeout    time.Duration // how long to wait for tokens before also starting keyboard; 0 = wait forever
 
+	keyfileDeviceRef *deviceRef    // non-nil when keyfile is on a separate device
+	keyfileTimeout   time.Duration // device wait timeout for keyfile device (0 = use MountTimeout)
+
 	keySlot       int   // -1 = all slots; >=0 restricts unlock to that slot
 	tries         int   // 0 = unlimited keyboard retries; >0 = max attempts
 	noFail        bool  // non-fatal unlock failure — boot continues on error
@@ -435,10 +438,33 @@ func readKeyfile(path string, offset, size int64) ([]byte, error) {
 	return io.ReadAll(f)
 }
 
-// acquireKeyfilePassword reads the keyfile referenced by mapping, applying any
-// configured offset and size restrictions.
+// acquireFile mounts ref read-only at mountDir and returns filepath.Join(mountDir, filePath)
+// along with a cleanup function. If ref is nil, filePath is returned as-is with a no-op cleanup.
+// This is the shared implementation used by both acquireHeader and acquireKeyfilePassword.
+func acquireFile(ref *deviceRef, mountDir, filePath string, timeout time.Duration) (string, func(), error) {
+	if ref == nil {
+		return filePath, func() {}, nil
+	}
+	unmount, err := mountDeviceReadOnly(ref, mountDir, timeout)
+	if err != nil {
+		return "", func() {}, err
+	}
+	return filepath.Join(mountDir, filePath), unmount, nil
+}
+
+// acquireKeyfilePassword resolves the keyfile path (mounting a separate device if needed),
+// reads the file applying any configured offset and size, then releases the mount.
 func acquireKeyfilePassword(mapping *luksMapping) ([]byte, error) {
-	return readKeyfile(mapping.keyfile, mapping.keyfileOffset, mapping.keyfileSize)
+	timeout := mapping.keyfileTimeout
+	if timeout == 0 {
+		timeout = time.Duration(config.MountTimeout) * time.Second
+	}
+	path, cleanup, err := acquireFile(mapping.keyfileDeviceRef, "/run/booster/keydev-"+mapping.name, mapping.keyfile, timeout)
+	defer cleanup()
+	if err != nil {
+		return nil, fmt.Errorf("keyfile device for %s: %v", mapping.name, err)
+	}
+	return readKeyfile(path, mapping.keyfileOffset, mapping.keyfileSize)
 }
 
 func recoverKeyfilePassword(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, checkSlots []int, mapping *luksMapping) {

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -142,6 +142,16 @@ func plymouthAskPassword(prompt string) ([]byte, error) {
 	return []byte(password), nil
 }
 
+// statusMessage shows msg on the Plymouth splash, or on the console if Plymouth
+// is disabled. Passing an empty string clears the Plymouth message (no-op on console).
+func statusMessage(msg string) {
+	if plymouthEnabled {
+		plymouthMessage(msg)
+	} else if msg != "" {
+		console(msg + "\n")
+	}
+}
+
 // plymouthMessage displays a message on the plymouth splash screen.
 func plymouthMessage(msg string) {
 	if err := exec.Command("plymouth", "display-message", "--text="+msg).Run(); err != nil {

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -32,6 +32,13 @@ var assetGenerators = map[string]assetGenerator{
 		"FS_UUID=781780d2-bf67-4a17-9ca8-fd22336c1b2e",
 		"HEADER_OUTPUT=assets/luks2.detached_header.hdr",
 	}},
+	// luks2.keyfile_device.img and its companion keydev are both created by a single generator run.
+	"luks2.keyfile_device.img": {"luks_keyfile_device.sh", []string{
+		"LUKS_UUID=7c2a39be-15d1-4b71-9f2e-5c4d1a3b8e6f",
+		"FS_UUID=a3d8e2c1-4f7b-4e9c-b2a1-6d5f3c8e1a7b",
+		"KEYDEV_UUID=f1e2d3c4-b5a6-4789-8abc-def123456789",
+		"KEYDEV_OUTPUT=assets/luks2.keyfile_device.keydev.img",
+	}},
 	// luks2.detached_header.hdrdev.img: small ext4 device containing luks2.detached_header.hdr
 	// at /root.hdr.  Used by TestLUKS2DetachedHeaderCmdlineOnDevice to exercise the
 	// rd.luks.header=UUID=/root.hdr:UUID=<devuuid> cmdline path (headerDeviceRef != nil).
@@ -50,7 +57,14 @@ var assetGenerators = map[string]assetGenerator{
 	"archlinux.btrfs.raw":       {"archlinux_btrfs.sh", []string{"LUKS_PASSWORD=hello"}},
 	"voidlinux.img":             {"voidlinux.sh", nil},
 	"alpinelinux.img":           {"alpinelinux.sh", nil},
-	"systemd-fido2.img":         {"systemd_fido2.sh", []string{"LUKS_UUID=b12cbfef-da87-429f-ac96-7dda7232c189", "FS_UUID=bb351f0d-07f2-4fe4-bc53-d6ae39fa1c23", "LUKS_PASSWORD=567", "FIDO2_PIN=" + os.Getenv("BOOSTER_TEST_FIDO2_PIN")}}, // to regenerate: delete assets/systemd-fido2.img and run with BOOSTER_TEST_FIDO2_PIN=<pin> in the environment
+	// systemd-fido2-nodev.img: LUKS2 with a fake systemd-fido2 token injected
+	// directly into the header (random credential — never matches a real device).
+	// Used to test the token-timeout fallback path without physical FIDO2 hardware.
+	"systemd-fido2-nodev.img": {"luks_fido2_nodev.sh", []string{
+		"LUKS_UUID=a6cdb03e-ad77-440a-8a93-28ad97de3b00",
+		"FS_UUID=0cb4665f-65a0-4acc-9710-05163af16f19",
+		"LUKS_PASSWORD=567",
+	}},
 	"systemd-tpm2.img":          {"systemd_tpm2.sh", []string{"LUKS_UUID=5cbc48ce-0e78-4c6b-ac90-a8a540514b90", "FS_UUID=d8673e36-d4a3-4408-a87d-be0cb79f91a2", "LUKS_PASSWORD=567"}},
 	"systemd-tpm2-withpin.img":  {"systemd_tpm2.sh", []string{"LUKS_UUID=8bb97618-7ef4-4c93-b4f7-f2cb17cf7da1", "FS_UUID=26dbbe17-9af9-4322-bb5f-c1d74a40e618", "LUKS_PASSWORD=9999", "CRYPTENROLL_TPM2_PIN=foo654"}},
 	"systemd-recovery.img":      {"systemd_recovery.sh", []string{"LUKS_UUID=62020168-58b9-4095-a3d0-176403353d20", "FS_UUID=b0cfeb48-c1e2-459d-a327-4d611804ac24", "LUKS_PASSWORD=2211"}},

--- a/tests/crypttab_test.go
+++ b/tests/crypttab_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -141,5 +143,178 @@ func TestCrypttabCmdlinePrecedence(t *testing.T) {
 
 	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cmdroot:"))
 	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+const (
+	keyfileDevLuksUUID   = "7c2a39be-15d1-4b71-9f2e-5c4d1a3b8e6f"
+	keyfileDevFsUUID     = "a3d8e2c1-4f7b-4e9c-b2a1-6d5f3c8e1a7b"
+	keyfileDevKeydevUUID = "f1e2d3c4-b5a6-4789-8abc-def123456789"
+)
+
+// TestCrypttabKeyfileDevice verifies that booster can unlock a LUKS2 volume
+// whose keyfile lives on a separate block device configured via the crypttab
+// keyfile field (/keyfile:UUID=<keydev>).  The key device is presented as a
+// second virtio disk; no passphrase prompt is expected.
+func TestCrypttabKeyfileDevice(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.keyfile_device.img"))
+
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptroot UUID="+keyfileDevLuksUUID+" /keyfile:UUID="+keyfileDevKeydevUUID+" x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.keyfile_device.img",
+		params:       []string{"-drive", "file=assets/luks2.keyfile_device.keydev.img,if=virtio,format=raw"},
+		kernelArgs:   []string{"root=UUID=" + keyfileDevFsUUID},
+		crypttabFile: crypttabPath,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestCrypttabHeader verifies that booster can unlock a LUKS2 volume with a
+// detached header referenced via the crypttab header= option.  The generator
+// bundles the header file into the initramfs automatically.
+func TestCrypttabHeader(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.detached_header.img"))
+
+	headerPath, err := filepath.Abs("assets/luks2.detached_header.hdr")
+	require.NoError(t, err)
+
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptroot UUID="+detachedHeaderLuksUUID+" none header="+headerPath+",x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.detached_header.img",
+		kernelArgs:   []string{"root=UUID=" + detachedHeaderFsUUID},
+		crypttabFile: crypttabPath,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestCrypttabFido2 verifies that a crypttab entry with fido2-device=auto
+// causes the generator to auto-bundle fido2plugin.so and the init to attempt
+// FIDO2 token unlock before falling back to keyboard.
+//
+// Requires a physical FIDO2 device and BOOSTER_TEST_FIDO2_PIN to be set.
+// A fresh LUKS image is created for each run enrolling the connected device,
+// so the test works for any FIDO2 device without pre-built assets.
+func TestCrypttabFido2(t *testing.T) {
+	pin := os.Getenv("BOOSTER_TEST_FIDO2_PIN")
+	if pin == "" {
+		t.Skip("BOOSTER_TEST_FIDO2_PIN not set")
+	}
+
+	yubikeys, err := detectYubikeys()
+	require.NoError(t, err)
+	if len(yubikeys) == 0 {
+		t.Skip("no Yubikeys detected")
+	}
+
+	if !fileExists(binariesDir + "/fido2plugin.so") {
+		t.Skip("fido2plugin.so not built (libfido2 may not be installed)")
+	}
+
+	luksUUID, fsUUID, imgPath := createFido2LuksImage(t, pin)
+
+	params := make([]string, 0)
+	for _, y := range yubikeys {
+		params = append(params, y.toQemuParams()...)
+	}
+
+	// The crypttab entry specifies fido2-device=auto; the generator auto-detects
+	// this and bundles fido2plugin.so without needing enable_fido2: true in config.
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptroot UUID="+luksUUID+" none fido2-device=auto,x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         imgPath,
+		params:       params,
+		kernelArgs:   []string{"root=UUID=" + fsUUID},
+		crypttabFile: crypttabPath,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	re, err := regexp.Compile(`(Enter FIDO2 PIN for |Hello, booster!)`)
+	require.NoError(t, err)
+	for {
+		matches, err := vm.ConsoleExpectRE(re)
+		require.NoError(t, err)
+		if matches[0] == "Hello, booster!" {
+			break
+		}
+		require.NoError(t, vm.ConsoleWrite(pin+"\n"))
+	}
+}
+
+// TestCrypttabFido2NoDevice verifies that when fido2-device=auto is set in
+// crypttab and the LUKS volume has a FIDO2 token enrolled but no physical key
+// is present, init waits token-timeout seconds then falls back to the keyboard
+// passphrase prompt.
+//
+// Uses systemd-fido2-nodev.img which has a fake systemd-fido2 token with a
+// random credential — it will never match any real device, so no hardware is
+// required.  The default token-timeout of 30s applies.
+func TestCrypttabFido2NoDevice(t *testing.T) {
+	if !fileExists(binariesDir + "/fido2plugin.so") {
+		t.Skip("fido2plugin.so not built (libfido2 may not be installed)")
+	}
+
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptroot UUID=a6cdb03e-ad77-440a-8a93-28ad97de3b00 none fido2-device=auto,x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/systemd-fido2-nodev.img",
+		kernelArgs:   []string{"root=UUID=0cb4665f-65a0-4acc-9710-05163af16f19"},
+		crypttabFile: crypttabPath,
+		// tokenTimeout defaults to 30s; allow enough time for that plus boot
+		vmTimeout: 90 * time.Second,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	// No FIDO2 device is present, so init waits token-timeout then falls back.
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("567\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestCrypttabTPM2 verifies that a crypttab entry with tpm2-device=auto causes
+// the init to attempt TPM2 token unlock.  Uses the swtpm software emulator.
+func TestCrypttabTPM2(t *testing.T) {
+	swtpm, params, err := startSwtpm()
+	require.NoError(t, err)
+	defer swtpm.Kill()
+
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptroot UUID=5cbc48ce-0e78-4c6b-ac90-a8a540514b90 none tpm2-device=auto,x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/systemd-tpm2.img",
+		params:       params,
+		kernelArgs:   []string{"root=UUID=d8673e36-d4a3-4408-a87d-be0cb79f91a2"},
+		crypttabFile: crypttabPath,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
 }

--- a/tests/generators/luks_fido2_nodev.sh
+++ b/tests/generators/luks_fido2_nodev.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Creates a LUKS2 image with a fake systemd-fido2 token injected directly
+# into the LUKS2 metadata.  The credential and salt are random bytes that
+# will never match any real FIDO2 device.  This is used to test that booster
+# correctly waits token-timeout seconds for a FIDO2 device and then falls
+# back to the keyboard passphrase prompt.
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  sudo umount "${dir}" 2>/dev/null || true
+  rm -r "${dir}" 2>/dev/null || true
+  sudo cryptsetup close "${LUKS_DEV_NAME}" 2>/dev/null || true
+  sudo losetup -d "${lodev}" 2>/dev/null || true
+}
+
+LUKS_DEV_NAME=luks-booster-fido2nodev
+
+truncate --size 40M "${OUTPUT}"
+lodev=$(sudo losetup -f -P --show "${OUTPUT}")
+sudo cryptsetup luksFormat --uuid "${LUKS_UUID}" --type luks2 "${lodev}" <<< "${LUKS_PASSWORD}"
+
+# Inject a fake systemd-fido2 token.  Random credential/salt ensure it will
+# never successfully authenticate against any real device.  Booster will
+# find the token, wait token-timeout for a matching hidraw device, then fall
+# back to the keyboard prompt.
+FAKE_CREDENTIAL=$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 -w0)
+FAKE_SALT=$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 -w0)
+printf '{"type":"systemd-fido2","keyslots":["0"],"fido2-credential":"%s","fido2-salt":"%s","fido2-rp":"io.systemd.cryptsetup","fido2-clientPin-required":false,"fido2-up-required":true,"fido2-uv-required":false}' \
+    "${FAKE_CREDENTIAL}" "${FAKE_SALT}" \
+    | sudo cryptsetup token import --json-file=- "${lodev}"
+
+sudo cryptsetup open --disable-external-tokens --type luks2 "${lodev}" "${LUKS_DEV_NAME}" <<< "${LUKS_PASSWORD}"
+sudo mkfs.ext4 -U "${FS_UUID}" -L atestlabel12 "/dev/mapper/${LUKS_DEV_NAME}"
+dir=$(mktemp -d)
+sudo mount "/dev/mapper/${LUKS_DEV_NAME}" "${dir}"
+sudo chown "${USER}" "${dir}"
+mkdir "${dir}/sbin"
+cp assets/init "${dir}/sbin/init"

--- a/tests/generators/luks_keyfile_device.sh
+++ b/tests/generators/luks_keyfile_device.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Creates two disk images:
+#   $OUTPUT        — LUKS2 root disk, unlocked by keyfile only (no password slot)
+#   $KEYDEV_OUTPUT — small ext4 "key device" containing the keyfile at /keyfile
+#
+# Required env vars:
+#   OUTPUT          path for the LUKS root image
+#   KEYDEV_OUTPUT   path for the key device image
+#   LUKS_UUID       UUID for the LUKS container
+#   FS_UUID         UUID for the ext4 filesystem inside LUKS
+#   KEYDEV_UUID     UUID for the ext4 key device filesystem
+
+set -o errexit
+
+LUKS_DEV_NAME="luks-${LUKS_UUID}"
+KEYFILE=$(mktemp)
+
+rootlodev=
+keylodev=
+rootdir=
+keydir=
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  [ -n "${rootdir}" ]   && { sudo umount "${rootdir}"; rm -rf "${rootdir}"; }
+  [ -n "${keydir}" ]    && { sudo umount "${keydir}";  rm -rf "${keydir}"; }
+  sudo cryptsetup close "${LUKS_DEV_NAME}" 2>/dev/null || true
+  [ -n "${rootlodev}" ] && sudo losetup -d "${rootlodev}"
+  [ -n "${keylodev}" ]  && sudo losetup -d "${keylodev}"
+  rm -f "${KEYFILE}"
+}
+
+# Generate a random binary keyfile
+dd if=/dev/urandom of="${KEYFILE}" bs=512 count=8 status=none
+
+# --- key device: small ext4 image containing the keyfile ---
+truncate --size 10M "${KEYDEV_OUTPUT}"
+mkfs.ext4 -U "${KEYDEV_UUID}" "${KEYDEV_OUTPUT}"
+keylodev=$(sudo losetup -f --show "${KEYDEV_OUTPUT}")
+keydir=$(mktemp -d)
+sudo mount "${keylodev}" "${keydir}"
+sudo chown "${USER}" "${keydir}"
+cp "${KEYFILE}" "${keydir}/keyfile"
+sudo umount "${keydir}"
+rm -rf "${keydir}"; keydir=
+sudo losetup -d "${keylodev}"; keylodev=
+
+# --- LUKS root disk: keyfile-only (no password slot) ---
+truncate --size 40M "${OUTPUT}"
+rootlodev=$(sudo losetup -f --show "${OUTPUT}")
+sudo cryptsetup luksFormat --uuid "${LUKS_UUID}" --type luks2 \
+  --key-file "${KEYFILE}" "${rootlodev}"
+sudo cryptsetup open --key-file "${KEYFILE}" "${rootlodev}" "${LUKS_DEV_NAME}"
+sudo mkfs.ext4 -U "${FS_UUID}" "/dev/mapper/${LUKS_DEV_NAME}"
+rootdir=$(mktemp -d)
+sudo mount "/dev/mapper/${LUKS_DEV_NAME}" "${rootdir}"
+sudo chown "${USER}" "${rootdir}"
+mkdir "${rootdir}/sbin"
+cp assets/init "${rootdir}/sbin/init"
+sudo umount "${rootdir}"
+rm -rf "${rootdir}"; rootdir=
+sudo cryptsetup close "${LUKS_DEV_NAME}"
+sudo losetup -d "${rootlodev}"; rootlodev=

--- a/tests/generators/systemd_fido2.sh
+++ b/tests/generators/systemd_fido2.sh
@@ -1,31 +1,55 @@
 #!/usr/bin/env bash
+#
+# Creates a LUKS2 image with FIDO2 enrolled via systemd-cryptenroll.
+#
+# cryptsetup luksFormat and systemd-cryptenroll both support regular files
+# directly, so we avoid loop devices (and the udev/blkid lock conflicts they
+# trigger) until the final mount step.
 
-trap 'quit' EXIT ERR
+set -euo pipefail
+trap 'quit' EXIT
 
 quit() {
-  set +o errexit
-  sudo umount "${dir}"
-  rm assets/{cryptenroll.passphrase,fido2-pin}
-  rm -r "${dir}"
-  sudo cryptsetup close "${LUKS_DEV_NAME}"
-  sudo losetup -d "${lodev}"
+  trap - EXIT
+  [ -n "${cred_dir:-}" ] && rm -rf "${cred_dir}"
+  sudo umount "${dir}" 2>/dev/null || true
+  rm -rf "${dir}" 2>/dev/null || true
+  sudo cryptsetup close "${LUKS_DEV_NAME}" 2>/dev/null || true
+  [ -n "${lodev:-}" ] && sudo losetup -d "${lodev}" 2>/dev/null || true
 }
 
 LUKS_DEV_NAME=luks-booster-systemd
+cred_dir=
+dir=
+lodev=
 
+# Format directly on the image file — no loop device or kernel involvement,
+# so no udev races.
 truncate --size 40M "${OUTPUT}"
-lodev=$(sudo losetup -f -P --show "${OUTPUT}")
-sudo cryptsetup luksFormat --uuid "${LUKS_UUID}" --type luks2 "${lodev}" <<< "${LUKS_PASSWORD}"
+cryptsetup luksFormat --uuid "${LUKS_UUID}" --type luks2 "${OUTPUT}" <<< "${LUKS_PASSWORD}"
 
-printf '%s' "${LUKS_PASSWORD}" > assets/cryptenroll.passphrase
-printf '%s' "${FIDO2_PIN}" > assets/fido2-pin
-sudo CREDENTIALS_DIRECTORY="$(pwd)/assets" systemd-cryptenroll --fido2-device=auto --fido2-with-client-pin=yes "${lodev}"
+# Enroll FIDO2 directly on the file (systemd-cryptenroll supports regular
+# files for LUKS2).  Run as the current user so it can access the FIDO2
+# device via seat-based udev permissions.
+#
+# Store credentials in XDG_RUNTIME_DIR (tmpfs on systemd systems — PIN stays
+# in RAM, never touches disk).  systemd-cryptenroll requires regular files;
+# names must match exactly what it looks for.
+cred_dir=$(mktemp -d -p "${XDG_RUNTIME_DIR:-/tmp}")
+printf '%s' "${LUKS_PASSWORD}" > "${cred_dir}/cryptenroll.passphrase"
+printf '%s' "${FIDO2_PIN}" > "${cred_dir}/cryptenroll.fido2-pin"
+CREDENTIALS_DIRECTORY="${cred_dir}" systemd-cryptenroll --fido2-device=auto --fido2-with-client-pin=yes "${OUTPUT}"
+rm -rf "${cred_dir}"; cred_dir=
 
-sudo cryptsetup open --disable-external-tokens --type luks2 "${lodev}" "${LUKS_DEV_NAME}" <<< "${LUKS_PASSWORD}"
+# Now attach as a loop device only for the mount step.  By this point the
+# LUKS2 header is fully written; udev will probe and see it quickly.
+lodev=$(sudo losetup -f --show "${OUTPUT}")
+udevadm settle --timeout=10 || true
+
+sudo cryptsetup open --disable-external-tokens --disable-locks --type luks2 "${lodev}" "${LUKS_DEV_NAME}" <<< "${LUKS_PASSWORD}"
 sudo mkfs.ext4 -U "${FS_UUID}" -L atestlabel12 "/dev/mapper/${LUKS_DEV_NAME}"
 dir=$(mktemp -d)
 sudo mount "/dev/mapper/${LUKS_DEV_NAME}" "${dir}"
 sudo chown "${USER}" "${dir}"
 mkdir "${dir}/sbin"
 cp assets/init "${dir}/sbin/init"
-

--- a/tests/systemd_test.go
+++ b/tests/systemd_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 func TestSystemdFido2(t *testing.T) {
-	// Check prerequisites before starting QEMU or touching hardware.
 	// PIN is read from the environment to avoid hardcoding it in source.
 	// Set BOOSTER_TEST_FIDO2_PIN to the PIN on your FIDO2 device before running.
-	// Tip: use read -s to avoid shell history: read -s BOOSTER_TEST_FIDO2_PIN && sudo -E BOOSTER_TEST_FIDO2_PIN=$BOOSTER_TEST_FIDO2_PIN go test -run TestSystemdFido2
+	// Tip: use read -s to avoid shell history: read -s BOOSTER_TEST_FIDO2_PIN
 	pin := os.Getenv("BOOSTER_TEST_FIDO2_PIN")
 	if pin == "" {
 		t.Skip("BOOSTER_TEST_FIDO2_PIN not set")
@@ -24,13 +23,17 @@ func TestSystemdFido2(t *testing.T) {
 		t.Skip("no Yubikeys detected")
 	}
 
+	// Create a fresh LUKS image enrolled against the connected FIDO2 device so
+	// the test works for any device without pre-built assets.
+	luksUUID, fsUUID, imgPath := createFido2LuksImage(t, pin)
+
 	params := make([]string, 0)
 	for _, y := range yubikeys {
 		params = append(params, y.toQemuParams()...)
 	}
 	vm, err := buildVmInstance(t, Opts{
-		disk:        "assets/systemd-fido2.img",
-		kernelArgs:  []string{"rd.luks.uuid=b12cbfef-da87-429f-ac96-7dda7232c189", "root=UUID=bb351f0d-07f2-4fe4-bc53-d6ae39fa1c23"},
+		disk:        imgPath,
+		kernelArgs:  []string{"rd.luks.uuid=" + luksUUID, "root=UUID=" + fsUUID},
 		params:      params,
 		enableFido2: true,
 	})
@@ -42,12 +45,10 @@ func TestSystemdFido2(t *testing.T) {
 	for {
 		matches, err := vm.ConsoleExpectRE(re)
 		require.NoError(t, err)
-
 		if matches[0] == "Hello, booster!" {
 			break
-		} else {
-			require.NoError(t, vm.ConsoleWrite(pin+"\n"))
 		}
+		require.NoError(t, vm.ConsoleWrite(pin+"\n"))
 	}
 }
 

--- a/tests/util.go
+++ b/tests/util.go
@@ -100,6 +100,27 @@ func startTangd() (*tang.NativeServer, []string, error) {
 	return tangd, []string{"-nic", fmt.Sprintf("user,id=n1,restrict=on,guestfwd=tcp:10.0.2.100:5697-tcp:localhost:%d", tangd.Port)}, nil
 }
 
+// createFido2LuksImage creates a temporary LUKS2 image with a FIDO2 token
+// enrolled against the currently-connected FIDO2 device.  The image is written
+// to t.TempDir() and cleaned up automatically when the test finishes.
+//
+// The returned luksUUID and fsUUID should be threaded through to the crypttab
+// entry and kernel args of the QEMU VM so they match the generated image.
+func createFido2LuksImage(t *testing.T, pin string) (luksUUID, fsUUID, imgPath string) {
+	t.Helper()
+	luksUUID = "b12cbfef-da87-429f-ac96-7dda7232c189"
+	fsUUID = "bb351f0d-07f2-4fe4-bc53-d6ae39fa1c23"
+	imgPath = filepath.Join(t.TempDir(), "fido2.img")
+	require.NoError(t, shell("generators/systemd_fido2.sh",
+		"OUTPUT="+imgPath,
+		"LUKS_UUID="+luksUUID,
+		"FS_UUID="+fsUUID,
+		"LUKS_PASSWORD=567",
+		"FIDO2_PIN="+pin,
+	))
+	return
+}
+
 func waitForFile(filename string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 
@@ -314,6 +335,7 @@ type Opts struct {
 	asIso                bool // generate ISO file instead of *.raw
 	scriptEnvvars        []string
 	mountTimeout         int // in seconds
+	vmTimeout            time.Duration // QEMU VM timeout; 0 = use default (40s)
 	appendAllModAliases  bool
 	extraFiles           string
 	stripBinaries        bool
@@ -417,12 +439,16 @@ func buildVmInstance(t *testing.T, opts Opts) (*vmtest.Qemu, error) {
 		require.NoError(t, shell("generators/iso.sh", env...))
 	}
 
+	vmTimeout := opts.vmTimeout
+	if vmTimeout == 0 {
+		vmTimeout = 40 * time.Second
+	}
 	options := vmtest.QemuOptions{
 		Params:          params,
 		OperatingSystem: vmtest.OS_LINUX,
 		Disks:           disks,
 		Verbose:         testing.Verbose(),
-		Timeout:         40 * time.Second,
+		Timeout:         vmTimeout,
 	}
 	if isoFile != "" {
 		options.CdRom = isoFile


### PR DESCRIPTION
Extends `/etc/crypttab` support (built on the now-merged crypttab-core and libfido2 work) with the remaining advanced options. All features are opt-in via crypttab entry options and require no configuration changes when not used.

## New options

**`keyfile=/path:UUID=xxx`** — keyfile on a separate block device. Booster waits for the device, mounts it read-only, reads the key, then unmounts. `keyfile-timeout=` controls how long to wait (default: `mount_timeout`).

**`header=`** — detached LUKS header. Plain absolute paths are bundled into the initramfs at build time. The `/path:UUID=xxx` form mounts the header device at runtime; `/dev/...` uses the raw block device directly.

**`fido2-device=auto`** — activates FIDO2 token unlock. The generator auto-detects this option and bundles `fido2plugin.so` without requiring `enable_fido2: true` in the config. Init iterates attached FIDO2 devices, prompts for PIN (with Plymouth support), and falls back to the keyboard passphrase after `token-timeout=` elapses (default: 30 s).

**`tpm2-device=auto`** — activates TPM2 token unlock with the same priority scheduling and timeout behaviour as `fido2-device=`.

**`token-timeout=`** / **`keyfile-timeout=`** — accept a bare integer (seconds) or any Go duration string (e.g. `30s`, `2m`).

## Plymouth improvements

The switch from the `fido2-assert` subprocess to the native `go-libfido2` plugin gives the init binary fine-grained control over the FIDO2 assertion flow for the first time. Under `fido2-assert`, the subprocess handled device interaction internally and returned only a final result — there was no opportunity to surface intermediate state like "waiting for touch" or "PIN incorrect, try again" to the user. With the plugin, each stage of the assertion is visible to the caller, making meaningful status messages possible.

This is why the Plymouth integration is appearing here rather than in the Plymouth PR: the messages it carries are only meaningful now. Routing them to either Plymouth or the console throughout the unlock flow prompted a small `statusMessage()` helper in `plymouth.go` that avoids repeated if/else blocks. The TPM2 PIN prompt was also updated to route through Plymouth consistently — a gap that had existed since TPM2 support was first added.

## Testing

`TestCrypttabKeyfileDevice` and `TestCrypttabHeader` use static assets and run entirely in QEMU.

`TestCrypttabFido2` requires a hardware FIDO2 device but not a specific one — any device recognised by `fido2-token -L` works. It is skipped when `BOOSTER_TEST_FIDO2_PIN` is unset. The recommended invocation to avoid exposing the PIN in shell history:

```zsh
read -s "pin?FIDO2 PIN: " && echo
BOOSTER_TEST_FIDO2_PIN="$pin" go test -v -run TestCrypttabFido2 . 2>&1 | tee /tmp/fido2-test.log
```

During image creation the PIN is written only to a tmpfs file under `XDG_RUNTIME_DIR`, passed to `systemd-cryptenroll` via `CREDENTIALS_DIRECTORY`, and deleted immediately after enrolment — it never touches disk.

`TestCrypttabFido2NoDevice` covers the token-timeout → passphrase fallback path without any hardware, using a static image with a fake `systemd-fido2` LUKS token. This was the primary development vehicle for iterating on the fallback logic.

`TestCrypttabTPM2` verifies `tpm2-device=auto` using the `swtpm` software emulator.

Closes #319.