### PR TITLE
init: fix TPM2 integrity check failure for systemd v252+ enrolled tokens (closes #233)

### DIFF
--- a/init/luks.go
+++ b/init/luks.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/anatol/clevis.go"
 	"github.com/anatol/luks.go"
+	"github.com/google/go-tpm/tpmutil"
 	"golang.org/x/sys/unix"
 )
 
@@ -353,11 +353,13 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 
 func recoverSystemdTPM2Password(t luks.Token) ([]byte, error) {
 	var node struct {
-		Blob       string `json:"tpm2-blob"` // base64
+		Blob       string `json:"tpm2-blob"`        // base64
 		PCRs       []int  `json:"tpm2-pcrs"`
 		PCRBank    string `json:"tpm2-pcr-bank"`    // either sha1 or sha256
-		PolicyHash string `json:"tpm2-policy-hash"` // base64
+		PolicyHash string `json:"tpm2-policy-hash"` // hex
 		Pin        bool   `json:"tpm2-pin"`
+		Salt       string `json:"tpm2_salt"`         // base64 random salt; systemd v255+ PIN tokens
+		Srk        string `json:"tpm2_srk"`          // base64 IESYS bytes; systemd v252+ tokens
 	}
 	if err := json.Unmarshal(t.Payload, &node); err != nil {
 		return nil, err
@@ -400,11 +402,26 @@ func recoverSystemdTPM2Password(t luks.Token) ([]byte, error) {
 			return nil, err
 		}
 
-		hash := sha256.Sum256(pin)
-		authValue = hash[:]
+		var salt []byte
+		if node.Salt != "" {
+			salt, err = base64.StdEncoding.DecodeString(node.Salt)
+			if err != nil {
+				return nil, fmt.Errorf("tpm2_salt: %v", err)
+			}
+		}
+		authValue = tpm2PINAuthValue(pin, salt)
 	}
 
-	password, err := tpm2Unseal(public, private, node.PCRs, bank, policyHash, authValue)
+	var srkHandle tpmutil.Handle
+	if node.Srk != "" {
+		srkBytes, err := base64.StdEncoding.DecodeString(node.Srk)
+		if err != nil {
+			return nil, fmt.Errorf("tpm2_srk: %v", err)
+		}
+		srkHandle = extractSRKHandle(srkBytes)
+	}
+
+	password, err := tpm2Unseal(public, private, node.PCRs, bank, policyHash, authValue, srkHandle)
 	if err != nil {
 		return nil, err
 	}

--- a/init/luks_test.go
+++ b/init/luks_test.go
@@ -1,10 +1,62 @@
 package main
 
 import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
 	"testing"
 
+	"github.com/google/go-tpm/tpmutil"
 	"github.com/stretchr/testify/require"
 )
