### PR TITLE
generator: include usbhid and hid_generic when FIDO2 is enabled

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -292,6 +292,16 @@ func generateInitRamfs(conf *generatorConfig) error {
 		}
 	}
 
+	if conf.enableFido2 {
+		// FIDO2 security keys are USB HID devices. In host-specific mode,
+		// usbhid and hid_generic may be absent if no USB HID device is
+		// connected at build time. Include them unconditionally so the key
+		// is recognized when plugged in during the passphrase prompt.
+		if err := kmod.activateModules(false, false, "usbhid", "hid_generic"); err != nil {
+			return err
+		}
+	}
+
 	if err := kmod.resolveDependencies(); err != nil {
 		return err
 	}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -64,6 +64,7 @@ type options struct {
 	vConsoleConfig, localeConfig string
 	enableMdraid                 bool
 	mdraidConfigPath             string
+	enableFido2                  bool
 }
 
 func generateAliasesFile(aliases []alias) []byte {
@@ -162,8 +163,17 @@ func createTestInitRamfs(t *testing.T, o *options) {
 		compression = "none"
 	}
 
+	initBinary := "/usr/bin/false"
+	if o.enableFido2 {
+		// fido2plugin.so is read from the same directory as the init binary.
+		// Create dummy stand-ins in the work directory so the generator can find them.
+		initBinary = wd + "/init"
+		require.NoError(t, os.WriteFile(initBinary, []byte("dummy"), 0o755))
+		require.NoError(t, os.WriteFile(wd+"/fido2plugin.so", []byte("dummy"), 0o755))
+	}
+
 	conf := generatorConfig{
-		initBinary:          "/usr/bin/false",
+		initBinary:          initBinary,
 		compression:         compression,
 		universal:           o.universal,
 		kernelVersion:       "matestkernel",
@@ -178,6 +188,7 @@ func createTestInitRamfs(t *testing.T, o *options) {
 		enableLVM:           o.enableLVM,
 		enableMdraid:        o.enableMdraid,
 		mdraidConfigPath:    o.mdraidConfigPath,
+		enableFido2:         o.enableFido2,
 		crypttabFile:        "/dev/null", // tests run without root; avoid reading /etc/crypttab
 	}
 	if o.vConsoleConfig != "" {
@@ -413,6 +424,24 @@ pci:v*d*sv*sd*bc0Csc03i30* cbc`
 	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/whiteheat.fw.zst")
 	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/usbdux_firmware.bin.zst")
 	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/rtw88/rtw8723d_fw.bin.zst")
+}
+
+func TestFido2HostModeIncludesUsbHid(t *testing.T) {
+	// Regression test for https://github.com/anatol/booster/issues/277.
+	// In host-specific mode, usbhid and hid_generic must be included when
+	// enable_fido2 is set, even if no USB HID device was connected at build time
+	// (i.e. neither module appears in the host's loaded-module list).
+	opts := options{
+		universal:        false,
+		prepareModulesAt: []string{"kernel/drivers/hid/usbhid.ko", "kernel/drivers/hid/hid_generic.ko"},
+		hostModules:      []string{}, // no USB HID modules loaded at build time
+		enableFido2:      true,
+		unpackImage:      true,
+	}
+	createTestInitRamfs(t, &opts)
+
+	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/modules/usbhid.ko")
+	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/modules/hid_generic.ko")
 }
 
 func TestExtraFiles(t *testing.T) {


### PR DESCRIPTION
## Summary

- In host-specific mode, `usbhid` and `hid_generic` may be absent from the image if no USB HID device is connected at build time
- When a FIDO2 key is plugged in at boot, the kernel cannot load the driver, the udev bind event never fires, and `usbhidWg.Wait()` in `recoverFido2Password` blocks indefinitely
- Fix: when `conf.enableFido2` is true (set via `enable_fido2` in booster.yaml or auto-detected from a `fido2-device=` crypttab entry), activate `usbhid` and `hid_generic` with `filter=false` so they are unconditionally included in host-specific images

Force-loading is intentionally avoided. Boot opens the netlink socket inside the `udevListener` goroutine, then immediately calls `loadModules` on the main goroutine. If `usbhid` were force-loaded, it could bind to an already-connected key before the netlink socket exists, dropping the bind event. `usbhidWg.Wait()` would then block forever waiting for an event that already fired. The existing wait-group approach (added in 31d06a4) is correct — the modules just need to be present in the image.

Adds a generator unit test: places `usbhid` and `hid_generic` in the simulated modules directory with an empty `hostModules` list, enables FIDO2, and asserts both modules appear in the output image.

Closes #277.