### PR TITLE
init/luks: improve FIDO2 unlock error handling and PIN-attempt accounting

### DIFF
--- a/init/fido2_cgo.go
+++ b/init/fido2_cgo.go
@@ -71,3 +71,11 @@ func isFido2PinBlockedError(err error) bool {
 	}
 	return fido2plugin.IsFido2PinBlocked(err)
 }
+
+func isFido2WrongDeviceError(err error) bool {
+	loadFido2Plugin()
+	if fido2plugin == nil {
+		return false
+	}
+	return fido2plugin.IsFido2WrongDevice(err)
+}

--- a/init/fido2_cgo.go
+++ b/init/fido2_cgo.go
@@ -87,3 +87,11 @@ func isFido2PinRequiredError(err error) bool {
 	}
 	return fido2plugin.IsFido2PinRequired(err)
 }
+
+func isFido2TouchTimeoutError(err error) bool {
+	loadFido2Plugin()
+	if fido2plugin == nil {
+		return false
+	}
+	return fido2plugin.IsFido2TouchTimeout(err)
+}

--- a/init/fido2_cgo.go
+++ b/init/fido2_cgo.go
@@ -79,3 +79,11 @@ func isFido2WrongDeviceError(err error) bool {
 	}
 	return fido2plugin.IsFido2WrongDevice(err)
 }
+
+func isFido2PinRequiredError(err error) bool {
+	loadFido2Plugin()
+	if fido2plugin == nil {
+		return false
+	}
+	return fido2plugin.IsFido2PinRequired(err)
+}

