### PR TITLE
vconsole: fix FONT_MAP/FONT_UNIMAP resolution and make setfont non-fatal

### DIFF
--- a/generator/console.go
+++ b/generator/console.go
@@ -13,8 +13,31 @@ import (
 	"strings"
 )
 
-// path to console fonts, adjust it to your distro (e.g. Fedora uses /usr/lib/kbd/consolefonts path for it)
-var consolefontsDir = "/usr/share/kbd/consolefonts/"
+// kbdBaseDir is the root of the kbd data tree. Arch/Debian/openSUSE/Alpine use
+// /usr/share/kbd; Fedora/RHEL use /usr/lib/kbd. Probe at startup so the generator
+// works on any distro without configuration.
+var kbdBaseDir = func() string {
+	for _, d := range []string{"/usr/share/kbd", "/usr/lib/kbd"} {
+		if _, err := os.Stat(filepath.Join(d, "consolefonts")); err == nil {
+			return d
+		}
+	}
+	return "/usr/share/kbd"
+}()
+
+var (
+	consolefontsDir = filepath.Join(kbdBaseDir, "consolefonts")
+	consoletransDir = filepath.Join(kbdBaseDir, "consoletrans")
+	unimapsDir      = filepath.Join(kbdBaseDir, "unimaps")
+)
+
+// Suffix lists mirror kbd's kfont_context defaults (src/libkfont/context.c).
+// kbdfile_find resolves a name by trying name+suffix for each suffix in order.
+var (
+	consolefontsSuffixes = []string{"", ".psfu", ".psf", ".cp", ".fnt"}
+	consoletransSuffixes = []string{"", ".trans", "_to_uni.trans", ".acm"}
+	unimapsSuffixes      = []string{"", ".uni", ".sfm"}
+)
 
 func (img *Image) enableVirtualConsole(vConsolePath, localePath string) (*VirtualConsole, error) {
 	debug("enabling virtual console")
@@ -62,7 +85,7 @@ func (img *Image) enableVirtualConsole(vConsolePath, localePath string) (*Virtua
 			return nil, err
 		}
 
-		blob, err := readFontFile(font)
+		blob, err := findKbdFile(consolefontsDir, font, consolefontsSuffixes)
 		if err != nil {
 			return nil, err
 		}
@@ -72,23 +95,23 @@ func (img *Image) enableVirtualConsole(vConsolePath, localePath string) (*Virtua
 		}
 
 		if m, ok := vprop["FONT_MAP"]; ok {
-			blob, err := readFontFile(m)
+			blob, err := findKbdFile(consoletransDir, m, consoletransSuffixes)
 			if err != nil {
 				return nil, err
 			}
-			conf.FontFile = "/console/font.map"
-			if err := img.AppendContent(conf.FontFile, 0o644, blob); err != nil {
+			conf.FontMapFile = "/console/font.map"
+			if err := img.AppendContent(conf.FontMapFile, 0o644, blob); err != nil {
 				return nil, err
 			}
 		}
 
 		if u, ok := vprop["FONT_UNIMAP"]; ok {
-			blob, err := readFontFile(u)
+			blob, err := findKbdFile(unimapsDir, u, unimapsSuffixes)
 			if err != nil {
 				return nil, err
 			}
-			conf.FontFile = "/console/font.unimap"
-			if err := img.AppendContent(conf.FontFile, 0o644, blob); err != nil {
+			conf.FontUnicodeFile = "/console/font.unimap"
+			if err := img.AppendContent(conf.FontUnicodeFile, 0o644, blob); err != nil {
 				return nil, err
 			}
 		}
@@ -116,37 +139,36 @@ func loadKeymap(keymap, keymapToggle string, isUtf bool) ([]byte, error) {
 	return blob, err
 }
 
-func readFontFile(font string) (blob []byte, err error) {
-	entries, err := os.ReadDir(consolefontsDir)
-	if err != nil {
-		return nil, err
-	}
-	for _, d := range entries {
-		name := d.Name()
-		if strings.HasPrefix(name, font+".") {
-			fileName := filepath.Join(consolefontsDir, name)
-			debug("font %s matched to file %s", font, fileName)
-			blob, err := os.ReadFile(fileName)
+func readFontFile(font string) ([]byte, error) {
+	return findKbdFile(consolefontsDir, font, consolefontsSuffixes)
+}
+
+// findKbdFile locates a kbd data file by trying name+suffix combinations in dir,
+// mirroring how setfont's kbdfile_find resolves files. Gzip-compressed variants
+// are transparently decompressed.
+func findKbdFile(dir, name string, suffixes []string) ([]byte, error) {
+	for _, suffix := range suffixes {
+		for _, comp := range []string{"", ".gz"} {
+			path := filepath.Join(dir, name+suffix+comp)
+			blob, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			debug("kbd file '%s' matched to %s", name, path)
+			if comp != ".gz" {
+				return blob, nil
+			}
+			gz, err := gzip.NewReader(bytes.NewReader(blob))
 			if err != nil {
 				return nil, err
 			}
-
-			if strings.HasSuffix(name, ".gz") {
-				// unpack the archive
-				gz, err := gzip.NewReader(bytes.NewReader(blob))
-				if err != nil {
-					return nil, err
-				}
-				defer gz.Close()
-
-				blob, err = io.ReadAll(gz)
-				if err != nil {
-					return nil, err
-				}
+			blob, err = io.ReadAll(gz)
+			gz.Close()
+			if err != nil {
+				return nil, err
 			}
-
 			return blob, nil
 		}
 	}
-	return nil, fmt.Errorf("unable to find file for specified font '%s'", font)
+	return nil, fmt.Errorf("unable to find file for specified font '%s'", name)
 }

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -525,10 +525,32 @@ func TestStripBinaries(t *testing.T) {
 	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/rtw88/rtw8723d_fw.bin.zst")
 }
 
+func TestVirtualConsoleFontMap(t *testing.T) {
+	// Regression test for https://github.com/anatol/booster/issues/207:
+	// FONT_MAP files (e.g. 8859-2) live in consoletrans/, not consolefonts/.
+	// The generator must find and bundle the map file and set FontMapFile
+	// (not FontFile) in the init config so setfont receives it via -m.
+	opts := options{
+		vConsoleConfig: "KEYMAP=us\nFONT=lat1-10\nFONT_MAP=8859-2\nFONT_UNIMAP=cp437\n",
+		localeConfig:   "LANG=en_US.UTF-8\n",
+		unpackImage:    true,
+	}
+	createTestInitRamfs(t, &opts)
+
+	checkFileExistence(t, opts.workDir+"/image.unpacked/console/font")
+	checkFileExistence(t, opts.workDir+"/image.unpacked/console/font.map")
+	checkFileExistence(t, opts.workDir+"/image.unpacked/console/font.unimap")
+
+	cfg := readGeneratedInitConfig(t, opts.workDir)
+	require.Equal(t, "/console/font", cfg.VirtualConsole.FontFile)
+	require.Equal(t, "/console/font.map", cfg.VirtualConsole.FontMapFile)
+	require.Equal(t, "/console/font.unimap", cfg.VirtualConsole.FontUnicodeFile)
+}
+
 func TestEnableVirtualConsole(t *testing.T) {
 	opts := options{
 		universal:      true,
-		vConsoleConfig: "KEYMAP=us\nKEYMAP_TOGGLE=de\nFONT=lat1-10\nFONT_UNIMAP=GohaClassic-14\n",
+		vConsoleConfig: "KEYMAP=us\nKEYMAP_TOGGLE=de\nFONT=lat1-10\n",
 		localeConfig:   "LANG=en_US.UTF-8\n",
 		unpackImage:    true,
 	}
@@ -537,13 +559,12 @@ func TestEnableVirtualConsole(t *testing.T) {
 	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/bin/setfont")
 	checkFileExistence(t, opts.workDir+"/image.unpacked/console/keymap")
 	checkFileExistence(t, opts.workDir+"/image.unpacked/console/font")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/console/font.unimap")
 }
 
 func TestEnableVirtualConsoleWithoutLocaleConf(t *testing.T) {
 	opts := options{
 		universal:      true,
-		vConsoleConfig: "KEYMAP=us\nKEYMAP_TOGGLE=de\nFONT=lat1-10\nFONT_UNIMAP=GohaClassic-14\n",
+		vConsoleConfig: "KEYMAP=us\nKEYMAP_TOGGLE=de\nFONT=lat1-10\n",
 		unpackImage:    true,
 	}
 	createTestInitRamfs(t, &opts)
@@ -551,7 +572,6 @@ func TestEnableVirtualConsoleWithoutLocaleConf(t *testing.T) {
 	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/bin/setfont")
 	checkFileExistence(t, opts.workDir+"/image.unpacked/console/keymap")
 	checkFileExistence(t, opts.workDir+"/image.unpacked/console/font")
-	checkFileExistence(t, opts.workDir+"/image.unpacked/console/font.unimap")
 
 	cfg := readGeneratedInitConfig(t, opts.workDir)
 	require.Equal(t, true, cfg.VirtualConsole.Utf)

--- a/init/console.go
+++ b/init/console.go
@@ -27,8 +27,10 @@ func consoleSetFont(c *VirtualConsole) error {
 	if c.FontUnicodeFile != "" {
 		args = append(args, "-u", c.FontUnicodeFile)
 	}
-	err := exec.Command("setfont", args...).Run()
-	return unwrapExitError(err)
+	if err := exec.Command("setfont", args...).Run(); err != nil {
+		warning("setfont: %v (continuing without custom font)", unwrapExitError(err))
+	}
+	return nil
 }
 
 func loadKmap(fd uintptr, file string) error {

--- a/init/console_test.go
+++ b/init/console_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsoleSetFontFailureIsNonFatal(t *testing.T) {
+	// Regression test for https://github.com/anatol/booster/issues/234:
+	// when setfont exits non-zero (e.g. EINVAL from KMS refusing an oversized
+	// font), configureVirtualConsole propagates the error and init exits,
+	// preventing the system from booting. A font load failure is cosmetic —
+	// boot must continue with a warning rather than crashing.
+	f, err := os.CreateTemp("", "booster-test-font-*")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.WriteString("not a valid psf font")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	vc := &VirtualConsole{FontFile: f.Name()}
+	err = consoleSetFont(vc)
+	require.NoError(t, err) // setfont failure must not propagate — font is cosmetic, boot must continue
+}


### PR DESCRIPTION
Two vconsole fixes: FONT_MAP and FONT_UNIMAP files were being looked up in the
wrong directory with the wrong suffixes, and a setfont failure was incorrectly
aborting the boot sequence.

## generator: fix vconsole FONT_MAP and FONT_UNIMAP file resolution

`FONT_MAP` entries (e.g. `8859-2`) were searched in `consolefonts/` using font
suffixes instead of `consoletrans/` using map suffixes — causing "unable to find
file" errors for any system with `FONT_MAP` set (closes #207). `FONT_UNIMAP` had
the same misdirection into `consolefonts/` rather than `unimaps/`.

Both lookups now mirror kbd's `kbdfile_find` resolution logic
(`src/libkfont/context.c`): each directory has its own suffix list
(`.trans`/`_to_uni.trans`/`.acm` for maps; `.uni`/`.sfm` for unimaps).
Gzip-compressed variants are transparently decompressed.

The generator now probes for the kbd base directory at startup (`/usr/share/kbd`
on Arch/Debian/openSUSE/Alpine; `/usr/lib/kbd` on Fedora/RHEL) rather than
hardcoding `/usr/share/kbd`.

Additionally fixes the config fields: `FONT_MAP` and `FONT_UNIMAP` were both
written to `FontFile` instead of `FontMapFile` and `FontUnicodeFile`, so `setfont`
never received them via `-m` and `-u`.

## init: make setfont failure non-fatal

`setfont` exits non-zero when the kernel (KMS) rejects a font as too large for
the framebuffer. This caused `vconsole: true` to abort the boot sequence before
the LUKS password prompt on affected systems (closes #234, #256, #290).

Font loading is cosmetic — boot now continues with a warning rather than crashing.

## Testing

- `TestVirtualConsoleFontMap`: regression test for the FONT_MAP/FONT_UNIMAP
  directory misdirection — verifies files land in the image and that
  `FontMapFile`/`FontUnicodeFile` are set correctly in the init config
- `TestConsoleSetFontFailureIsNonFatal`: verifies setfont failure does not
  propagate out of `consoleSetFont`
- Live boot verified on affected hardware