### PR TITLE
init: remove crypttab fido2-device=/tpm2-device= token flags in favour of LUKS2 header

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -128,7 +128,7 @@ Some parts of booster boot functionality can be modified with kernel boot parame
     * **Initramfs file** — an absolute path (e.g. `/etc/luks/root.hdr`) to a header file bundled into the initramfs at build time via `extra_files`.
     * **Raw block device** — a device path (e.g. `/dev/sdb`) where the LUKS header begins at byte offset 0. Booster waits for the device to appear and passes it directly to cryptsetup without mounting.
     * **File on a separate device** — `$path:$deviceref` where `$deviceref` is `UUID=...`, `LABEL=...`, `PARTUUID=...`, or `PARTLABEL=...`. Booster mounts the device read-only, reads the header file, then unmounts before unlocking.
- * `rd.luks.options=opt1,opt2` a comma-separated list of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`. `token-timeout=<duration>` sets how long to wait for hardware tokens (FIDO2, TPM2) before also prompting for a keyboard passphrase. Accepts a decimal number followed by a unit (`s`, `m`, `h`), or a bare integer treated as seconds. Default (0) is to wait for all tokens to complete before prompting.
+ * `rd.luks.options=opt1,opt2` a comma-separated list of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`. `token-timeout=<duration>` sets how long to wait for hardware tokens (FIDO2, TPM2) before also prompting for a keyboard passphrase. Accepts a decimal number followed by a unit (`s`, `m`, `h`), or a bare integer treated as seconds. Default is 30 s.
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
 
 Booster supports unlocking LUKS volumes declared in `/etc/crypttab` (see **crypttab(5)**).
@@ -138,7 +138,7 @@ Booster-specific behaviour for selected options:
  * **keyfile** `/path:UUID=xxx` (or `LABEL=`, `PARTUUID=`, `PARTLABEL=`) — keyfile on a separate device. Booster mounts the device read-only at boot, reads the key, then unmounts. The file is not bundled into the initramfs.
  * **`header=`** — if the path is a plain absolute path the generator bundles the file into the initramfs automatically. The `/path:deviceref` form mounts the device at boot; `/dev/...` uses the raw block device directly.
  * **`fido2-device=auto`** — when present the generator automatically bundles `fido2plugin.so`; no `enable_fido2: true` in the config file is required.
- * **`fido2-device=auto`** / **`tpm2-device=auto`** — Booster defers the keyboard passphrase prompt until the token attempt fails or `token-timeout=` elapses (default: 30 s).
+ * **`fido2-device=auto`** / **`tpm2-device=auto`** — accepted for compatibility. Booster detects enrolled tokens directly from the LUKS2 header, so these flags are no longer required to activate token-aware behaviour. The keyboard passphrase prompt is deferred for any LUKS2 volume that has enrolled tokens until the token attempt completes or `token-timeout=` elapses.
  * **`keyfile-timeout=`** / **`token-timeout=`** — accept a bare integer (seconds) or any duration string accepted by Go's `time.ParseDuration` (e.g. `30s`, `2m`).
 
  * `rd.modules_force_load` a comma-separated list of extra kernel modules which should be force loaded.

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -134,9 +134,9 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 					m.header = hdrPath
 					m.headerDeviceRef = hdrRef
 				case strings.HasPrefix(opt, "fido2-device="):
-					m.tokenFido2 = true // value ("auto") ignored — booster auto-detects enrolled tokens
+					// accepted for compatibility; token detection uses LUKS2 header
 				case strings.HasPrefix(opt, "tpm2-device="):
