### PR TITLE
fix PKGBUILD — remove duplicate libfido2 optdepend, explicit CGO_ENABLED=1 for init

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -13,7 +13,6 @@ makedepends=(git go ruby-ronn-ng libfido2)
 optdepends=(
   'busybox: to enable emergency shell at the boot time'
   'yubikey-personalization: for clevis Yubikey challenge-response support'
-  'libfido2: for systemd-enroll with FIDO2'
   'systemd-ukify: for generating UKIs'
   'binutils: to strip kernel modules'
 )
@@ -41,7 +40,7 @@ build() {
       -ldflags "-linkmode external -extldflags \"${LDFLAGS}\""
 
   cd ../init
-  go build -trimpath -mod=readonly -modcacherw
+  CGO_ENABLED=1 go build -trimpath -mod=readonly -modcacherw
 
   cd fido2plugin
   CGO_ENABLED=1 CGO_CPPFLAGS="${CPPFLAGS}" CGO_CFLAGS="${CFLAGS}" CGO_CXXFLAGS="${CXXFLAGS}" CGO_LDFLAGS="${LDFLAGS}" \


### PR DESCRIPTION
  ---                                                                                                                                                                                           
  Two small fixes to the Arch PKGBUILD introduced alongside the fido2plugin.so support:                                                                                                         
                                                                                                                                                                                                
  1. Remove libfido2 from optdepends                                                                                                                                                            
                                                                                                                                                                                                
  libfido2 is already in makedepends. Listing it in both is contradictory — optdepends signals "install this at runtime if you want the feature," but a makedepend means it's already required to build the package. The entry was redundant and would confuse users expecting to opt in at install time.
                                                                                                                                                                                                
  2. Explicit CGO_ENABLED=1 on the init build                                                                                                                                                   
   
  The init binary must be built with CGO enabled so that fido2_cgo.go (the runtime plugin-loader) is compiled in instead of the stub fido2_nocgo.go. Previously this relied on the Go toolchain's implicit default (CGO=1 when a C compiler is present), which is fragile. Making it explicit ensures the correct code path is always compiled regardless of build environment.
                                                                                                                                                                                                
  Background: fido2plugin.so is dynamically loaded by init at boot via plugin.Open(). This mechanism requires CGO_ENABLED=1 at init build time — the //go:build cgo tag on fido2_cgo.go controls which file compiles. With CGO_ENABLED=0 (the previous default), the build silently selects fido2_nocgo.go which returns "FIDO2 not supported in this build" unconditionally, regardless of whether fido2plugin.so is present in the initramfs.                                                                                                                                           
                  
  ---
  The AUR booster-git PKGBUILD also needs to be updated — otherwise it will still use CGO_ENABLED=0 and wont build or install fido2plugin.so at all. 