### PR TITLE
init: fix TPM2 PIN token unlock — empty PCR policy digest and missing retry/skip

### DIFF
--- a/init/luks.go
+++ b/init/luks.go
@@ -253,6 +253,7 @@ var fido2Mu sync.Mutex
 var errFido2Skipped = errors.New("FIDO2 skipped by user")
 var errFido2PinInvalid = errors.New("FIDO2 PIN invalid")
 var errFido2FallbackToKeyboard = errors.New("FIDO2 falling back to keyboard")
+var errTPM2Skipped = errors.New("TPM2 skipped by user")
 
 func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, error) {
 	var node struct {
@@ -349,7 +350,7 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 	return nil, errFido2FallbackToKeyboard
 }
 
-func recoverSystemdTPM2Password(t luks.Token) ([]byte, error) {
+func recoverSystemdTPM2Password(t luks.Token, mappingName string) ([]byte, error) {
 	var node struct {
 		Blob       string `json:"tpm2-blob"`        // base64
 		PCRs       []int  `json:"tpm2-pcrs"`
@@ -382,34 +383,6 @@ func recoverSystemdTPM2Password(t luks.Token) ([]byte, error) {
 
 	bank := parsePCRBank(node.PCRBank)
 
-	var authValue []byte
-	if node.Pin {
-		prompt := "Please enter TPM pin: "
-		var pin []byte
-		var err error
-		if plymouthEnabled {
-			pin, err = plymouthAskPassword(prompt)
-			if err != nil {
-				warning("Plymouth password prompt failed: %v, falling back to console", err)
-				pin, err = readPassword(prompt, "")
-			}
-		} else {
-			pin, err = readPassword(prompt, "")
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		var salt []byte
-		if node.Salt != "" {
-			salt, err = base64.StdEncoding.DecodeString(node.Salt)
-			if err != nil {
-				return nil, fmt.Errorf("tpm2_salt: %v", err)
-			}
-		}
-		authValue = tpm2PINAuthValue(pin, salt)
-	}
-
 	var srkHandle tpmutil.Handle
 	if node.Srk != "" {
 		srkBytes, err := base64.StdEncoding.DecodeString(node.Srk)
@@ -419,11 +392,56 @@ func recoverSystemdTPM2Password(t luks.Token) ([]byte, error) {
 		srkHandle = extractSRKHandle(srkBytes)
 	}
 
-	password, err := tpm2Unseal(public, private, node.PCRs, bank, policyHash, authValue, srkHandle)
-	if err != nil {
+	var salt []byte
+	if node.Salt != "" {
+		var err error
+		salt, err = base64.StdEncoding.DecodeString(node.Salt)
+		if err != nil {
+			return nil, fmt.Errorf("tpm2_salt: %v", err)
+		}
+	}
+
+	maxAttempts := 1
+	if node.Pin {
+		maxAttempts = 3
+	}
+	promptPrefix := ""
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		var authValue []byte
+		if node.Pin {
+			prompt := promptPrefix + "Enter TPM2 PIN for " + mappingName + ":"
+			var pin []byte
+			var err error
+			if plymouthEnabled {
+				pin, err = plymouthAskPassword(prompt)
+				if err != nil {
+					warning("Plymouth password prompt failed: %v, falling back to console", err)
+					pin, err = readPassword(prompt, "")
+				}
+			} else {
+				pin, err = readPassword(prompt, "")
+			}
+			if err != nil {
+				return nil, err
+			}
+			if len(pin) == 0 {
+				statusMessage("TPM2 PIN skipped")
+				return nil, errTPM2Skipped
+			}
+			authValue = tpm2PINAuthValue(pin, salt)
+		}
+
+		password, err := tpm2Unseal(public, private, node.PCRs, bank, policyHash, authValue, srkHandle)
+		if err == nil {
+			return []byte(base64.StdEncoding.EncodeToString(password)), nil
+		}
+		if node.Pin && attempt < maxAttempts-1 {
+			promptPrefix = "TPM2 PIN incorrect — "
+			continue
+		}
 		return nil, err
 	}
-	return []byte(base64.StdEncoding.EncodeToString(password)), nil
+	return nil, fmt.Errorf("TPM2 PIN incorrect")
 }
 
 func parseSystemdTPM2Blob(blob []byte) (private, public []byte, err error) {
@@ -458,7 +476,7 @@ func recoverTokenPassword(volumes chan *luks.Volume, done <-chan struct{}, d luk
 	case "systemd-fido2":
 		password, err = recoverSystemdFido2Password(t, mappingName)
 	case "systemd-tpm2":
-		password, err = recoverSystemdTPM2Password(t)
+		password, err = recoverSystemdTPM2Password(t, mappingName)
 	default:
 		info("token #%d has unknown type: %s", t.ID, t.Type)
 		return false
@@ -466,6 +484,9 @@ func recoverTokenPassword(volumes chan *luks.Volume, done <-chan struct{}, d luk
 
 	if errors.Is(err, errFido2FallbackToKeyboard) {
 		return false // intentional fallback; message already logged in recoverSystemdFido2Password
+	}
+	if errors.Is(err, errTPM2Skipped) {
+		return false // intentional fallback; message already shown in recoverSystemdTPM2Password
 	}
 	if err != nil {
 		warning("recovering %s token #%d failed: %v", t.Type, t.ID, err)

--- a/init/tpm.go
+++ b/init/tpm.go
@@ -183,14 +183,14 @@ func policyPCRSession(dev io.ReadWriteCloser, pcrs []int, algo tpm2.Algorithm, e
 		return tpm2.HandleNull, nil, fmt.Errorf("unable to start session: %v", err)
 	}
 
-	pcrSelection := tpm2.PCRSelection{
-		Hash: algo,
-		PCRs: pcrs,
-	}
-
-	// An empty expected digest means that digest verification is skipped.
-	if err := tpm2.PolicyPCR(dev, sessHandle, nil, pcrSelection); err != nil {
-		return tpm2.HandleNull, nil, fmt.Errorf("unable to bind PCRs to auth policy: %v", err)
+	if len(pcrs) > 0 {
+		pcrSelection := tpm2.PCRSelection{
+			Hash: algo,
+			PCRs: pcrs,
+		}
+		if err := tpm2.PolicyPCR(dev, sessHandle, nil, pcrSelection); err != nil {
+			return tpm2.HandleNull, nil, fmt.Errorf("unable to bind PCRs to auth policy: %v", err)
+		}
 	}
 
 	if usePassword {

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -67,6 +67,10 @@ var assetGenerators = map[string]assetGenerator{
 	}},
 	"systemd-tpm2.img":              {"systemd_tpm2.sh", []string{"LUKS_UUID=5cbc48ce-0e78-4c6b-ac90-a8a540514b90", "FS_UUID=d8673e36-d4a3-4408-a87d-be0cb79f91a2", "LUKS_PASSWORD=567"}},
 	"systemd-tpm2-withpin.img":      {"systemd_tpm2.sh", []string{"LUKS_UUID=8bb97618-7ef4-4c93-b4f7-f2cb17cf7da1", "FS_UUID=26dbbe17-9af9-4322-bb5f-c1d74a40e618", "LUKS_PASSWORD=9999", "CRYPTENROLL_TPM2_PIN=foo654"}},
+	// systemd-tpm2-pin-passphrase.img: LUKS2 with both a TPM2+PIN token and a
+	// passphrase slot.  Used to test empty-PIN skip (falls through to passphrase)
+	// and PIN exhaustion (3 wrong tries → passphrase fallback).
+	"systemd-tpm2-pin-passphrase.img": {"systemd_tpm2.sh", []string{"LUKS_UUID=f3e4d5c6-b7a8-4901-c234-d5e6f7a8b9c0", "FS_UUID=a4b5c6d7-e8f9-4012-d345-e6f7a8b9c0d1", "LUKS_PASSWORD=567", "CRYPTENROLL_TPM2_PIN=foo654", "KEEP_PASSPHRASE_SLOT=1"}},
 	// systemd-tpm2-nopcr-pin.img: TPM2+PIN token enrolled without PCR binding.
 	// Exercises the policyPCRSession path where len(pcrs)==0 so only PolicyPassword
 	// is applied (no PolicyPCR call).  Regression test for the bug where an empty

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -67,6 +67,11 @@ var assetGenerators = map[string]assetGenerator{
 	}},
 	"systemd-tpm2.img":              {"systemd_tpm2.sh", []string{"LUKS_UUID=5cbc48ce-0e78-4c6b-ac90-a8a540514b90", "FS_UUID=d8673e36-d4a3-4408-a87d-be0cb79f91a2", "LUKS_PASSWORD=567"}},
 	"systemd-tpm2-withpin.img":      {"systemd_tpm2.sh", []string{"LUKS_UUID=8bb97618-7ef4-4c93-b4f7-f2cb17cf7da1", "FS_UUID=26dbbe17-9af9-4322-bb5f-c1d74a40e618", "LUKS_PASSWORD=9999", "CRYPTENROLL_TPM2_PIN=foo654"}},
+	// systemd-tpm2-nopcr-pin.img: TPM2+PIN token enrolled without PCR binding.
+	// Exercises the policyPCRSession path where len(pcrs)==0 so only PolicyPassword
+	// is applied (no PolicyPCR call).  Regression test for the bug where an empty
+	// PCR selection still mutated the policy digest, causing auth failure.
+	"systemd-tpm2-nopcr-pin.img": {"systemd_tpm2.sh", []string{"LUKS_UUID=d9ef7bf3-b4f8-4271-9f3c-df63d457fcc6", "FS_UUID=6abcf123-4182-452b-9c87-a769dc344e3b", "LUKS_PASSWORD=567", "CRYPTENROLL_TPM2_PIN=foo654", "CRYPTENROLL_TPM2_PCRS="}},
 	"systemd-tpm2-srk.img":          {"systemd_tpm2.sh", []string{"LUKS_UUID=c09debc6-6a06-4317-94f5-0916bb9ea1c8", "FS_UUID=5a6daa83-ea51-47dd-a38b-2b66d5cc8428", "LUKS_PASSWORD=567"}},
 	// systemd-tpm2-legacy-pin.img: v252-254 format token — tpm2_srk present but
 	// no tpm2_salt, PIN auth via SHA256(pin) without PBKDF2.  Generated with

--- a/tests/generators/systemd_tpm2.sh
+++ b/tests/generators/systemd_tpm2.sh
@@ -47,6 +47,10 @@ printf '%s' "${LUKS_PASSWORD}" > assets/cryptenroll.passphrase
 # it looks like edk2 extends PCR 0-7 so let's use some other PCR outside of this range.
 # Pass SWTPM env vars explicitly so systemd-cryptenroll uses our TCP swtpm rather
 # than any real hardware TPM that may be present on the host.
+# CRYPTENROLL_TPM2_PCRS controls PCR binding. Defaults to 10+13; set to empty
+# string to enroll without PCR binding (tests the no-PCR policy path).
+PCRS_FLAG="--tpm2-pcrs=${CRYPTENROLL_TPM2_PCRS:-10+13}"
+
 if [ "${CRYPTENROLL_TPM2_PIN}" != "" ]; then
   # cryptenroll.new-tpm2-pin is the credential name for setting a new PIN during enrollment
   printf '%s' "${CRYPTENROLL_TPM2_PIN}" > assets/cryptenroll.new-tpm2-pin
@@ -54,11 +58,11 @@ if [ "${CRYPTENROLL_TPM2_PIN}" != "" ]; then
   # Pass the full TCTI string directly so cryptenroll cannot fall back to /dev/tpm0.
   sudo env CREDENTIALS_DIRECTORY="$(pwd)/assets" \
     systemd-cryptenroll --tpm2-device="swtpm:host=localhost,port=2321" \
-    --tpm2-pcrs=10+13 --tpm2-with-pin=true "${lodev}"
+    "${PCRS_FLAG}" --tpm2-with-pin=true "${lodev}"
 else
   sudo env CREDENTIALS_DIRECTORY="$(pwd)/assets" \
     systemd-cryptenroll --tpm2-device="swtpm:host=localhost,port=2321" \
-    --tpm2-pcrs=10+13 "${lodev}"
+    "${PCRS_FLAG}" "${lodev}"
 fi
 
 sudo cryptsetup open --disable-external-tokens --type luks2 "${lodev}" "${LUKS_DEV_NAME}" <<< "${LUKS_PASSWORD}"

--- a/tests/generators/systemd_tpm2.sh
+++ b/tests/generators/systemd_tpm2.sh
@@ -73,7 +73,7 @@ sudo chown "${USER}" "${dir}"
 mkdir "${dir}/sbin"
 cp assets/init "${dir}/sbin/init"
 
-if [ "${CRYPTENROLL_TPM2_PIN}" != "" ]; then
+if [ "${CRYPTENROLL_TPM2_PIN}" != "" ] && [ "${KEEP_PASSPHRASE_SLOT}" != "1" ]; then
   sudo cryptsetup -v luksKillSlot "${lodev}" 0
 fi
 

--- a/tests/systemd_test.go
+++ b/tests/systemd_test.go
@@ -82,7 +82,7 @@ func TestSystemdTPM2WithPin(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Shutdown()
 
-	require.NoError(t, vm.ConsoleExpect("Please enter TPM pin:"))
+	require.NoError(t, vm.ConsoleExpect("Enter TPM2 PIN for"))
 	require.NoError(t, vm.ConsoleWrite("foo654\n"))
 
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
@@ -108,6 +108,76 @@ func TestSystemdTPM2NoPcrPin(t *testing.T) {
 
 	require.NoError(t, vm.ConsoleExpect("Enter TPM2 PIN for"))
 	require.NoError(t, vm.ConsoleWrite("foo654\n"))
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+func TestSystemdTPM2PinSkip(t *testing.T) {
+	swtpm, params, err := startSwtpm()
+	require.NoError(t, err)
+	defer swtpm.Kill()
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:       "assets/systemd-tpm2-pin-passphrase.img",
+		kernelArgs: []string{"rd.luks.uuid=f3e4d5c6-b7a8-4901-c234-d5e6f7a8b9c0", "root=UUID=a4b5c6d7-e8f9-4012-d345-e6f7a8b9c0d1"},
+		params:     params,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	// Empty PIN skips the TPM2 token and falls through to passphrase prompt.
+	require.NoError(t, vm.ConsoleExpect("Enter TPM2 PIN for"))
+	require.NoError(t, vm.ConsoleWrite("\n"))
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for"))
+	require.NoError(t, vm.ConsoleWrite("567\n"))
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+func TestSystemdTPM2PinRetry(t *testing.T) {
+	swtpm, params, err := startSwtpm()
+	require.NoError(t, err)
+	defer swtpm.Kill()
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:       "assets/systemd-tpm2-withpin.img",
+		kernelArgs: []string{"rd.luks.uuid=8bb97618-7ef4-4c93-b4f7-f2cb17cf7da1", "root=UUID=26dbbe17-9af9-4322-bb5f-c1d74a40e618"},
+		params:     params,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	// Wrong PIN on first attempt; correct PIN on retry.
+	require.NoError(t, vm.ConsoleExpect("Enter TPM2 PIN for"))
+	require.NoError(t, vm.ConsoleWrite("wrongpin\n"))
+	require.NoError(t, vm.ConsoleExpect("TPM2 PIN incorrect"))
+	require.NoError(t, vm.ConsoleWrite("foo654\n"))
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+func TestSystemdTPM2PinExhausted(t *testing.T) {
+	swtpm, params, err := startSwtpm()
+	require.NoError(t, err)
+	defer swtpm.Kill()
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:       "assets/systemd-tpm2-pin-passphrase.img",
+		kernelArgs: []string{"rd.luks.uuid=f3e4d5c6-b7a8-4901-c234-d5e6f7a8b9c0", "root=UUID=a4b5c6d7-e8f9-4012-d345-e6f7a8b9c0d1"},
+		params:     params,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	// Three wrong PINs exhaust the token; booster falls back to passphrase.
+	require.NoError(t, vm.ConsoleExpect("Enter TPM2 PIN for"))
+	require.NoError(t, vm.ConsoleWrite("bad1\n"))
+	require.NoError(t, vm.ConsoleExpect("TPM2 PIN incorrect"))
+	require.NoError(t, vm.ConsoleWrite("bad2\n"))
+	require.NoError(t, vm.ConsoleExpect("TPM2 PIN incorrect"))
+	require.NoError(t, vm.ConsoleWrite("bad3\n"))
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for"))
+	require.NoError(t, vm.ConsoleWrite("567\n"))
 
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
 }
@@ -155,7 +225,7 @@ func TestSystemdTPM2LegacyPin(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Shutdown()
 
-	require.NoError(t, vm.ConsoleExpect("Please enter TPM pin:"))
+	require.NoError(t, vm.ConsoleExpect("Enter TPM2 PIN for"))
 	require.NoError(t, vm.ConsoleWrite("foo654\n"))
 
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))

--- a/tests/systemd_test.go
+++ b/tests/systemd_test.go
@@ -88,6 +88,30 @@ func TestSystemdTPM2WithPin(t *testing.T) {
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
 }
 
+// TestSystemdTPM2NoPcrPin tests unlock of a LUKS2 volume whose TPM2+PIN token
+// was enrolled without PCR binding (--tpm2-pcrs="").  The policy digest only
+// covers PolicyPassword; a previous bug caused policyPCRSession to call
+// PolicyPCR with an empty selection even when len(pcrs)==0, which mutated the
+// digest and made the unseal fail regardless of PIN correctness.
+func TestSystemdTPM2NoPcrPin(t *testing.T) {
+	swtpm, params, err := startSwtpm()
+	require.NoError(t, err)
+	defer swtpm.Kill()
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:       "assets/systemd-tpm2-nopcr-pin.img",
+		kernelArgs: []string{"rd.luks.uuid=d9ef7bf3-b4f8-4271-9f3c-df63d457fcc6", "root=UUID=6abcf123-4182-452b-9c87-a769dc344e3b"},
+		params:     params,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter TPM2 PIN for"))
+	require.NoError(t, vm.ConsoleWrite("foo654\n"))
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
 // TestSystemdTPM2SRK tests unlock of a LUKS2 volume enrolled with systemd-cryptenroll
 // v252+, which provisions a persistent SRK at handle 0x81000001 and records it as
 // tpm2_srk in the token JSON. Booster must use that handle rather than deriving a


### PR DESCRIPTION
Two TPM2 PIN improvements.

## Bug — `policyPCRSession` corrupts policy digest for PCR-free tokens

When a token is enrolled without PCR binding (`systemd-cryptenroll --tpm2-pcrs=""`), the stored policy digest is computed from `PolicyPassword` only. `policyPCRSession` was calling `tpm2.PolicyPCR` unconditionally — even when `len(pcrs) == 0`. An empty PCR selection still mutates the running policy digest in the TPM session, so the computed digest diverged from the stored one and unseal failed regardless of whether the PIN was correct.

## Feature — TPM2 PIN retry loop and empty-input skip (parity with FIDO2)

FIDO2 PIN tokens already had 3-attempt retry with per-attempt feedback and an empty-input path to skip the token and fall through to the passphrase prompt. TPM2 now matches:

- 3-attempt loop with `"TPM2 PIN incorrect — "` prefix on subsequent prompts
- Empty PIN on first attempt skips the token immediately, falling through to the passphrase prompt
- Prompt updated from the generic `"Please enter TPM pin:"` to `"Enter TPM2 PIN for <name>:"` consistent with FIDO2

## Tests

- `TestSystemdTPM2NoPcrPin` — regression test for the PCR digest bug; image enrolled with `--tpm2-pcrs=""`
- `TestSystemdTPM2PinSkip` — empty PIN falls through to passphrase
- `TestSystemdTPM2PinRetry` — wrong PIN then correct PIN succeeds
- `TestSystemdTPM2PinExhausted` — 3 wrong PINs fall through to passphrase
- `systemd_tpm2.sh` gains `CRYPTENROLL_TPM2_PCRS` and `KEEP_PASSPHRASE_SLOT` env vars to support the new asset variants