### PR TITLE
init/luks: dispatch tokens in deterministic ID order

### DIFF
--- a/init/luks.go
+++ b/init/luks.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"net"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -769,6 +770,11 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	if err != nil {
 		return err
 	}
+
+	// Sort ascending by token ID. d.Tokens() iterates a Go map so its return
+	// order is randomised every boot; without the sort the user can't predict
+	// which token (TPM2 vs FIDO2 vs clevis) tries to unlock first.
+	sort.Slice(tokens, func(i, j int) bool { return tokens[i].ID < tokens[j].ID })
 
 	slotsWithTokens := make(map[int]bool)
 	for _, t := range tokens {


### PR DESCRIPTION
`d.Tokens()` iterates a `map[int]json.RawMessage` internally, so the
returned slice order is randomised across reboots. Without a sort,
the "first token to prompt" varies between boots even when the user
has a clear preferred unlock method (e.g. enrolled the TPM2 first
and expects it to be tried before the FIDO2 backup).

Sort tokens by ID in ascending order before dispatch so the order
matches enrollment.

Also a prerequisite for any future per-token priority scheduling work.