+
+func iesysBytes(handle uint32) []byte {
+	b := make([]byte, 10)
+	binary.BigEndian.PutUint32(b[0:4], 0x69657379) // magic
+	binary.BigEndian.PutUint16(b[4:6], 1)           // version
+	binary.BigEndian.PutUint32(b[6:10], handle)
+	return b
+}
+
+func TestExtractSRKHandle(t *testing.T) {
+	t.Parallel()
+
+	// Well-formed bytes with standard systemd SRK handle.
+	require.Equal(t, tpmutil.Handle(0x81000001), extractSRKHandle(iesysBytes(0x81000001)))
+
+	// Well-formed bytes with a non-standard persistent handle.
+	require.Equal(t, tpmutil.Handle(0x81000002), extractSRKHandle(iesysBytes(0x81000002)))
+
+	// Wrong magic → falls back to 0x81000001.
+	bad := iesysBytes(0x81000099)
+	binary.BigEndian.PutUint32(bad[0:4], 0xdeadbeef)
+	require.Equal(t, tpmutil.Handle(0x81000001), extractSRKHandle(bad))
+
+	// Buffer too short → falls back to 0x81000001.
+	require.Equal(t, tpmutil.Handle(0x81000001), extractSRKHandle([]byte{0x69, 0x65, 0x73, 0x79}))
+
+	// Empty → falls back to 0x81000001.
+	require.Equal(t, tpmutil.Handle(0x81000001), extractSRKHandle(nil))
+
+	// Handle field is zero → falls back to 0x81000001.
+	require.Equal(t, tpmutil.Handle(0x81000001), extractSRKHandle(iesysBytes(0)))
+}
+
+func TestTPM2PINAuthValue(t *testing.T) {
+	t.Parallel()
+
+	// No salt: authValue = SHA256_trimmed(pin)
+	noSaltAuth := tpm2PINAuthValue([]byte("foo654"), nil)
+	noSaltExpected, _ := hex.DecodeString("b45f7ebd746ed390f878184a49b08d17d4fbdeccc27e226675fd81c0a94aea21")
+	require.Equal(t, noSaltExpected, noSaltAuth)
+
+	// With salt (systemd v255+ salted PIN): authValue = SHA256_trimmed(base64(PBKDF2-HMAC-SHA256(pin, salt, 10000, 32)))
+	// Values from actual systemd-tpm2-withpin.img token, pin = "foo654"
+	salt, _ := base64.StdEncoding.DecodeString("8/ysu/pr1gnBowEfpa7sJjtk2Yky5LC2jC7grjOrX3s=")
+	saltedAuth := tpm2PINAuthValue([]byte("foo654"), salt)
+	saltedExpected, _ := hex.DecodeString("9c1a75519102e847b61bebe79f9052a92cbd754e6cd9903c714614a222741761")
+	require.Equal(t, saltedExpected, saltedAuth)
+}
 
 func TestParseSystemdTPM2Blob(t *testing.T) {
 	t.Parallel()

--- a/init/tpm.go
+++ b/init/tpm.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
@@ -9,6 +12,7 @@ import (
 
 	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpmutil"
+	"golang.org/x/crypto/pbkdf2"
 )
 
 var defaultSymScheme = &tpm2.SymScheme{
@@ -58,7 +62,45 @@ func tpmAwaitReady() bool {
 	return !timedOut
 }
 
-func tpm2Unseal(public, private []byte, pcrs []int, bank tpm2.Algorithm, policyHash, password []byte) ([]byte, error) {
+// extractSRKHandle parses the Intel TSS2 IESYS_RESOURCE_SERIALIZE format that
+// systemd uses to store the SRK reference in LUKS2 token JSON (tpm2_srk field).
+// Layout: magic[4] version[2] handle[4] ... Falls back to 0x81000001, which is
+// systemd's standard persistent SRK handle, on any parse failure.
+func extractSRKHandle(srk []byte) tpmutil.Handle {
+	const iesysMagic = 0x69657379
+	if len(srk) >= 10 && binary.BigEndian.Uint32(srk[0:4]) == iesysMagic {
+		if h := binary.BigEndian.Uint32(srk[6:10]); h != 0 {
+			return tpmutil.Handle(h)
+		}
+	}
+	return tpmutil.Handle(0x81000001)
+}
+
+// tpm2PINAuthValue derives the TPM2 authValue from a PIN, matching systemd's convention.
+//
+// systemd v255+ ("salted PIN"): authValue = SHA256_trimmed(base64(PBKDF2-HMAC-SHA256(pin, salt, 10000, 32)))
+// Older tokens (no salt):       authValue = SHA256_trimmed(pin)
+//
+// Trailing zero bytes are trimmed per TPM2 spec Part 1 "HMAC Computation" authValue Note 2.
+func tpm2PINAuthValue(pin, salt []byte) []byte {
+	var input []byte
+	if len(salt) > 0 {
+		dk := pbkdf2.Key(pin, salt, 10000, 32, sha256.New)
+		b64 := base64.StdEncoding.EncodeToString(dk)
+		input = []byte(b64)
+	} else {
+		input = pin
+	}
+	h := sha256.Sum256(input)
+	auth := h[:]
+	// Trim trailing zero bytes
+	for len(auth) > 0 && auth[len(auth)-1] == 0 {
+		auth = auth[:len(auth)-1]
+	}
+	return auth
+}
+
+func tpm2Unseal(public, private []byte, pcrs []int, bank tpm2.Algorithm, policyHash, password []byte, srkHandle tpmutil.Handle) ([]byte, error) {
 	tpmAwaitReady()
 
 	dev, err := openTPM()
@@ -73,22 +115,30 @@ func tpm2Unseal(public, private []byte, pcrs []int, bank tpm2.Algorithm, policyH
 	}
 	defer tpm2.FlushContext(dev, sessHandle)
 
-	srkTemplate := tpm2.Public{
-		Type:          tpm2.AlgECC,
-		NameAlg:       tpm2.AlgSHA256,
-		Attributes:    tpm2.FlagStorageDefault,
-		AuthPolicy:    nil,
-		ECCParameters: defaultECCParams,
-		RSAParameters: defaultRSAParams,
+	var parent tpmutil.Handle
+	if srkHandle != 0 {
+		// Use the persistent SRK provisioned by systemd-tpm2-setup (systemd v252+ tokens).
+		// Do not FlushContext on a persistent handle — that would evict it from the TPM.
+		parent = srkHandle
+	} else {
+		// Legacy path: derive a transient primary from the well-known ECC template.
+		// Used for tokens created by systemd pre-v252 that have no tpm2_srk field.
+		srkTemplate := tpm2.Public{
+			Type:          tpm2.AlgECC,
+			NameAlg:       tpm2.AlgSHA256,
+			Attributes:    tpm2.FlagStorageDefault,
+			AuthPolicy:    nil,
+			ECCParameters: defaultECCParams,
+			RSAParameters: defaultRSAParams,
+		}
+		parent, _, err = tpm2.CreatePrimary(dev, tpm2.HandleOwner, tpm2.PCRSelection{}, "", "", srkTemplate)
+		if err != nil {
+			return nil, fmt.Errorf("clevis.go/tpm2: can't create primary key: %v", err)
+		}
+		defer tpm2.FlushContext(dev, parent)
 	}
 
-	srkHandle, _, err := tpm2.CreatePrimary(dev, tpm2.HandleOwner, tpm2.PCRSelection{}, "", "", srkTemplate)
-	if err != nil {
-		return nil, fmt.Errorf("clevis.go/tpm2: can't create primary key: %v", err)
-	}
-	defer tpm2.FlushContext(dev, srkHandle)
-
-	objectHandle, _, err := tpm2.Load(dev, srkHandle, "", public, private)
+	objectHandle, _, err := tpm2.Load(dev, parent, "", public, private)
 	if err != nil {
 		return nil, fmt.Errorf("clevis.go/tpm2: unable to load data: %v", err)
 	}

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -65,8 +65,14 @@ var assetGenerators = map[string]assetGenerator{
 		"FS_UUID=0cb4665f-65a0-4acc-9710-05163af16f19",
 		"LUKS_PASSWORD=567",
 	}},
-	"systemd-tpm2.img":          {"systemd_tpm2.sh", []string{"LUKS_UUID=5cbc48ce-0e78-4c6b-ac90-a8a540514b90", "FS_UUID=d8673e36-d4a3-4408-a87d-be0cb79f91a2", "LUKS_PASSWORD=567"}},
-	"systemd-tpm2-withpin.img":  {"systemd_tpm2.sh", []string{"LUKS_UUID=8bb97618-7ef4-4c93-b4f7-f2cb17cf7da1", "FS_UUID=26dbbe17-9af9-4322-bb5f-c1d74a40e618", "LUKS_PASSWORD=9999", "CRYPTENROLL_TPM2_PIN=foo654"}},
+	"systemd-tpm2.img":              {"systemd_tpm2.sh", []string{"LUKS_UUID=5cbc48ce-0e78-4c6b-ac90-a8a540514b90", "FS_UUID=d8673e36-d4a3-4408-a87d-be0cb79f91a2", "LUKS_PASSWORD=567"}},
+	"systemd-tpm2-withpin.img":      {"systemd_tpm2.sh", []string{"LUKS_UUID=8bb97618-7ef4-4c93-b4f7-f2cb17cf7da1", "FS_UUID=26dbbe17-9af9-4322-bb5f-c1d74a40e618", "LUKS_PASSWORD=9999", "CRYPTENROLL_TPM2_PIN=foo654"}},
+	"systemd-tpm2-srk.img":          {"systemd_tpm2.sh", []string{"LUKS_UUID=c09debc6-6a06-4317-94f5-0916bb9ea1c8", "FS_UUID=5a6daa83-ea51-47dd-a38b-2b66d5cc8428", "LUKS_PASSWORD=567"}},
+	// systemd-tpm2-legacy-pin.img: v252-254 format token — tpm2_srk present but
+	// no tpm2_salt, PIN auth via SHA256(pin) without PBKDF2.  Generated with
+	// raw tpm2-tools rather than systemd-cryptenroll to be independent of the
+	// installed systemd version.  Requires tpm2-tools; test skips if absent.
+	"systemd-tpm2-legacy-pin.img":   {"systemd_tpm2_legacy_pin.sh", []string{"LUKS_UUID=1e8a6049-18a7-48df-a4f6-edc80650e19f", "FS_UUID=b0d4b4c2-cef2-43b5-a063-e3379a49f79c", "LUKS_PASSWORD=567", "CRYPTENROLL_TPM2_PIN=foo654"}},
 	"systemd-recovery.img":      {"systemd_recovery.sh", []string{"LUKS_UUID=62020168-58b9-4095-a3d0-176403353d20", "FS_UUID=b0cfeb48-c1e2-459d-a327-4d611804ac24", "LUKS_PASSWORD=2211"}},
 	// luks2.shared_pass.img: GPT disk with two LUKS2 partitions sharing the same
 	// passphrase.  Partition 1 has no inner filesystem; partition 2 has ext4.

--- a/tests/generators/swtpm.sh
+++ b/tests/generators/swtpm.sh
@@ -7,4 +7,38 @@ sudo chown "${USER}" /var/lib/swtpm-localca
 
 mkdir assets/tpm2
 swtpm_setup --tpm-state assets/tpm2 --tpm2 --ecc --create-ek-cert --create-platform-cert --lock-nvram
+# swtpm_setup may leave the state directory and files owned by root; fix so the
+# test framework (running as the normal user) can read and copy the pristine.
+sudo chown -R "${USER}": assets/tpm2
+
+# Provision a persistent SRK at handle 0x81000001 if tpm2-tools are available.
+# systemd-cryptenroll v252+ calls tpm2_get_or_create_srk during enrollment, so
+# it will provision the SRK automatically on the first enrollment run and the
+# systemd_tpm2.sh quit trap will save the result back to this pristine.
+# Pre-provisioning here is optional but makes the pristine self-contained for
+# the systemd_tpm2_legacy_pin.sh generator (which uses tpm2-tools directly).
+if command -v tpm2_createprimary &>/dev/null && command -v tpm2_evictcontrol &>/dev/null; then
+  swtpm socket --tpmstate dir=assets/tpm2 --tpm2 \
+    --server type=tcp,port=12321 --ctrl type=tcp,port=12322 \
+    --flags not-need-init,startup-clear &
+  swtpm_pid=$!
+
+  for i in $(seq 1 50); do
+    swtpm_ioctl --tcp :12322 --ping 2>/dev/null && break
+    sleep 0.1
+  done
+
+  srk_ctx=$(mktemp --suffix=.ctx)
+  TPM2TOOLS_TCTI="swtpm:host=localhost,port=12321" \
+    tpm2_createprimary -C o -g sha256 -G ecc \
+    -a "fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda|restricted|decrypt" \
+    -c "${srk_ctx}"
+  TPM2TOOLS_TCTI="swtpm:host=localhost,port=12321" \
+    tpm2_evictcontrol -C o -c "${srk_ctx}" 0x81000001
+  rm -f "${srk_ctx}"
+
+  swtpm_ioctl --tcp :12322 -s
+  wait "${swtpm_pid}"
+fi
+
 mv assets/tpm2/tpm2-00.permall assets/tpm2/tpm2-00.permall.pristine

--- a/tests/generators/systemd_tpm2.sh
+++ b/tests/generators/systemd_tpm2.sh
@@ -2,11 +2,22 @@
 
 trap 'quit' EXIT ERR
 
+success=0
+swtpm_pid=
+
 quit() {
   set +o errexit
-  swtpm_ioctl --tcp :2322 -s
+  swtpm_ioctl --tcp :2322 -s 2>/dev/null
+  wait "${swtpm_pid}" 2>/dev/null  # ensure state is fully written to disk before copying
+  # On success, save the swtpm state back as pristine. With systemd v252+ the
+  # SRK is provisioned into the TPM during enrollment; tests need this state so
+  # booster can load the sealed key from handle 0x81000001.
+  if [ "${success}" = "1" ] && [ -f "assets/tpm2.generate/tpm2-00.permall" ]; then
+    sudo cp "assets/tpm2.generate/tpm2-00.permall" "assets/tpm2/tpm2-00.permall.pristine"
+    sudo chown "${USER}": "assets/tpm2/tpm2-00.permall.pristine"
+  fi
   rm -rf assets/tpm2.generate
-  rm assets/cryptenroll.passphrase
+  rm -f assets/cryptenroll.passphrase assets/cryptenroll.tpm2-pin assets/cryptenroll.new-tpm2-pin
   sudo umount "${dir}"
   rm -r "${dir}"
   sudo cryptsetup close "${LUKS_DEV_NAME}"
@@ -15,21 +26,39 @@ quit() {
 
 LUKS_DEV_NAME=luks-booster-systemd
 
+rm -rf assets/tpm2.generate
 mkdir assets/tpm2.generate
 cp assets/tpm2/tpm2-00.permall.pristine assets/tpm2.generate/tpm2-00.permall
 swtpm socket --tpmstate dir=assets/tpm2.generate --tpm2 --server type=tcp,port=2321 --ctrl type=tcp,port=2322 --flags not-need-init,startup-clear &
+swtpm_pid=$!
+
+# Wait for swtpm to be ready before running cryptenroll, otherwise it may fall
+# back to the real hardware TPM (/dev/tpm0) if present on the host.
+for i in $(seq 1 50); do
+  swtpm_ioctl --tcp :2322 --ping 2>/dev/null && break
+  sleep 0.1
+done
 
 truncate --size 40M "${OUTPUT}"
 lodev=$(sudo losetup -f -P --show "${OUTPUT}")
 sudo cryptsetup luksFormat --uuid "${LUKS_UUID}" --type luks2 "${lodev}" <<< "${LUKS_PASSWORD}"
 
 printf '%s' "${LUKS_PASSWORD}" > assets/cryptenroll.passphrase
-# it looks like edk2 extends PCR 0-7 so let's use some other PCR outside of this range
+# it looks like edk2 extends PCR 0-7 so let's use some other PCR outside of this range.
+# Pass SWTPM env vars explicitly so systemd-cryptenroll uses our TCP swtpm rather
+# than any real hardware TPM that may be present on the host.
 if [ "${CRYPTENROLL_TPM2_PIN}" != "" ]; then
-  printf '%s' "${CRYPTENROLL_TPM2_PIN}" > assets/cryptenroll.tpm2-pin
-  sudo CREDENTIALS_DIRECTORY="$(pwd)/assets" systemd-cryptenroll --tpm2-device=swtpm: --tpm2-pcrs=10+13 --tpm2-with-pin=true "${lodev}"
+  # cryptenroll.new-tpm2-pin is the credential name for setting a new PIN during enrollment
+  printf '%s' "${CRYPTENROLL_TPM2_PIN}" > assets/cryptenroll.new-tpm2-pin
+  # Use sudo env so CREDENTIALS_DIRECTORY survives sudo's env_reset.
+  # Pass the full TCTI string directly so cryptenroll cannot fall back to /dev/tpm0.
+  sudo env CREDENTIALS_DIRECTORY="$(pwd)/assets" \
+    systemd-cryptenroll --tpm2-device="swtpm:host=localhost,port=2321" \
+    --tpm2-pcrs=10+13 --tpm2-with-pin=true "${lodev}"
 else
-  sudo CREDENTIALS_DIRECTORY="$(pwd)/assets" systemd-cryptenroll --tpm2-device=swtpm: --tpm2-pcrs=10+13 "${lodev}"
+  sudo env CREDENTIALS_DIRECTORY="$(pwd)/assets" \
+    systemd-cryptenroll --tpm2-device="swtpm:host=localhost,port=2321" \
+    --tpm2-pcrs=10+13 "${lodev}"
 fi
 
 sudo cryptsetup open --disable-external-tokens --type luks2 "${lodev}" "${LUKS_DEV_NAME}" <<< "${LUKS_PASSWORD}"
@@ -43,3 +72,5 @@ cp assets/init "${dir}/sbin/init"
 if [ "${CRYPTENROLL_TPM2_PIN}" != "" ]; then
   sudo cryptsetup -v luksKillSlot "${lodev}" 0
 fi
+
+success=1

--- a/tests/generators/systemd_tpm2_legacy_pin.sh
+++ b/tests/generators/systemd_tpm2_legacy_pin.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Generates a LUKS2 image with a systemd-tpm2 token in v252–254 format:
+# tpm2_srk present (persistent SRK at 0x81000001) but no tpm2_salt,
+# with PIN auth using authValue = SHA256_trimmed(pin).
+#
+# This tests booster's backward-compat path for users who enrolled with
+# systemd v252–254 before the salted PBKDF2 PIN auth was introduced in v255.
+#
+# Requires: swtpm, tpm2-tools (tpm2_create, tpm2_createprimary, tpm2_evictcontrol)
+
+set -euo pipefail
+trap 'quit' EXIT
+
+success=0
+swtpm_pid=
+dir=
+lodev=
+tmpdir=$(mktemp -d)
+T="${tmpdir}/t"
+
+quit() {
+  set +o errexit
+  swtpm_ioctl --tcp :2322 -s 2>/dev/null
+  wait "${swtpm_pid}" 2>/dev/null
+  # On success save the swtpm state (including the provisioned SRK) back to
+  # pristine so test runs can unseal against the same SRK.
+  if [ "${success}" = "1" ] && [ -f "assets/tpm2.generate/tpm2-00.permall" ]; then
+    sudo cp "assets/tpm2.generate/tpm2-00.permall" "assets/tpm2/tpm2-00.permall.pristine"
+    sudo chown "${USER}": "assets/tpm2/tpm2-00.permall.pristine"
+  fi
+  rm -rf assets/tpm2.generate "${tmpdir}"
+  [ -n "${dir}" ] && { sudo umount "${dir}" 2>/dev/null; rm -r "${dir}"; }
+  sudo cryptsetup close luks-booster-tpm2-legacy >/dev/null 2>&1 || true
+  [ -n "${lodev}" ] && sudo losetup -d "${lodev}" >/dev/null 2>&1 || true
+}
+
+TCTI="swtpm:host=localhost,port=2321"
+
+rm -rf assets/tpm2.generate
+mkdir assets/tpm2.generate
+cp assets/tpm2/tpm2-00.permall.pristine assets/tpm2.generate/tpm2-00.permall
+swtpm socket --tpmstate dir=assets/tpm2.generate --tpm2 \
+  --server type=tcp,port=2321 --ctrl type=tcp,port=2322 \
+  --flags not-need-init,startup-clear &
+swtpm_pid=$!
+
+for i in $(seq 1 50); do
+  swtpm_ioctl --tcp :2322 --ping 2>/dev/null && break
+  sleep 0.1
+done
+
+# Ensure the SRK is provisioned at 0x81000001.  If the pristine was generated
+# without tpm2-tools the SRK may be absent; provision it now.
+if ! TPM2TOOLS_TCTI="${TCTI}" tpm2_readpublic -c 0x81000001 &>/dev/null; then
+  TPM2TOOLS_TCTI="${TCTI}" \
+    tpm2_createprimary -C o -g sha256 -G ecc \
+    -a "fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda|restricted|decrypt" \
+    -c "${T}.srk.ctx"
+  TPM2TOOLS_TCTI="${TCTI}" tpm2_evictcontrol -C o -c "${T}.srk.ctx" 0x81000001
+  rm -f "${T}.srk.ctx"
+fi
+
+# PCR policy for PCRs 10+13 with password extension (PCRs are 0 in fresh swtpm).
+# tpm2_policypassword -L saves the final policy digest after both PCR and
+# password commands; no separate policygetdigest tool needed in tpm2-tools 5.x.
+TPM2TOOLS_TCTI="${TCTI}" tpm2_startauthsession --policy-session -S "${T}.sess"
+TPM2TOOLS_TCTI="${TCTI}" tpm2_policypcr      -S "${T}.sess" -l sha256:10,13
+TPM2TOOLS_TCTI="${TCTI}" tpm2_policypassword -S "${T}.sess" -L "${T}.policy"
+POLICY_HASH=$(python3 -c "print(open('${T}.policy','rb').read().hex())")
+TPM2TOOLS_TCTI="${TCTI}" tpm2_flushcontext -l
+
+# authValue = SHA256_trimmed(pin) — the pre-v255 convention, no PBKDF2.
+PIN_AUTH_HEX=$(python3 -c "
+import hashlib
+h = bytearray(hashlib.sha256('${CRYPTENROLL_TPM2_PIN}'.encode()).digest())
+while h and h[-1] == 0:
+    h = h[:-1]
+print(bytes(h).hex())
+")
+
+# Generate the random key that will be sealed; the LUKS slot passphrase is
+# base64(raw_key) to match booster's recoverSystemdTPM2Password return value.
+openssl rand 32 > "${T}.rawkey"
+LUKS_TPM_PASSPHRASE=$(base64 -w0 "${T}.rawkey")
+
+# Seal raw_key against the SRK with the PCR+password policy and PIN authValue.
+TPM2TOOLS_TCTI="${TCTI}" \
+  tpm2_create -C 0x81000001 \
+  -i "${T}.rawkey" \
+  -L "${T}.policy" \
+  -p "hex:${PIN_AUTH_HEX}" \
+  -u "${T}.pub" -r "${T}.priv"
+
+# systemd-tpm2 blob: TPM2B_PRIVATE || TPM2B_PUBLIC (each size-prefixed big-endian,
+# exactly as tpm2_create writes them — matches parseSystemdTPM2Blob's wire format).
+cat "${T}.priv" "${T}.pub" > "${T}.blob"
+
+# Build the token JSON.  tpm2_srk is present (IESYS_RESOURCE_SERIALIZE format,
+# 10-byte header encoding handle 0x81000001) but tpm2_salt is intentionally
+# absent — this is the v252–254 format that predates the salted PIN in v255.
+python3 > "${T}.token.json" << PYEOF
+import json, base64, struct
+
+blob_b64 = base64.b64encode(open("${T}.blob", "rb").read()).decode()
+
+# Minimal IESYS_RESOURCE_SERIALIZE: magic(4) + version(2) + handle(4).
+# extractSRKHandle parses this and returns Handle(0x81000001).
+srk_b64 = base64.b64encode(struct.pack(">IHI", 0x69657379, 1, 0x81000001)).decode()
+
+print(json.dumps({
+    "type": "systemd-tpm2",
+    "keyslots": ["1"],
+    "tpm2-blob": blob_b64,
+    "tpm2-pcrs": [10, 13],
+    "tpm2-pcr-bank": "sha256",
+    "tpm2-primary-alg": "ecc",
+    "tpm2-policy-hash": "${POLICY_HASH}",
+    "tpm2-pin": True,
+    "tpm2_srk": srk_b64,
+    # tpm2_salt absent: simulates systemd v252-254 (SHA256 PIN, no PBKDF2)
+}))
+PYEOF
+
+# Write passphrases to temp files so cryptsetup never reads stdin.
+# Avoids conflicts with sudo's PAM/FIDO2 authentication when running non-interactively.
+printf '%s' "${LUKS_PASSWORD}"       > "${T}.lukspass"
+printf '%s' "${LUKS_TPM_PASSPHRASE}" > "${T}.tpmpass"
+
+# Create the LUKS2 image.
+truncate --size 40M "${OUTPUT}"
+lodev=$(sudo losetup -f -P --show "${OUTPUT}" | grep -Em1 '^/dev/loop[0-9]+$')
+sudo cryptsetup luksFormat --batch-mode --uuid "${LUKS_UUID}" --type luks2 \
+  --key-file "${T}.lukspass" "${lodev}"
+
+# Add TPM key slot (slot 1) authenticated by the temporary passphrase slot.
+sudo cryptsetup luksAddKey --batch-mode --key-slot 1 \
+  --key-file "${T}.lukspass" "${lodev}" "${T}.tpmpass"
+
+# Import the token (associates it with slot 1).
+sudo cryptsetup token import "${lodev}" < "${T}.token.json"
+
+# Populate the filesystem.
+sudo cryptsetup open --disable-external-tokens --type luks2 \
+  --key-file "${T}.lukspass" "${lodev}" luks-booster-tpm2-legacy
+sudo mkfs.ext4 -U "${FS_UUID}" -L atestlabel12 "/dev/mapper/luks-booster-tpm2-legacy"
+dir=$(mktemp -d)
+sudo mount "/dev/mapper/luks-booster-tpm2-legacy" "${dir}"
+sudo chown "${USER}" "${dir}"
+mkdir "${dir}/sbin"
+cp assets/init "${dir}/sbin/init"
+
+# Remove passphrase slot so only the TPM-PIN slot remains.
+sudo cryptsetup luksKillSlot --batch-mode --key-file "${T}.tpmpass" "${lodev}" 0
+
+success=1

--- a/tests/systemd_test.go
+++ b/tests/systemd_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"os"
+	"os/exec"
 	"regexp"
 	"testing"
 
@@ -76,6 +77,55 @@ func TestSystemdTPM2WithPin(t *testing.T) {
 	vm, err := buildVmInstance(t, Opts{
 		disk:       "assets/systemd-tpm2-withpin.img",
 		kernelArgs: []string{"rd.luks.uuid=8bb97618-7ef4-4c93-b4f7-f2cb17cf7da1", "root=UUID=26dbbe17-9af9-4322-bb5f-c1d74a40e618"},
+		params:     params,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Please enter TPM pin:"))
+	require.NoError(t, vm.ConsoleWrite("foo654\n"))
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestSystemdTPM2SRK tests unlock of a LUKS2 volume enrolled with systemd-cryptenroll
+// v252+, which provisions a persistent SRK at handle 0x81000001 and records it as
+// tpm2_srk in the token JSON. Booster must use that handle rather than deriving a
+// transient primary, otherwise tpm2.Load returns an integrity check failure.
+func TestSystemdTPM2SRK(t *testing.T) {
+	swtpm, params, err := startSwtpm()
+	require.NoError(t, err)
+	defer swtpm.Kill()
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:       "assets/systemd-tpm2-srk.img",
+		kernelArgs: []string{"rd.luks.uuid=c09debc6-6a06-4317-94f5-0916bb9ea1c8", "root=UUID=5a6daa83-ea51-47dd-a38b-2b66d5cc8428"},
+		params:     params,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestSystemdTPM2LegacyPin tests unlock of a LUKS2 volume whose systemd-tpm2
+// token was enrolled with a v252–254 era systemd-cryptenroll: the token has
+// tpm2_srk (persistent SRK) but no tpm2_salt, so PIN auth uses the pre-v255
+// convention authValue = SHA256_trimmed(pin) rather than the PBKDF2 path.
+// The image is generated with raw tpm2-tools to be independent of the installed
+// systemd version.  The test is skipped when tpm2-tools are not available.
+func TestSystemdTPM2LegacyPin(t *testing.T) {
+	if _, err := exec.LookPath("tpm2_create"); err != nil {
+		t.Skip("tpm2-tools not installed; skipping legacy-pin backward-compat test")
+	}
+
+	swtpm, params, err := startSwtpm()
+	require.NoError(t, err)
+	defer swtpm.Kill()
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:       "assets/systemd-tpm2-legacy-pin.img",
+		kernelArgs: []string{"rd.luks.uuid=1e8a6049-18a7-48df-a4f6-edc80650e19f", "root=UUID=b0d4b4c2-cef2-43b5-a063-e3379a49f79c"},
 		params:     params,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Users who enrolled with `systemd-cryptenroll` v252 or later see:

```
recovering systemd-tpm2 token failed: clevis.go/tpm2: unable to load data: integrity check failed
```

Two changes in systemd broke compatibility:

**1. Persistent SRK (v252+)**

`systemd-cryptenroll` v252 began provisioning a persistent SRK at handle `0x81000001` via `tpm2_get_or_create_srk` and recording it in the LUKS2 token JSON as `tpm2_srk`. Booster was always deriving a transient primary via `CreatePrimary`. When a persistent SRK was used during enrollment, loading the sealed object against a freshly derived primary produces a different parent key, causing the integrity check to fail.

The fix avoids the `IESYS_RESOURCE` deserialization problem noted in #233 — we only need the `TPM2_HANDLE` embedded in the IESYS header (bytes 6–9, big-endian), which maps directly to a `tpmutil.Handle`. When `tpm2_srk` is present, `tpm2.Load` is called against the persistent handle. `FlushContext` is intentionally skipped on the persistent handle (it would evict it from the TPM). Pre-v252 tokens with no `tpm2_srk` continue to use the old `CreatePrimary` path.

**2. PBKDF2 PIN auth (v255+)**

`systemd-cryptenroll` v255 added a `tpm2_salt` field to PIN-protected tokens. The old formula was `authValue = SHA256_trimmed(pin)`; the new formula is `SHA256_trimmed(base64(PBKDF2-HMAC-SHA256(pin, salt, 10000, 32)))`. Tokens without `tpm2_salt` continue to use the old path.

**Coverage**

Four QEMU integration tests cover all relevant paths:

| Token format | Test |
|---|---|
| Pre-v252 (transient primary, no SRK) | `TestSystemdTPM2` (existing) |
| v252+ (persistent SRK, no PIN) | `TestSystemdTPM2SRK` (new) |
| v255+ (persistent SRK + PBKDF2 PIN) | `TestSystemdTPM2WithPin` (existing) |
| v252–254 (persistent SRK, SHA256 PIN, no PBKDF2) | `TestSystemdTPM2LegacyPin` (new) |

The legacy-PIN test uses raw `tpm2-tools` to construct the token independently of the installed systemd version and is skipped if `tpm2-tools` are absent.

**Known limitation**

The TPM2 PIN prompt does not yet include the mapping name and has no retry loop on wrong PIN. The FIDO2 path gained both (mapping name in prompt, 3-attempt retry with progressive feedback) in a recent PR; parity for TPM2 is planned as a follow-up.