### PR TITLE
init: cache passphrases for multi-device LUKS unlock (closes #306)

### DIFF
--- a/init/luks.go
+++ b/init/luks.go
@@ -65,6 +65,14 @@ func tryPassphraseAgainstSlots(volumes chan *luks.Volume, done <-chan struct{}, 
 	return false
 }
 
+// passphraseCache holds passwords that successfully unlocked a LUKS volume during
+// this boot, so subsequent volumes (e.g. btrfs RAID1 members) can be tried
+// automatically without prompting the user again.
+var passphraseCache struct {
+	sync.Mutex
+	passwords [][]byte
+}
+
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
 var rdLuksOptions = map[string]string{
 	"discard":                luks.FlagAllowDiscards,
@@ -503,6 +511,19 @@ func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d 
 	// plymouthd is still starting, causing the graphical prompt to fail.
 	waitForPlymouthInit()
 
+	// Fast path: try passwords that already unlocked another volume this boot
+	// (e.g. two LUKS members of a btrfs RAID1 with the same passphrase).
+	passphraseCache.Lock()
+	cached := make([][]byte, len(passphraseCache.passwords))
+	copy(cached, passphraseCache.passwords)
+	passphraseCache.Unlock()
+
+	for _, pw := range cached {
+		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, pw) {
+			return
+		}
+	}
+
 	attempts := 0
 	promptPrefix := ""
 	for {
@@ -533,6 +554,9 @@ func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d 
 		attempts++
 
 		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, password) {
+			passphraseCache.Lock()
+			passphraseCache.passwords = append(passphraseCache.passwords, password)
+			passphraseCache.Unlock()
 			statusMessage("") // clear any error message before Plymouth quits
 			return
 		}

--- a/init/luks.go
+++ b/init/luks.go
@@ -73,6 +73,14 @@ var passphraseCache struct {
 	passwords [][]byte
 }
 
+// keyboardMu serializes keyboard password prompts across concurrent luksOpen calls.
+// Without this, two devices unlocked simultaneously (e.g. root + swap LUKS, or
+// btrfs RAID1 members) both check passphraseCache before either has stored a
+// successful password, causing a double prompt. Holding the mutex ensures the
+// second device re-checks the cache after the first has finished prompting and
+// stored its passphrase.
+var keyboardMu sync.Mutex
+
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
 var rdLuksOptions = map[string]string{
 	"discard":                luks.FlagAllowDiscards,
@@ -511,10 +519,42 @@ func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d 
 	// plymouthd is still starting, causing the graphical prompt to fail.
 	waitForPlymouthInit()
 
+	// Bail early if the device was already unlocked by a token goroutine.
+	select {
+	case <-done:
+		return
+	default:
+	}
+
 	// Fast path: try passwords that already unlocked another volume this boot
 	// (e.g. two LUKS members of a btrfs RAID1 with the same passphrase).
 	passphraseCache.Lock()
 	cached := make([][]byte, len(passphraseCache.passwords))
+	copy(cached, passphraseCache.passwords)
+	passphraseCache.Unlock()
+
+	for _, pw := range cached {
+		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, pw) {
+			return
+		}
+	}
+
+	// Serialize prompts across concurrent luksOpen calls. A second device whose
+	// keyboard goroutine starts while the first device is prompting will block
+	// here, then re-check the cache after the first device succeeds and releases
+	// the lock — avoiding a double prompt for shared passphrases (issue #306).
+	keyboardMu.Lock()
+	defer keyboardMu.Unlock()
+
+	// Re-check after acquiring the lock: another device may have just unlocked.
+	select {
+	case <-done:
+		return
+	default:
+	}
+
+	passphraseCache.Lock()
+	cached = make([][]byte, len(passphraseCache.passwords))
 	copy(cached, passphraseCache.passwords)
 	passphraseCache.Unlock()
 

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -68,6 +68,24 @@ var assetGenerators = map[string]assetGenerator{
 	"systemd-tpm2.img":          {"systemd_tpm2.sh", []string{"LUKS_UUID=5cbc48ce-0e78-4c6b-ac90-a8a540514b90", "FS_UUID=d8673e36-d4a3-4408-a87d-be0cb79f91a2", "LUKS_PASSWORD=567"}},
 	"systemd-tpm2-withpin.img":  {"systemd_tpm2.sh", []string{"LUKS_UUID=8bb97618-7ef4-4c93-b4f7-f2cb17cf7da1", "FS_UUID=26dbbe17-9af9-4322-bb5f-c1d74a40e618", "LUKS_PASSWORD=9999", "CRYPTENROLL_TPM2_PIN=foo654"}},
 	"systemd-recovery.img":      {"systemd_recovery.sh", []string{"LUKS_UUID=62020168-58b9-4095-a3d0-176403353d20", "FS_UUID=b0cfeb48-c1e2-459d-a327-4d611804ac24", "LUKS_PASSWORD=2211"}},
+	// luks2.shared_pass.img: GPT disk with two LUKS2 partitions sharing the same
+	// passphrase.  Partition 1 has no inner filesystem; partition 2 has ext4.
+	// Used by TestPassphraseCache to verify single-prompt unlock (issue #306).
+	"luks2.shared_pass.img": {"luks_shared_pass.sh", []string{
+		"LUKS_UUID1=a4c8e2f6-1b3d-4678-9ace-0f2468ace024",
+		"LUKS_UUID2=b5d9f307-2c4e-4789-ab1f-1e3579bdf135",
+		"FS_UUID=c6ea04b8-3d5f-4890-bc2e-2f468ace0246",
+		"LUKS_PASSWORD=1234",
+	}},
+	// luks2.btrfs_raid1.img: GPT disk with two LUKS2 partitions each wrapping a
+	// btrfs RAID1 member, both sharing the same passphrase.
+	// Used by TestLuksBtrfsRaid1 to verify single-prompt unlock of LUKS-on-btrfs.
+	"luks2.btrfs_raid1.img": {"luks_btrfs_raid1.sh", []string{
+		"LUKS_UUID1=d7fb15c9-4e6a-4901-cd3f-3a579bdf1357",
+		"LUKS_UUID2=e8ac26da-5f7b-4012-de40-4b68ace02468",
+		"FS_UUID=f9bd37eb-607c-4123-ef51-5c79bdf13579",
+		"LUKS_PASSWORD=1234",
+	}},
 	"swap.raw":                  {"swap.sh", nil},
 	"zfs.img":                   {"zfs.sh", nil},
 	"zfs_encrypted.img":         {"zfs.sh", []string{"ZFS_PASSPHRASE=encrypted"}},

--- a/tests/generators/luks_btrfs_raid1.sh
+++ b/tests/generators/luks_btrfs_raid1.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Creates a single GPT disk with two LUKS2 partitions, each wrapping one member
+# of a btrfs RAID1 volume.  Both partitions share the same passphrase.
+#
+#   Partition 1: LUKS2, UUID=$LUKS_UUID1 → btrfs RAID1 member
+#   Partition 2: LUKS2, UUID=$LUKS_UUID2 → btrfs RAID1 member
+#   btrfs filesystem UUID: $FS_UUID
+#
+# Used by TestLuksBtrfsRaid1 to verify that both LUKS members unlock with a
+# single passphrase prompt and btrfs assembles correctly.
+#
+# Required env vars:
+#   OUTPUT        path for the disk image
+#   LUKS_UUID1    UUID of the first  LUKS2 container
+#   LUKS_UUID2    UUID of the second LUKS2 container
+#   FS_UUID       UUID of the btrfs filesystem spanning both containers
+#   LUKS_PASSWORD passphrase used for both LUKS containers
+
+set -o errexit
+
+lodev=
+dir=
+MAPPER1="luks-btrfs1-${LUKS_UUID1}"
+MAPPER2="luks-btrfs2-${LUKS_UUID2}"
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  [ -n "${dir}" ] && { sudo umount "${dir}" 2>/dev/null; rm -rf "${dir}"; }
+  sudo cryptsetup close "${MAPPER1}" 2>/dev/null || true
+  sudo cryptsetup close "${MAPPER2}" 2>/dev/null || true
+  [ -n "${lodev}" ] && sudo losetup -d "${lodev}"
+}
+
+truncate --size 450M "${OUTPUT}"
+lodev=$(sudo losetup -f -P --show "${OUTPUT}" | grep -m1 '^/dev/')
+
+sudo parted -s "${lodev}" mklabel gpt \
+  mkpart member1 2MiB 224MiB \
+  mkpart member2 224MiB 446MiB
+
+sudo partprobe "${lodev}"
+sleep 0.5
+
+sudo cryptsetup luksFormat --uuid "${LUKS_UUID1}" --type luks2 "${lodev}p1" <<< "${LUKS_PASSWORD}"
+sudo cryptsetup luksFormat --uuid "${LUKS_UUID2}" --type luks2 "${lodev}p2" <<< "${LUKS_PASSWORD}"
+
+sudo cryptsetup open "${lodev}p1" "${MAPPER1}" <<< "${LUKS_PASSWORD}"
+sudo cryptsetup open "${lodev}p2" "${MAPPER2}" <<< "${LUKS_PASSWORD}"
+
+sudo mkfs.btrfs -f --uuid "${FS_UUID}" -d raid1 -m raid1 \
+  "/dev/mapper/${MAPPER1}" "/dev/mapper/${MAPPER2}"
+
+dir=$(mktemp -d)
+sudo mount "/dev/mapper/${MAPPER1}" "${dir}"
+sudo chown "${USER}" "${dir}"
+mkdir "${dir}/sbin"
+cp assets/init "${dir}/sbin/init"

--- a/tests/generators/luks_shared_pass.sh
+++ b/tests/generators/luks_shared_pass.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Creates a single GPT disk with two LUKS2 partitions sharing the same passphrase.
+#
+#   Partition 1 (extra): LUKS2, UUID=$LUKS_UUID1 — no inner filesystem
+#   Partition 2 (root):  LUKS2, UUID=$LUKS_UUID2 → ext4, UUID=$FS_UUID
+#
+# Used by TestPassphraseCache to verify that when two concurrent LUKS unlocks
+# share the same passphrase the user is prompted exactly once (issue #306).
+#
+# Required env vars:
+#   OUTPUT        path for the disk image
+#   LUKS_UUID1    UUID of the first (extra) LUKS2 container
+#   LUKS_UUID2    UUID of the second (root)  LUKS2 container
+#   FS_UUID       UUID of the ext4 filesystem inside the root container
+#   LUKS_PASSWORD passphrase used for both LUKS containers
+
+set -o errexit
+
+lodev=
+dir=
+MAPPER="luks-root-${LUKS_UUID2}"
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  [ -n "${dir}" ] && { sudo umount "${dir}" 2>/dev/null; rm -rf "${dir}"; }
+  sudo cryptsetup close "${MAPPER}" 2>/dev/null || true
+  [ -n "${lodev}" ] && sudo losetup -d "${lodev}"
+}
+
+truncate --size 60M "${OUTPUT}"
+lodev=$(sudo losetup -f -P --show "${OUTPUT}" | grep -m1 '^/dev/')
+
+sudo parted -s "${lodev}" mklabel gpt \
+  mkpart extra 2MiB 28MiB \
+  mkpart root  28MiB 58MiB
+
+sudo partprobe "${lodev}"
+sleep 0.5
+
+sudo cryptsetup luksFormat --uuid "${LUKS_UUID1}" --type luks2 "${lodev}p1" <<< "${LUKS_PASSWORD}"
+sudo cryptsetup luksFormat --uuid "${LUKS_UUID2}" --type luks2 "${lodev}p2" <<< "${LUKS_PASSWORD}"
+
+sudo cryptsetup open "${lodev}p2" "${MAPPER}" <<< "${LUKS_PASSWORD}"
+sudo mkfs.ext4 -U "${FS_UUID}" "/dev/mapper/${MAPPER}"
+dir=$(mktemp -d)
+sudo mount "/dev/mapper/${MAPPER}" "${dir}"
+sudo chown "${USER}" "${dir}"
+mkdir "${dir}/sbin"
+cp assets/init "${dir}/sbin/init"