--- a/init/fido2_nocgo.go
+++ b/init/fido2_nocgo.go
@@ -19,3 +19,7 @@ func isFido2PinAuthBlockedError(err error) bool {
 func isFido2PinBlockedError(err error) bool {
 	return false
 }
+
+func isFido2WrongDeviceError(err error) bool {
+	return false
+}

--- a/init/fido2_nocgo.go
+++ b/init/fido2_nocgo.go
@@ -23,3 +23,7 @@ func isFido2PinBlockedError(err error) bool {
 func isFido2WrongDeviceError(err error) bool {
 	return false
 }
+
+func isFido2PinRequiredError(err error) bool {
+	return false
+}

--- a/init/fido2_nocgo.go
+++ b/init/fido2_nocgo.go
@@ -27,3 +27,7 @@ func isFido2WrongDeviceError(err error) bool {
 func isFido2PinRequiredError(err error) bool {
 	return false
 }
+
+func isFido2TouchTimeoutError(err error) bool {
+	return false
+}

--- a/init/fido2iface/fido2iface.go
+++ b/init/fido2iface/fido2iface.go
@@ -10,4 +10,5 @@ type Fido2Plugin interface {
 	IsFido2PinInvalid(err error) bool
 	IsFido2PinAuthBlocked(err error) bool
 	IsFido2PinBlocked(err error) bool
+	IsFido2WrongDevice(err error) bool
 }

--- a/init/fido2iface/fido2iface.go
+++ b/init/fido2iface/fido2iface.go
@@ -11,4 +11,5 @@ type Fido2Plugin interface {
 	IsFido2PinAuthBlocked(err error) bool
 	IsFido2PinBlocked(err error) bool
 	IsFido2WrongDevice(err error) bool
+	IsFido2PinRequired(err error) bool
 }

--- a/init/fido2iface/fido2iface.go
+++ b/init/fido2iface/fido2iface.go
@@ -12,4 +12,5 @@ type Fido2Plugin interface {
 	IsFido2PinBlocked(err error) bool
 	IsFido2WrongDevice(err error) bool
 	IsFido2PinRequired(err error) bool
+	IsFido2TouchTimeout(err error) bool
 }

--- a/init/fido2plugin/errors_test.go
+++ b/init/fido2plugin/errors_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	libfido2 "github.com/keys-pub/go-libfido2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsFido2WrongDevice(t *testing.T) {
+	impl := &fido2Impl{}
+
+	require.True(t, impl.IsFido2WrongDevice(libfido2.ErrNoCredentials))
+	require.True(t, impl.IsFido2WrongDevice(libfido2.ErrInvalidCredential))
+	require.True(t, impl.IsFido2WrongDevice(fmt.Errorf("wrap: %w", libfido2.ErrNoCredentials)))
+
+	require.False(t, impl.IsFido2WrongDevice(nil))
+	require.False(t, impl.IsFido2WrongDevice(libfido2.ErrPinInvalid))
+	require.False(t, impl.IsFido2WrongDevice(errors.New("some other error")))
+}
+
+func TestIsFido2PinRequired(t *testing.T) {
+	impl := &fido2Impl{}
+
+	require.True(t, impl.IsFido2PinRequired(libfido2.ErrPinRequired))
+	require.True(t, impl.IsFido2PinRequired(fmt.Errorf("wrap: %w", libfido2.ErrPinRequired)))
+
+	require.False(t, impl.IsFido2PinRequired(nil))
+	require.False(t, impl.IsFido2PinRequired(libfido2.ErrPinInvalid))
+	require.False(t, impl.IsFido2PinRequired(libfido2.ErrNoCredentials))
+}
+
+func TestIsFido2PinInvalid(t *testing.T) {
+	impl := &fido2Impl{}
+
+	// FIDO_ERR_PIN_INVALID (49) — mapped sentinel.
+	require.True(t, impl.IsFido2PinInvalid(libfido2.ErrPinInvalid))
+	require.True(t, impl.IsFido2PinInvalid(fmt.Errorf("wrap: %w", libfido2.ErrPinInvalid)))
+
+	// FIDO_ERR_PIN_AUTH_INVALID (51) — unmapped, generic error string.
+	require.True(t, impl.IsFido2PinInvalid(libfido2.Error{Code: 51}))
+	require.True(t, impl.IsFido2PinInvalid(errors.New("libfido2 error 51")))
+
+	// FIDO_ERR_UV_INVALID (63) — unmapped, generic error string.
+	require.True(t, impl.IsFido2PinInvalid(libfido2.Error{Code: 63}))
+	require.True(t, impl.IsFido2PinInvalid(errors.New("libfido2 error 63")))
+
+	require.False(t, impl.IsFido2PinInvalid(nil))
+	require.False(t, impl.IsFido2PinInvalid(errors.New("libfido2 error 50"))) // PIN blocked
+	require.False(t, impl.IsFido2PinInvalid(errors.New("libfido2 error 47"))) // touch timeout
+	require.False(t, impl.IsFido2PinInvalid(errors.New("some other error")))
+}
+
+func TestIsFido2TouchTimeout(t *testing.T) {
+	impl := &fido2Impl{}
+
+	// Device-side timeout: mapped sentinel.
+	require.True(t, impl.IsFido2TouchTimeout(libfido2.ErrActionTimeout))
+	require.True(t, impl.IsFido2TouchTimeout(fmt.Errorf("wrapped: %w", libfido2.ErrActionTimeout)))
+
+	// Host-side timeout: unmapped, surfaces as the generic Error{Code: 47} string.
+	require.True(t, impl.IsFido2TouchTimeout(libfido2.Error{Code: 47}))
+	require.True(t, impl.IsFido2TouchTimeout(fmt.Errorf("wrapped: libfido2 error 47")))
+
+	require.False(t, impl.IsFido2TouchTimeout(nil))
+	require.False(t, impl.IsFido2TouchTimeout(errors.New("libfido2 error 50"))) // PIN blocked
+	require.False(t, impl.IsFido2TouchTimeout(errors.New("libfido2 error 54"))) // PIN required (distinct case)
+	require.False(t, impl.IsFido2TouchTimeout(errors.New("some other error")))
+}

--- a/init/fido2plugin/main.go
+++ b/init/fido2plugin/main.go
@@ -100,8 +100,21 @@ func (f *fido2Impl) Fido2Assertion(devPath string, credID, saltBytes []byte, rel
 	return []byte(base64.StdEncoding.EncodeToString(res.assertion.HMACSecret)), nil
 }
 
+// IsFido2PinInvalid covers the user-typed-the-wrong-PIN family of CTAP errors.
+// All three should consume a PIN attempt and re-prompt; without 51 and 63 the
+// caller treats them as opaque errors and never retries the PIN.
+//   - FIDO_ERR_PIN_INVALID      (0x31 / 49) → ErrPinInvalid (mapped sentinel)
+//   - FIDO_ERR_PIN_AUTH_INVALID (0x33 / 51) → unmapped, generic error string
+//   - FIDO_ERR_UV_INVALID       (0x3f / 63) → unmapped, generic error string
 func (f *fido2Impl) IsFido2PinInvalid(err error) bool {
-	return errors.Is(err, libfido2.ErrPinInvalid)
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, libfido2.ErrPinInvalid) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "libfido2 error 51") || strings.Contains(msg, "libfido2 error 63")
 }
 
 func (f *fido2Impl) IsFido2PinAuthBlocked(err error) bool {

--- a/init/fido2plugin/main.go
+++ b/init/fido2plugin/main.go
@@ -129,3 +129,12 @@ func (f *fido2Impl) IsFido2WrongDevice(err error) bool {
 	}
 	return errors.Is(err, libfido2.ErrNoCredentials) || errors.Is(err, libfido2.ErrInvalidCredential)
 }
