### PR TITLE
tests: fix systemd_recovery.sh generator for non-interactive and modern systemd

### DIFF
--- a/tests/generators/systemd_recovery.sh
+++ b/tests/generators/systemd_recovery.sh
@@ -21,11 +21,12 @@ err() {
 LUKS_DEV_NAME=luks-booster-recover
 
 truncate --size 40M "${OUTPUT}"
-lodev=$(sudo losetup -f --show "${OUTPUT}")
+lodev=$(sudo losetup -f --show "${OUTPUT}" | grep -m1 '^/dev/')
 sudo cryptsetup luksFormat --uuid "${LUKS_UUID}" --type luks2 "${lodev}" <<< "${LUKS_PASSWORD}"
 
 printf '%s' "${LUKS_PASSWORD}" > assets/cryptenroll.passphrase
-recovery_key=$(sudo CREDENTIALS_DIRECTORY="$(pwd)/assets" systemd-cryptenroll --recovery-key "${lodev}")
+recovery_key=$(sudo CREDENTIALS_DIRECTORY="$(pwd)/assets" systemd-cryptenroll --recovery-key "${lodev}" \
+  | sed 's/\x1b\[[0-9;]*m//g' | grep -m1 '^[a-z0-9]')
 printf '%s' "${recovery_key}" > assets/systemd.recovery.key
 
 sudo cryptsetup open "${lodev}" "${LUKS_DEV_NAME}" <<< "${LUKS_PASSWORD}"
@@ -36,4 +37,4 @@ sudo chown "${USER}" "${dir}"
 mkdir "${dir}/sbin"
 cp assets/init "${dir}/sbin/init"
 
-sudo cryptsetup -v luksKillSlot "${lodev}" 0
+sudo cryptsetup -v luksKillSlot "${lodev}" 0 <<< "${recovery_key}"


### PR DESCRIPTION
## Problem

`TestSystemdRecovery` relies on a pre-generated `assets/systemd-recovery.img`. The
`checkAsset` helper regenerates missing assets by running `generators/systemd_recovery.sh`,
but the script had three bugs that made automatic regeneration fail silently or hang —
meaning anyone who deleted or never had the asset would see the test suite fail with no
clear explanation, and the only workaround was to build the image manually outside the
test runner.

## Fixes

- **`losetup` stdout contamination**: `pam_u2f` (FIDO2 sudo auth) writes the touch
  prompt to stdout inside command substitution, corrupting `$lodev`. Filter with
  `grep -m1 '^/dev/'`, consistent with `luks_btrfs_raid1.sh` and `luks_shared_pass.sh`
  which already carry this fix.

- **ANSI codes in `systemd-cryptenroll` output**: systemd v255+ wraps the recovery key
  in color escape sequences. Without stripping them the captured `$recovery_key` is
  unusable as a LUKS passphrase and the key file is written with garbage. The
  `sed | grep` pipeline is a no-op on older systemd that emits plain text.

- **`luksKillSlot` interactive prompt**: `cryptsetup luksKillSlot` requires a passphrase
  confirming access via a remaining slot. The test framework runs the script with no
  controlling terminal, so the prompt always hangs or returns an error. Feeding
  `$recovery_key` via stdin makes the step non-interactive and self-contained.

Without all three fixes, `systemd-recovery.img` must be built manually before running
the test suite, and any CI environment or fresh checkout will have a broken
`TestSystemdRecovery`.

## Test plan

- [ ] Delete `tests/assets/systemd-recovery.img` and `tests/assets/systemd.recovery.key`,
  run `go test -v -run TestSystemdRecovery` — asset regenerates and test passes
- [ ] Confirm test still passes when assets already exist (no regeneration triggered)