### PR TITLE
init: fix rd.luks.name suppressing crypttab fido2-device= and token unlock race

### DIFF
--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -176,15 +176,50 @@ func parseCrypttabDuration(s string) (time.Duration, error) {
 	return time.ParseDuration(s)
 }
 
-// luksMatchExists reports whether luksMappings already contains an entry for ref,
-// allowing rd.luks.* kernel parameters to take precedence over crypttab.
-func luksMatchExists(ref *deviceRef) bool {
+// findLuksMapping returns the existing luksMapping for ref, or nil if not found.
+func findLuksMapping(ref *deviceRef) *luksMapping {
 	for _, m := range luksMappings {
 		if deviceRefEqual(m.ref, ref) {
-			return true
+			return m
 		}
 	}
-	return false
+	return nil
+}
+
+// mergeCrypttabOptions merges security-relevant options from a crypttab entry (src)
+// into a cmdline-derived mapping (dst). dst's ref and name are preserved; crypttab
+// supplies token flags, keyfile, header, and other unlock options that rd.luks.*
+// params cannot express.
+func mergeCrypttabOptions(dst, src *luksMapping) {
+	if src.tokenFido2 {
+		dst.tokenFido2 = true
+	}
+	if src.tokenTpm2 {
+		dst.tokenTpm2 = true
+	}
+	// Adopt crypttab's token timeout when the cmdline mapping still has the
+	// default (30 s) and the crypttab entry carries an explicit value.
+	if src.tokenTimeout > 0 && src.tokenTimeout != dst.tokenTimeout {
+		dst.tokenTimeout = src.tokenTimeout
+	}
+	if dst.keyfile == "" && src.keyfile != "" {
+		dst.keyfile = src.keyfile
+		dst.keyfileDeviceRef = src.keyfileDeviceRef
+		dst.keyfileOffset = src.keyfileOffset
+		dst.keyfileSize = src.keyfileSize
+		dst.keyfileTimeout = src.keyfileTimeout
+	}
+	if dst.keySlot == -1 && src.keySlot != -1 {
+		dst.keySlot = src.keySlot
+	}
+	if dst.tries == 0 && src.tries != 0 {
+		dst.tries = src.tries
+	}
+	if dst.header == "" && src.header != "" {
+		dst.header = src.header
+		dst.headerDeviceRef = src.headerDeviceRef
+	}
+	dst.options = append(dst.options, src.options...)
 }
 
 // deviceRefEqual reports whether two deviceRefs refer to the same device.

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -244,12 +245,101 @@ func TestParseCrypttabXInitrdAttachIgnored(t *testing.T) {
 	}
 }
 
