### PR TITLE
init: last ro/rw cmdline param wins

### DIFF
--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -238,9 +238,11 @@ func parseParams(params string) error {
 		case "rootflags":
 			rootFlags = value
 		case "ro":
-			rootRo = true
+			b := true
+			rootReadOnly = &b
 		case "rw":
-			rootRw = true
+			b := false
+			rootReadOnly = &b
 		case "rd.luks.options":
 			for o := range strings.SplitSeq(value, ",") {
 				if after, ok := strings.CutPrefix(o, "token-timeout="); ok {

--- a/init/cmdline_test.go
+++ b/init/cmdline_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestParseParamsInvalidLuksOptions(t *testing.T) {
@@ -199,4 +200,37 @@ func TestParseParamsInvalidTokenTimeout(t *testing.T) {
 	luksMappings = nil
 
 	require.Error(t, parseParams("rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f rd.luks.options=token-timeout=notaduration"))
+}
+
+func TestMountFlagsRoRw(t *testing.T) {
+	reset := func() {
+		rootReadOnly = nil
+		rootFlags = ""
+		rootAutodiscoveryMountFlags = 0
+	}
+
+	reset()
+	flags, _ := mountFlags()
+	require.Zero(t, flags&unix.MS_RDONLY, "neither ro nor rw: should default to rw")
+
+	reset()
+	require.NoError(t, parseParams("ro"))
+	flags, _ = mountFlags()
+	require.NotZero(t, flags&unix.MS_RDONLY, "ro alone: should be read-only")
+
+	reset()
+	require.NoError(t, parseParams("rw"))
+	flags, _ = mountFlags()
+	require.Zero(t, flags&unix.MS_RDONLY, "rw alone: should be read-write")
+
+	// last param wins
+	reset()
+	require.NoError(t, parseParams("ro rw"))
+	flags, _ = mountFlags()
+	require.Zero(t, flags&unix.MS_RDONLY, "ro rw: rw is last, should be read-write")
+
+	reset()
+	require.NoError(t, parseParams("rw ro"))
+	flags, _ = mountFlags()
+	require.NotZero(t, flags&unix.MS_RDONLY, "rw ro: ro is last, should be read-only")
 }

--- a/init/main.go
+++ b/init/main.go
@@ -42,9 +42,9 @@ var (
 	rootAutodiscoveryMountFlags uintptr // autodiscovery mode uses GPT attribute to configure mount flags
 	activeEfiEspGUID            UUID    // partition that was used as Efi system partition last time
 
-	rootFsType     string
-	rootFlags      string
-	rootRo, rootRw bool
+	rootFsType   string
+	rootFlags    string
+	rootReadOnly *bool // nil = not set; true = ro, false = rw; last cmdline param wins
 
 	zfsDataset string
 
@@ -651,11 +651,12 @@ func waitForBtrfsDevicesReady(dev string) error {
 
 func mountFlags() (uintptr, string) {
 	rootMountFlags, options := sunderMountFlags(rootFlags, rootAutodiscoveryMountFlags)
-	if rootRo {
-		rootMountFlags |= unix.MS_RDONLY
-	}
-	if rootRw {
-		rootMountFlags &^= unix.MS_RDONLY
+	if rootReadOnly != nil {
+		if *rootReadOnly {
+			rootMountFlags |= unix.MS_RDONLY
+		} else {
+			rootMountFlags &^= unix.MS_RDONLY
+		}
 	}
 	return rootMountFlags, options
 }


### PR DESCRIPTION
Fixes #250.

The previous code tracked `ro` and `rw` as independent booleans, so if both appeared on the cmdline (e.g. a bootloader sets `ro` by default and the user appends `rw`, or vice versa), `rw` always won regardless of order.

Replace the two bools with a single `*bool` (`nil` = not set, `true` = ro, `false` = rw) so the last occurrence on the cmdline wins — matching Linux kernel behavior. The `nil` case correctly defers to whatever flags `sunderMountFlags` returns (including GPT autodiscovery attributes), without touching `MS_RDONLY`.

The issue suggested `else if` (ro unconditionally beats rw), but last-wins is the correct semantic and is easier to defend.

Includes unit tests covering all five cases: `ro` alone, `rw` alone, `ro rw` (rw wins), `rw ro` (ro wins), and neither set.