--- a/tests/luks_test.go
+++ b/tests/luks_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -82,6 +83,73 @@ func TestLoadableCryptoModule(t *testing.T) {
 	defer vm.Shutdown()
 
 	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+const (
+	sharedPassLuksUUID1 = "a4c8e2f6-1b3d-4678-9ace-0f2468ace024"
+	sharedPassLuksUUID2 = "b5d9f307-2c4e-4789-ab1f-1e3579bdf135"
+	sharedPassFsUUID    = "c6ea04b8-3d5f-4890-bc2e-2f468ace0246"
+
+	luksRaid1LuksUUID1 = "d7fb15c9-4e6a-4901-cd3f-3a579bdf1357"
+	luksRaid1LuksUUID2 = "e8ac26da-5f7b-4012-de40-4b68ace02468"
+	luksRaid1FsUUID    = "f9bd37eb-607c-4123-ef51-5c79bdf13579"
+)
+
+// TestPassphraseCache verifies that when two LUKS devices share the same
+// passphrase (the root+data scenario from issue #306) the user is prompted
+// exactly once and the second device unlocks automatically from the in-memory
+// passphrase cache.
+//
+// The root filesystem lives inside the second LUKS partition so that if a
+// spurious second prompt appears and goes unanswered, root never mounts and
+// the test times out — giving a reliable regression signal.
+func TestPassphraseCache(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.shared_pass.img"))
+
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptextra UUID="+sharedPassLuksUUID1+" none x-initrd.attach\n"+
+			"cryptroot  UUID="+sharedPassLuksUUID2+" none x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.shared_pass.img",
+		kernelArgs:   []string{"root=UUID=" + sharedPassFsUUID},
+		crypttabFile: crypttabPath,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for"))
+	require.NoError(t, vm.ConsoleWrite("1234\n"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestLuksBtrfsRaid1 verifies that a btrfs RAID1 volume whose two members are
+// each wrapped in LUKS2 boots with a single passphrase prompt.  Both LUKS
+// devices must be unlocked before btrfs can assemble, so if the passphrase
+// cache fails to supply the second device's key the root never mounts and the
+// test times out.
+func TestLuksBtrfsRaid1(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.btrfs_raid1.img"))
+
+	crypttabPath := filepath.Join(t.TempDir(), "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"luks-btrfs1 UUID="+luksRaid1LuksUUID1+" none x-initrd.attach\n"+
+			"luks-btrfs2 UUID="+luksRaid1LuksUUID2+" none x-initrd.attach\n",
+	), 0o644))
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:         "assets/luks2.btrfs_raid1.img",
+		kernelArgs:   []string{"root=UUID=" + luksRaid1FsUUID},
+		crypttabFile: crypttabPath,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for"))
 	require.NoError(t, vm.ConsoleWrite("1234\n"))
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
 }


### PR DESCRIPTION
When multiple LUKS volumes share the same passphrase — the common
root+swap or btrfs RAID1 layout — booster previously prompted for each
device separately. This PR implements a passphrase cache so the user is
prompted exactly once.

**init/luks.go**
- `passphraseCache`: mutex-protected in-memory store of passphrases that
  successfully unlocked a volume during this boot
- `tryPassphraseAgainstSlots`: helper to try a passphrase against a
  device's key slots without going through the prompt loop
- `requestKeyboardPassword`: fast-path tries cached passphrases before
  prompting; stores passphrase in cache on success
- `keyboardMu`: global mutex serializing keyboard prompts across
  concurrent luksOpen goroutines — without this, the race between "check
  cache" and "store passphrase" means both goroutines see an empty cache
  and both prompt; with it, the second goroutine re-checks after the
  first completes and typically unlocks silently

The cache is intentionally scoped to keyboard-entered passphrases only.
Token secrets (FIDO2, TPM2, clevis) are device- or policy-specific and
not meaningful to share. Holding the passphrase as plaintext in RAM
during the initrd phase follows the same approach as systemd-cryptsetup
(which caches passphrases across crypttab entries by default) and
dracut's crypt module — both treat the initrd memory space as trusted,
since there is no swap, no other processes, and no persistent storage
written at that stage.

**Tests**
- `TestPassphraseCache`: two LUKS2 partitions, shared passphrase, root
  on partition 2; a second unanswered prompt prevents root from mounting,
  making cache failures reliably detectable as a timeout
- `TestLuksBtrfsRaid1`: two LUKS2-wrapped btrfs RAID1 members; both
  must unlock before btrfs assembles, making cache failures
  structurally impossible to hide

Closes #306