+
+// IsFido2PinRequired reports whether the device says it requires a PIN that
+// we did not supply. Hits when credential metadata says no PIN is required
+// but the token has had one set since enrollment (firmware update, policy
+// change). Caller should re-prompt with PIN entry enabled.
+//   - FIDO_ERR_PIN_REQUIRED (0x36 / 54) → ErrPinRequired
+func (f *fido2Impl) IsFido2PinRequired(err error) bool {
+	return errors.Is(err, libfido2.ErrPinRequired)
+}

--- a/init/fido2plugin/main.go
+++ b/init/fido2plugin/main.go
@@ -115,3 +115,17 @@ func (f *fido2Impl) IsFido2PinBlocked(err error) bool {
 	// error string from errFromCode's default case.
 	return err != nil && strings.Contains(err.Error(), "libfido2 error 50")
 }
+
+// IsFido2WrongDevice reports whether the device rejected our credential —
+// either it was never enrolled here, or the credential ID we supplied is
+// invalid for it. Common when the user has multiple FIDO2 keys plugged in:
+// only one was enrolled with this volume; the others should be skipped
+// silently rather than logged at info level as opaque errors.
+//   - FIDO_ERR_NO_CREDENTIALS     (0x2e / 46) → ErrNoCredentials
+//   - FIDO_ERR_INVALID_CREDENTIAL (0x22 / 34) → ErrInvalidCredential
+func (f *fido2Impl) IsFido2WrongDevice(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, libfido2.ErrNoCredentials) || errors.Is(err, libfido2.ErrInvalidCredential)
+}

--- a/init/fido2plugin/main.go
+++ b/init/fido2plugin/main.go
@@ -151,3 +151,18 @@ func (f *fido2Impl) IsFido2WrongDevice(err error) bool {
 func (f *fido2Impl) IsFido2PinRequired(err error) bool {
 	return errors.Is(err, libfido2.ErrPinRequired)
 }
+
+// IsFido2TouchTimeout reports whether the user did not touch the FIDO2 device
+// in time. libfido2 has two distinct codes for this — device-side timeout vs
+// host-side wait expiry — and we treat both the same:
+//   - FIDO_ERR_ACTION_TIMEOUT      (0x3a / 58) → ErrActionTimeout (mapped sentinel)
+//   - FIDO_ERR_USER_ACTION_TIMEOUT (0x2f / 47) → unmapped, generic error string
+func (f *fido2Impl) IsFido2TouchTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, libfido2.ErrActionTimeout) {
+		return true
+	}
+	return strings.Contains(err.Error(), "libfido2 error 47")
+}

