### PR TITLE
generator: include binary name in extra_files lookup error

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -431,7 +431,7 @@ func lookupPath(binary string) (string, error) {
 		return f, nil
 	}
 
-	return "", os.ErrNotExist
+	return "", fmt.Errorf("cannot find binary %q in PATH", binary)
 }
 
 func findFwFile(fw string) (string, error) {


### PR DESCRIPTION
Fixes #328.

When a non-absolute entry in `extra_files:` cannot be found in PATH, the error was a bare `file does not exist` with no indication of which binary was missing. Now returns `cannot find binary "name" in PATH`.