-					m.tokenTpm2 = true // value ("auto") ignored — booster auto-detects enrolled tokens
+					// accepted for compatibility; token detection uses LUKS2 header
 				case strings.HasPrefix(opt, "token-timeout="):
 					d, err := parseTokenTimeout(opt[14:])
 					if err != nil {
@@ -188,15 +188,8 @@ func findLuksMapping(ref *deviceRef) *luksMapping {
 
 // mergeCrypttabOptions merges security-relevant options from a crypttab entry (src)
 // into a cmdline-derived mapping (dst). dst's ref and name are preserved; crypttab
-// supplies token flags, keyfile, header, and other unlock options that rd.luks.*
-// params cannot express.
+// supplies keyfile, header, and other unlock options that rd.luks.* params cannot express.
 func mergeCrypttabOptions(dst, src *luksMapping) {
-	if src.tokenFido2 {
-		dst.tokenFido2 = true
-	}
-	if src.tokenTpm2 {
-		dst.tokenTpm2 = true
-	}
 	// Adopt crypttab's token timeout when the cmdline mapping still has the
 	// default (30 s) and the crypttab entry carries an explicit value.
 	if src.tokenTimeout > 0 && src.tokenTimeout != dst.tokenTimeout {

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -154,7 +154,7 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 			continue
 		}
 
-		if (m.tokenFido2 || m.tokenTpm2) && !tokenTimeoutExplicit {
+		if !tokenTimeoutExplicit {
 			m.tokenTimeout = 30 * time.Second // systemd default: wait 30s for tokens before also prompting keyboard
 		}
 

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -265,12 +265,13 @@ func TestParseCrypttabExplicitTokenTimeout(t *testing.T) {
 	require.Equal(t, 60*time.Second, mappings[0].tokenTimeout)
 }
 
+// fido2-device= and tpm2-device= are accepted for crypttab compatibility but no
+// longer set any field; token detection uses the LUKS2 header payload instead.
 func TestParseCrypttabFido2Device(t *testing.T) {
 	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none fido2-device=auto\n"
 	mappings, err := parseCrypttabReader(strings.NewReader(input))
 	require.NoError(t, err)
 	require.Len(t, mappings, 1)
-	require.True(t, mappings[0].tokenFido2)
 	require.Equal(t, 30*time.Second, mappings[0].tokenTimeout)
 }
 
@@ -279,7 +280,6 @@ func TestParseCrypttabTpm2Device(t *testing.T) {
 	mappings, err := parseCrypttabReader(strings.NewReader(input))
 	require.NoError(t, err)
 	require.Len(t, mappings, 1)
-	require.True(t, mappings[0].tokenTpm2)
 	require.Equal(t, 30*time.Second, mappings[0].tokenTimeout)
 }
 
@@ -302,14 +302,10 @@ func TestFindLuksMapping(t *testing.T) {
 func TestMergeCrypttabOptions(t *testing.T) {
 	dst := &luksMapping{name: "cmdline-name", keySlot: -1, tokenTimeout: 30 * time.Second}
 	src := &luksMapping{
-		tokenFido2:  true,
-		tokenTpm2:   false,
-		tries:       3,
+		tries:        3,
 		tokenTimeout: 45 * time.Second,
 	}
 	mergeCrypttabOptions(dst, src)
-	require.True(t, dst.tokenFido2)
-	require.False(t, dst.tokenTpm2)
 	require.Equal(t, 3, dst.tries)
 	require.Equal(t, 45*time.Second, dst.tokenTimeout)
 	require.Equal(t, "cmdline-name", dst.name) // name must not be overwritten
@@ -325,12 +321,10 @@ func TestMergeCrypttabOptionsDstWins(t *testing.T) {
 	require.Equal(t, "/cmdline/hdr", dst.header)   // cmdline header wins
 }
 
-// Regression test: rd.luks.name on the kernel cmdline must not suppress
-// fido2-device= / tpm2-device= options from crypttab for the same UUID.
-// Before the fix, the cmdline mapping silently dropped crypttab security
-// options, leaving tokenFido2=false and causing a spurious passphrase prompt
-// after a successful FIDO2 PIN+touch unlock.
-func TestRdLuksNamePreservesCrypttabFido2(t *testing.T) {
+// rd.luks.name= on the kernel cmdline creates a mapping before crypttab is parsed.
+// The crypttab merge must adopt options (token-timeout, keyfile, etc.) from the
+// crypttab entry without creating a duplicate mapping or overwriting the name.
+func TestRdLuksNameMergesCrypttabOptions(t *testing.T) {
 	const uuidStr = "ab6d7d78-b816-4495-928d-766d6607035e"
 	orig := luksMappings
 	defer func() { luksMappings = orig }()
@@ -341,10 +335,9 @@ func TestRdLuksNamePreservesCrypttabFido2(t *testing.T) {
 	))
 	require.Len(t, luksMappings, 1)
 	require.Equal(t, "cryptroot", luksMappings[0].name)
-	require.False(t, luksMappings[0].tokenFido2, "tokenFido2 should be false before crypttab merge")
 
 	// Simulate the crypttab merge loop from boost().
-	ctInput := "cryptroot UUID=" + uuidStr + " none fido2-device=auto\n"
+	ctInput := "cryptroot UUID=" + uuidStr + " none fido2-device=auto,token-timeout=60\n"
 	ctMappings, err := parseCrypttabReader(strings.NewReader(ctInput))
 	require.NoError(t, err)
 	for _, cm := range ctMappings {
@@ -358,8 +351,7 @@ func TestRdLuksNamePreservesCrypttabFido2(t *testing.T) {
 	require.Len(t, luksMappings, 1, "should still be one mapping, not two")
 	m := luksMappings[0]
 	require.Equal(t, "cryptroot", m.name, "cmdline name must be preserved")
-	require.True(t, m.tokenFido2, "fido2-device= from crypttab must be merged in")
-	require.Equal(t, 30*time.Second, m.tokenTimeout, "token timeout must be set for FIDO2")
+	require.Equal(t, 60*time.Second, m.tokenTimeout, "explicit token-timeout from crypttab must be merged")
 }
 
 // header= is silently ignored — deferred to pr/crypttab-header.

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -245,6 +245,26 @@ func TestParseCrypttabXInitrdAttachIgnored(t *testing.T) {
 	}
 }
 
+// Any LUKS entry gets the 30s default token-timeout, not just those with
+// fido2-device= or tpm2-device=. LUKS2 volumes may carry tokens enrolled
+// via systemd-cryptenroll without crypttab flags.
+func TestParseCrypttabDefaultTokenTimeout(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, 30*time.Second, mappings[0].tokenTimeout)
+}
+
+// Explicit token-timeout= in crypttab overrides the default.
+func TestParseCrypttabExplicitTokenTimeout(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none token-timeout=60\n"
+	mappings, err := parseCrypttabReader(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	require.Equal(t, 60*time.Second, mappings[0].tokenTimeout)
+}
+
 func TestParseCrypttabFido2Device(t *testing.T) {
 	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none fido2-device=auto\n"
 	mappings, err := parseCrypttabReader(strings.NewReader(input))

--- a/init/luks.go
+++ b/init/luks.go
@@ -32,8 +32,6 @@ type luksMapping struct {
 	header          string        // detached LUKS header path (empty = embedded header)
 	headerDeviceRef *deviceRef    // non-nil when header is a file on a separate device
 	tokenTimeout    time.Duration // how long to wait for tokens before also starting keyboard; 0 = wait forever
-	tokenFido2      bool          // fido2-device= was set in crypttab — parsed for compatibility; priority now derived from LUKS2 header
-	tokenTpm2       bool          // tpm2-device= was set in crypttab — parsed for compatibility; priority now derived from LUKS2 header
 
 	keyfileDeviceRef *deviceRef    // non-nil when keyfile is on a separate device
 	keyfileTimeout   time.Duration // device wait timeout for keyfile device (0 = use MountTimeout)
@@ -738,18 +736,6 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	var tokenWg sync.WaitGroup
 	var keyboardOnce sync.Once
 
-	// priorityTypes holds token types that should delay the keyboard prompt.
-	// When non-empty, keyboard unlock is deferred until these tokens finish
-	// (or tokenTimeout elapses), matching systemd-cryptsetup fido2-device= behavior.
-	priorityTypes := make(map[string]bool)
-	if mapping.tokenFido2 {
-		priorityTypes["systemd-fido2"] = true
-	}
-	if mapping.tokenTpm2 {
-		priorityTypes["systemd-tpm2"] = true
-	}
-	hasPriority := len(priorityTypes) > 0
-
 	// startKeyboard launches the keyboard (or keyfile) unlock goroutine at most once.
 	startKeyboard := func(checkSlots []int) {
 		keyboardOnce.Do(func() {
@@ -763,61 +749,46 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		})
 	}
 
-	slotsWithTokens := make(map[int]bool)
 	tokens, err := d.Tokens()
 	if err != nil {
 		return err
 	}
+
+	slotsWithTokens := make(map[int]bool)
 	for _, t := range tokens {
 		if t.Type == "systemd-recovery" {
 			continue // skipped: entered via keyboard later
 		}
 		t := t
-		if hasPriority && priorityTypes[t.Type] {
-			// Priority token: track in tokenWg so keyboard waits for it.
-			senderWg.Add(1)
-			tokenWg.Add(1)
-			go func() {
-				defer senderWg.Done()
-				defer tokenWg.Done()
-				if recoverTokenPassword(volumes, done, d, t, mapping.name) {
-					closeDone.Do(func() { close(done) })
-				}
-			}()
-		} else {
-			// Non-priority token: fire-and-forget w.r.t. keyboard *timing*, but
-			// close done on success so the waiter never races to start the keyboard
-			// after a successful token unlock.
-			senderWg.Add(1)
-			tokenWg.Add(1)
-			go func() {
-				defer senderWg.Done()
-				defer tokenWg.Done()
-				if recoverTokenPassword(volumes, done, d, t, mapping.name) {
-					closeDone.Do(func() { close(done) })
-				}
-			}()
-		}
+		senderWg.Add(1)
+		tokenWg.Add(1)
+		go func() {
+			defer senderWg.Done()
+			defer tokenWg.Done()
+			if recoverTokenPassword(volumes, done, d, t, mapping.name) {
+				closeDone.Do(func() { close(done) })
+			}
+		}()
 		for _, s := range t.Slots {
 			slotsWithTokens[s] = true
 		}
 	}
 
-	// checkSlotsWithPassword = slots not covered by any token; these are tried by
-	// the keyboard/keyfile goroutine.  When hasPriority is false we pass all
-	// available slots so the keyboard can try token slots too (existing behavior).
-	var checkSlotsWithPassword []int
-	if hasPriority {
+	// Keyboard always skips slots claimed by any token: a typed passphrase will never
+	// unseal a slot enrolled for a hardware credential (TPM2, FIDO2, clevis).
+	// Fall back to all slots only when every slot is token-owned (no dedicated
+	// passphrase slot exists).
+	checkSlotsWithPassword := availableSlots
+	if len(slotsWithTokens) > 0 {
+		var filtered []int
 		for _, s := range availableSlots {
 			if !slotsWithTokens[s] {
-				checkSlotsWithPassword = append(checkSlotsWithPassword, s)
+				filtered = append(filtered, s)
 			}
 		}
-		if len(checkSlotsWithPassword) == 0 {
-			checkSlotsWithPassword = availableSlots
+		if len(filtered) > 0 {
+			checkSlotsWithPassword = filtered
 		}
-	} else {
-		checkSlotsWithPassword = availableSlots
 	}
 
 	// Start keyboard/keyfile unlock after all token goroutines finish (or tokenTimeout

--- a/init/luks.go
+++ b/init/luks.go
@@ -32,8 +32,8 @@ type luksMapping struct {
 	header          string        // detached LUKS header path (empty = embedded header)
 	headerDeviceRef *deviceRef    // non-nil when header is a file on a separate device
 	tokenTimeout    time.Duration // how long to wait for tokens before also starting keyboard; 0 = wait forever
-	tokenFido2      bool          // fido2-device= was set in crypttab — attempt FIDO2 token unlock
-	tokenTpm2       bool          // tpm2-device= was set in crypttab — attempt TPM2 token unlock
+	tokenFido2      bool          // fido2-device= was set in crypttab — parsed for compatibility; priority now derived from LUKS2 header
+	tokenTpm2       bool          // tpm2-device= was set in crypttab — parsed for compatibility; priority now derived from LUKS2 header
 
 	keyfileDeviceRef *deviceRef    // non-nil when keyfile is on a separate device
 	keyfileTimeout   time.Duration // device wait timeout for keyfile device (0 = use MountTimeout)


### PR DESCRIPTION
Booster already reads the LUKS2 header via `d.Tokens()` for every unlock attempt — the same metadata `systemd-cryptenroll` writes. The `fido2-device=` and `tpm2-device=` crypttab options were therefore redundant: they duplicated information already available in the header and inconsistently with every other token type (clevis, recovery) which never required crypttab annotation.

The flags also left a correctness gap. Without them, `luksOpen` had no `priorityTypes` entry for the volume, so the keyboard goroutine would try passphrase unlock against hardware-credential slots (TPM2, FIDO2, clevis) where a typed passphrase can never succeed.

**Changes:**

- `fido2-device=` and `tpm2-device=` are still accepted in crypttab for compatibility but have no effect
- `tokenFido2`/`tokenTpm2` fields and the `priorityTypes`/`hasPriority` mechanism removed from `luksMapping` and `luksOpen`
- Slot exclusion is now unconditional: the keyboard goroutine always skips slots claimed by any token in the LUKS2 header, with fallback to all slots only when no dedicated passphrase slot exists
- The 30s `token-timeout` default now applies to all LUKS entries, not just those with crypttab token flags — any LUKS2 volume may carry enrolled tokens