--- a/init/luks.go
+++ b/init/luks.go
@@ -228,6 +228,9 @@ func recoverFido2Password(devName string, credential string, salt string, relyin
 	if err != nil && isFido2PinRequiredError(err) {
 		return nil, errFido2PinNeeded
 	}
+	if err != nil && isFido2TouchTimeoutError(err) {
+		return nil, errFido2TouchTimeout
+	}
 	if err == nil {
 		statusMessage("")
 	}
@@ -246,6 +249,7 @@ var errFido2Skipped = errors.New("FIDO2 skipped by user")
 var errFido2PinInvalid = errors.New("FIDO2 PIN invalid")
 var errFido2WrongDevice = errors.New("FIDO2 device does not have our credential")
 var errFido2PinNeeded = errors.New("FIDO2 device requires PIN we did not supply")
+var errFido2TouchTimeout = errors.New("FIDO2 touch timed out")
 var errFido2FallbackToKeyboard = errors.New("FIDO2 falling back to keyboard")
 var errTPM2Skipped = errors.New("TPM2 skipped by user")
 
@@ -322,6 +326,14 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 				pinRequired = true
 				maxAttempts = 3
 				promptPrefix = "FIDO2 token requires PIN — "
+				continue
+			}
+			// Touch timeout on a PIN device: re-prompt without consuming an
+			// attempt. The user typed the PIN correctly but didn't touch in
+			// time; making them lose 1 of 3 attempts for a fumbled tap is
+			// hostile.
+			if errors.Is(err, errFido2TouchTimeout) && pinRequired {
+				promptPrefix = "FIDO2 touch timed out — "
 				continue
 			}
 			if !errors.Is(err, errFido2PinInvalid) {

--- a/init/luks.go
+++ b/init/luks.go
@@ -222,6 +222,9 @@ func recoverFido2Password(devName string, credential string, salt string, relyin
 	if err != nil && isFido2PinInvalidError(err) {
 		return nil, errFido2PinInvalid
 	}
+	if err != nil && isFido2WrongDeviceError(err) {
+		return nil, errFido2WrongDevice
+	}
 	if err == nil {
 		statusMessage("")
 	}
@@ -238,6 +241,7 @@ var fido2Mu sync.Mutex
 
 var errFido2Skipped = errors.New("FIDO2 skipped by user")
 var errFido2PinInvalid = errors.New("FIDO2 PIN invalid")
+var errFido2WrongDevice = errors.New("FIDO2 device does not have our credential")
 var errFido2FallbackToKeyboard = errors.New("FIDO2 falling back to keyboard")
 var errTPM2Skipped = errors.New("TPM2 skipped by user")
 
@@ -326,6 +330,13 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 			if isFido2PinBlockedError(err) {
 				statusMessage("FIDO2 PIN is blocked (reset required), falling back to passphrase")
 				break
+			}
+			// Wrong device — credential not enrolled here. Skip silently;
+			// retrying this device would never succeed and the opaque
+			// "libfido2 error 46" message is noise when multiple keys are plugged in.
+			if errors.Is(err, errFido2WrongDevice) {
+				debug("FIDO2 device %s does not have our credential, skipping", devName)
+				continue
 			}
 			info("%v", err)
 			continue

--- a/init/luks.go
+++ b/init/luks.go
@@ -225,6 +225,9 @@ func recoverFido2Password(devName string, credential string, salt string, relyin
 	if err != nil && isFido2WrongDeviceError(err) {
 		return nil, errFido2WrongDevice
 	}
+	if err != nil && isFido2PinRequiredError(err) {
+		return nil, errFido2PinNeeded
+	}
 	if err == nil {
 		statusMessage("")
 	}
@@ -242,6 +245,7 @@ var fido2Mu sync.Mutex
 var errFido2Skipped = errors.New("FIDO2 skipped by user")
 var errFido2PinInvalid = errors.New("FIDO2 PIN invalid")
 var errFido2WrongDevice = errors.New("FIDO2 device does not have our credential")
+var errFido2PinNeeded = errors.New("FIDO2 device requires PIN we did not supply")
 var errFido2FallbackToKeyboard = errors.New("FIDO2 falling back to keyboard")
 var errTPM2Skipped = errors.New("TPM2 skipped by user")
 
@@ -295,26 +299,39 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 		}
 		seenHidrawDevices[devName] = true
 
+		// pinRequired starts from credential metadata but may be flipped on if
+		// the device returns FIDO_ERR_PIN_REQUIRED — i.e. metadata said no PIN
+		// but the token has had one set since enrollment (firmware update,
+		// policy change). On the flip we re-prompt without consuming an attempt.
+		pinRequired := node.PinRequired
 		maxAttempts := 1
-		if node.PinRequired {
+		if pinRequired {
 			maxAttempts = 3
 		}
 		var password []byte
 		var err error
 		pinExhausted := false
 		promptPrefix := ""
-		for attempt := 0; attempt < maxAttempts; attempt++ {
-			password, err = recoverFido2Password(devName, node.Credential, node.Salt, node.RelyingParty, node.PinRequired, node.UserPresenceRequired, node.UserVerificationRequired, mappingName, promptPrefix)
+		attempt := 0
+		for attempt < maxAttempts {
+			password, err = recoverFido2Password(devName, node.Credential, node.Salt, node.RelyingParty, pinRequired, node.UserPresenceRequired, node.UserVerificationRequired, mappingName, promptPrefix)
 			if err == nil {
 				break
+			}
+			if errors.Is(err, errFido2PinNeeded) && !pinRequired {
+				pinRequired = true
+				maxAttempts = 3
+				promptPrefix = "FIDO2 token requires PIN — "
+				continue
 			}
 			if !errors.Is(err, errFido2PinInvalid) {
 				break
 			}
-			if attempt < maxAttempts-1 {
-				promptPrefix = "FIDO2 PIN incorrect — "
-			} else {
+			attempt++
+			if attempt >= maxAttempts {
 				pinExhausted = true
+			} else {
+				promptPrefix = "FIDO2 PIN incorrect — "
 			}
 		}
 


### PR DESCRIPTION
Four small behavioural improvements to FIDO2 unlock that today fail opaquely or mis-account PIN attempts, plus a consolidated test file. Each commit is self-contained.

### 1. Silent skip when a plugged-in key isn't enrolled here

When the user has multiple FIDO2 keys plugged in (common: YubiKey + backup), only one is enrolled with a given volume. Today every other key logs an opaque `libfido2 error 46` at info level as the unlock loop iterates through them — noise rather than signal.

Recognise `FIDO_ERR_NO_CREDENTIALS` (0x2e/46) and `FIDO_ERR_INVALID_CREDENTIAL` (0x22/34) at the plugin layer via a new `IsFido2WrongDevice` predicate, surface them to the unlock loop as `errFido2WrongDevice`, and skip the device with a debug-level log instead.

### 2. Re-prompt with PIN entry when the token requires one

When credential metadata says no PIN is required but the token has had one set since enrollment (firmware update, policy change), the device returns `FIDO_ERR_PIN_REQUIRED` and the unlock fails opaquely. The user sees a `libfido2 error 54` log and is dropped to the passphrase prompt even though entering their PIN would have unlocked it.

Recognise `FIDO_ERR_PIN_REQUIRED` (0x36/54) via a new `IsFido2PinRequired` predicate, surface it as `errFido2PinNeeded`, and on first hit flip the local `pinRequired` flag, re-extend `maxAttempts` to 3, and re-enter the loop without consuming an attempt so the user gets a PIN prompt for this token.

### 3. Count PIN_AUTH_INVALID and UV_INVALID as wrong-PIN

`IsFido2PinInvalid` currently only matches `FIDO_ERR_PIN_INVALID` (49). Two related codes for the same wrong-secret family fall through to the opaque-info path and don't get retried:

- `FIDO_ERR_PIN_AUTH_INVALID` (0x33 / 51) — wrong PIN auth attempt
- `FIDO_ERR_UV_INVALID`       (0x3f / 63) — wrong on-device user-verification (built-in fingerprint, etc)

Neither is mapped to a named go-libfido2 error in v1.5.3, so detect them via the generic `libfido2 error N` string from `errFromCode`'s default case, mirroring the existing `IsFido2PinBlocked` pattern.

### 4. Don't consume a PIN attempt on touch timeout

When a PIN-bearing FIDO2 token times out waiting for touch (no finger inside the device's UP window), libfido2 returns `FIDO_ERR_USER_ACTION_TIMEOUT` (0x2f/47) or `FIDO_ERR_ACTION_TIMEOUT` (0x3a/58). Today the loop treats this as a generic error and breaks, so the user loses 1 of their 3 PIN attempts for a fumbled tap even though their PIN was correct.

New `IsFido2TouchTimeout` predicate covers both codes; on PIN devices the loop re-prompts without consuming an attempt. Non-PIN devices fall through unchanged (their loop only runs once).

### Tests

`init/fido2plugin/errors_test.go` covers all four predicates against their mapped sentinels, the unmapped generic-string codes, `errors.Is` wrapping, and negatives.