### PR TITLE
clevis: retry on USB transient errors during token recovery

### DIFF
--- a/init/luks.go
+++ b/init/luks.go
@@ -106,6 +106,13 @@ func recoverClevisPassword(t luks.Token, luksVersion int) ([]byte, error) {
 					// timed out waiting for tpm
 					return nil, err
 				}
+			} else if strings.Contains(err.Error(), "USB error") {
+				// USB device not yet ready (e.g. YubiKey still enumerating).
+				if time.Now().After(deadline) {
+					return nil, fmt.Errorf("timeout waiting for USB device")
+				}
+				time.Sleep(500 * time.Millisecond)
+				continue
 			} else if !errors.As(err, &netError) {
 				return nil, err
 			}


### PR DESCRIPTION
When a Clevis token backed by a USB device (e.g. YubiKey) fails with `"USB error: Resource temporarily unavailable"`, the device is still enumerating — the attempt is too early, not permanently broken.

`recoverClevisPassword()` already retries on network errors (up to 60 s) and TPM-not-found, but USB transient errors fell through to permanent failure. Add a third retry case: sleep 500ms and retry, bounded by the existing 60s deadline.

Fixes the race reported in #332, where LUKS unlock is attempted at ~1s but the YubiKey does not enumerate until ~1.4s and HID interfaces bind at ~1.6s.

Fixes #332.