### PR TITLE
init/luks: minor cleanups in keyboard unlock path

### DIFF
--- a/init/luks.go
+++ b/init/luks.go
@@ -570,6 +570,24 @@ func recoverKeyfilePassword(volumes chan *luks.Volume, done <-chan struct{}, d l
 	requestKeyboardPassword(volumes, done, d, checkSlots, mapping.name, mapping.tries)
 }
 
+// tryCachedPassphrases snapshots passphraseCache and tries each entry against
+// checkSlots. Returns true if any unlocked the volume — caller should return
+// without prompting. The snapshot avoids holding passphraseCache.Lock across
+// the (potentially slow) UnsealVolume calls.
+func tryCachedPassphrases(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, checkSlots []int) bool {
+	passphraseCache.Lock()
+	cached := make([][]byte, len(passphraseCache.passwords))
+	copy(cached, passphraseCache.passwords)
+	passphraseCache.Unlock()
+
+	for _, pw := range cached {
+		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, pw) {
+			return true
+		}
+	}
+	return false
+}
+
 func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, checkSlots []int, mappingName string, maxTries int) {
 	// Wait for plymouth initialization to complete before attempting to use
 	// it. Without this, udev events can trigger LUKS password prompts while
@@ -585,15 +603,8 @@ func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d 
 
 	// Fast path: try passwords that already unlocked another volume this boot
 	// (e.g. two LUKS members of a btrfs RAID1 with the same passphrase).
-	passphraseCache.Lock()
-	cached := make([][]byte, len(passphraseCache.passwords))
-	copy(cached, passphraseCache.passwords)
-	passphraseCache.Unlock()
-
-	for _, pw := range cached {
-		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, pw) {
-			return
-		}
+	if tryCachedPassphrases(volumes, done, d, checkSlots) {
+		return
 	}
 
 	// Serialize prompts across concurrent luksOpen calls. A second device whose
@@ -610,15 +621,8 @@ func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d 
 	default:
 	}
 
-	passphraseCache.Lock()
-	cached = make([][]byte, len(passphraseCache.passwords))
-	copy(cached, passphraseCache.passwords)
-	passphraseCache.Unlock()
-
-	for _, pw := range cached {
-		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, pw) {
-			return
-		}
+	if tryCachedPassphrases(volumes, done, d, checkSlots) {
+		return
 	}
 
 	attempts := 0

--- a/init/luks.go
+++ b/init/luks.go
@@ -764,20 +764,6 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	var closeDone sync.Once
 	var senderWg sync.WaitGroup
 	var tokenWg sync.WaitGroup
-	var keyboardOnce sync.Once
-
-	// startKeyboard launches the keyboard (or keyfile) unlock goroutine at most once.
-	startKeyboard := func(checkSlots []int) {
-		keyboardOnce.Do(func() {
-			senderWg.Go(func() {
-				if mapping.keyfile != "" {
-					recoverKeyfilePassword(volumes, done, d, checkSlots, mapping)
-				} else {
-					requestKeyboardPassword(volumes, done, d, checkSlots, mapping.name, mapping.tries)
-				}
-			})
-		})
-	}
 
 	tokens, err := d.Tokens()
 	if err != nil {
@@ -836,7 +822,13 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		default:
 		}
 		if len(checkSlotsWithPassword) > 0 {
-			startKeyboard(checkSlotsWithPassword)
+			senderWg.Go(func() {
+				if mapping.keyfile != "" {
+					recoverKeyfilePassword(volumes, done, d, checkSlotsWithPassword, mapping)
+				} else {
+					requestKeyboardPassword(volumes, done, d, checkSlotsWithPassword, mapping.name, mapping.tries)
+				}
+			})
 		}
 	})
 


### PR DESCRIPTION
  Two follow-up cleanups in the LUKS keyboard-unlock path. No functional changes.

  - Extract the duplicated passphrase-cache snapshot+iterate block in
    requestKeyboardPassword into a `tryCachedPassphrases` helper. The
    duplication emerged when the post-keyboardMu second snapshot was added
    (#306) — collapse both into one helper.
  - Drop the keyboardOnce sync.Once that guarded a closure with a single
    call site; inline the closure body.
    
    
    
  Both changes are pure refactors. The full test suite passes locally.