-// fido2-device= is silently ignored — deferred to pr/crypttab-fido2.
-func TestParseCrypttabFido2DeviceIgnored(t *testing.T) {
+func TestParseCrypttabFido2Device(t *testing.T) {
 	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none fido2-device=auto\n"
 	mappings, err := parseCrypttabReader(strings.NewReader(input))
 	require.NoError(t, err)
 	require.Len(t, mappings, 1)
+	require.True(t, mappings[0].tokenFido2)
+	require.Equal(t, 30*time.Second, mappings[0].tokenTimeout)
+}
+
+func TestParseCrypttabTpm2Device(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tpm2-device=auto\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.True(t, mappings[0].tokenTpm2)
+	require.Equal(t, 30*time.Second, mappings[0].tokenTimeout)
+}
+
+func TestFindLuksMapping(t *testing.T) {
+	uuid1, _ := parseUUID("ab6d7d78-b816-4495-928d-766d6607035e")
+	uuid2, _ := parseUUID("7843d77f-cdd6-4289-a4de-a708c4aacede")
+	m1 := &luksMapping{ref: &deviceRef{format: refFsUUID, data: uuid1}, name: "one"}
+	m2 := &luksMapping{ref: &deviceRef{format: refFsUUID, data: uuid2}, name: "two"}
+	orig := luksMappings
+	defer func() { luksMappings = orig }()
+
+	luksMappings = []*luksMapping{m1, m2}
+	require.Equal(t, m1, findLuksMapping(m1.ref))
+	require.Equal(t, m2, findLuksMapping(m2.ref))
+
+	uuid3, _ := parseUUID("7f28c723-fd6b-4640-bc94-9366edd8880d")
+	require.Nil(t, findLuksMapping(&deviceRef{format: refFsUUID, data: uuid3}))
+}
+
+func TestMergeCrypttabOptions(t *testing.T) {
+	dst := &luksMapping{name: "cmdline-name", keySlot: -1, tokenTimeout: 30 * time.Second}
+	src := &luksMapping{
+		tokenFido2:  true,
+		tokenTpm2:   false,
+		tries:       3,
+		tokenTimeout: 45 * time.Second,
+	}
+	mergeCrypttabOptions(dst, src)
+	require.True(t, dst.tokenFido2)
+	require.False(t, dst.tokenTpm2)
+	require.Equal(t, 3, dst.tries)
+	require.Equal(t, 45*time.Second, dst.tokenTimeout)
+	require.Equal(t, "cmdline-name", dst.name) // name must not be overwritten
+}
+
+func TestMergeCrypttabOptionsDstWins(t *testing.T) {
+	dst := &luksMapping{keyfile: "/cmdline/key", keySlot: 2, tries: 5, header: "/cmdline/hdr"}
+	src := &luksMapping{keyfile: "/crypttab/key", keySlot: 1, tries: 9, header: "/crypttab/hdr"}
+	mergeCrypttabOptions(dst, src)
+	require.Equal(t, "/cmdline/key", dst.keyfile)  // cmdline keyfile wins
+	require.Equal(t, 2, dst.keySlot)               // cmdline key-slot wins
+	require.Equal(t, 5, dst.tries)                 // cmdline tries wins
+	require.Equal(t, "/cmdline/hdr", dst.header)   // cmdline header wins
+}
+
+// Regression test: rd.luks.name on the kernel cmdline must not suppress
+// fido2-device= / tpm2-device= options from crypttab for the same UUID.
+// Before the fix, the cmdline mapping silently dropped crypttab security
+// options, leaving tokenFido2=false and causing a spurious passphrase prompt
+// after a successful FIDO2 PIN+touch unlock.
+func TestRdLuksNamePreservesCrypttabFido2(t *testing.T) {
+	const uuidStr = "ab6d7d78-b816-4495-928d-766d6607035e"
+	orig := luksMappings
+	defer func() { luksMappings = orig }()
+
+	luksMappings = nil
+	require.NoError(t, parseParams(
+		"rd.luks.name="+uuidStr+"=cryptroot root=/dev/mapper/cryptroot",
+	))
+	require.Len(t, luksMappings, 1)
+	require.Equal(t, "cryptroot", luksMappings[0].name)
+	require.False(t, luksMappings[0].tokenFido2, "tokenFido2 should be false before crypttab merge")
+
+	// Simulate the crypttab merge loop from boost().
+	ctInput := "cryptroot UUID=" + uuidStr + " none fido2-device=auto\n"
+	ctMappings, err := parseCrypttabReader(strings.NewReader(ctInput))
+	require.NoError(t, err)
+	for _, cm := range ctMappings {
+		if existing := findLuksMapping(cm.ref); existing != nil {
+			mergeCrypttabOptions(existing, cm)
+		} else {
+			luksMappings = append(luksMappings, cm)
+		}
+	}
+
+	require.Len(t, luksMappings, 1, "should still be one mapping, not two")
+	m := luksMappings[0]
+	require.Equal(t, "cryptroot", m.name, "cmdline name must be preserved")
+	require.True(t, m.tokenFido2, "fido2-device= from crypttab must be merged in")
+	require.Equal(t, 30*time.Second, m.tokenTimeout, "token timeout must be set for FIDO2")
 }
 
 // header= is silently ignored — deferred to pr/crypttab-header.

--- a/init/luks.go
+++ b/init/luks.go
@@ -768,13 +768,17 @@ func luksOpen(dev string, mapping *luksMapping) error {
 				}
 			}()
 		} else {
-			// Non-priority token (or no priority mode): fire-and-forget w.r.t. keyboard timing.
+			// Non-priority token: fire-and-forget w.r.t. keyboard *timing*, but
+			// close done on success so the waiter never races to start the keyboard
+			// after a successful token unlock.
 			senderWg.Add(1)
 			tokenWg.Add(1)
 			go func() {
 				defer senderWg.Done()
 				defer tokenWg.Done()
-				recoverTokenPassword(volumes, done, d, t, mapping.name)
+				if recoverTokenPassword(volumes, done, d, t, mapping.name) {
+					closeDone.Do(func() { close(done) })
+				}
 			}()
 		}
 		for _, s := range t.Slots {

--- a/init/main.go
+++ b/init/main.go
@@ -1057,13 +1057,18 @@ func boost() error {
 		return err
 	}
 
-	// Merge /etc/crypttab entries for devices not already covered by rd.luks.* params.
-	// rd.luks.* kernel parameters take precedence over crypttab.
+	// Merge /etc/crypttab entries with cmdline-derived mappings.
+	// rd.luks.* kernel parameters take precedence for device ref and name;
+	// crypttab supplies security options (fido2-device=, tpm2-device=, keyfile,
+	// header, tries, …) that rd.luks.* cannot express. When both sources cover
+	// the same device, merge rather than discard the crypttab entry.
 	if ctMappings, err := parseCrypttab(); err != nil {
 		warning("crypttab: %v", err)
 	} else {
 		for _, cm := range ctMappings {
-			if !luksMatchExists(cm.ref) {
+			if existing := findLuksMapping(cm.ref); existing != nil {
+				mergeCrypttabOptions(existing, cm)
+			} else {
 				luksMappings = append(luksMappings, cm)
 			}
 		}


### PR DESCRIPTION
Previously, when `rd.luks.*` kernel parameters and `/etc/crypttab` both described
the same device, the crypttab entry was silently discarded — kernel parameters
overrode crypttab entirely. This dropped security options like `fido2-device=` and
`tpm2-device=` that have no `rd.luks.*` equivalent. The fix merges rather than
discards: kernel parameters retain authority over device ref and mapping name,
while crypttab supplies token flags, keyfile, header, and other unlock options that
the cmdline cannot express.

This surfaced as a spurious passphrase prompt after a successful FIDO2 PIN+touch
unlock when `rd.luks.name=<UUID>=<name>` was present on the kernel cmdline
alongside `fido2-device=auto` in `/etc/crypttab`.

## Bug 1 — crypttab options silently dropped

When `rd.luks.name=<UUID>=<name>` is parsed, `findOrCreateLuksMapping` creates a
mapping with `tokenFido2=false`. The crypttab merge loop then saw
`luksMatchExists=true` for the same UUID and skipped the crypttab entry entirely,
dropping `fido2-device=auto` and any other crypttab unlock options.

With `tokenFido2=false`, `hasPriority=false`, so the FIDO2 token ran in the
non-priority branch which does not defer the keyboard prompt until after token
completion.

**Fix:** replace skip-if-exists with `mergeCrypttabOptions`, which copies token
flags, keyfile, keySlot, tries, header, tokenTimeout, and dm-crypt flags from the
crypttab entry into the cmdline-derived mapping. The cmdline's name and device ref
are preserved; crypttab augments the rest.

## Bug 2 — race between tokenWg.Done and close(done)

In the non-priority goroutine, `recoverTokenPassword` sends to `volumes` (triggering
the main thread's `close(done)`), returns, then `defer tokenWg.Done()` runs. These
two events are in different goroutines with no ordering guarantee: if `tokenWg.Done`
fires first, the waiter unblocks, sees `done` still open, and calls `startKeyboard`
— showing a passphrase prompt even though the volume is already unlocked.

**Fix:** call `closeDone.Do(func() { close(done) })` inside the non-priority
goroutine on success, before the deferred `tokenWg.Done` runs — matching the
priority branch and eliminating the race.

## Testing

- Unit tests in `init/crypttab_test.go` including `TestRdLuksNamePreservesCrypttabFido2`
  which reproduces the exact regression path
- Verified with a live boot: `rd.luks.name` present + `fido2-device=auto` in
  `/etc/crypttab`, FIDO2 PIN+touch unlock completes with no follow-on passphrase prompt