### PR TITLE
init/luks: convert done channel to context.Context

### DIFF
--- a/init/luks.go
+++ b/init/luks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -45,7 +46,7 @@ type luksMapping struct {
 
 // tryPassphraseAgainstSlots tries password against each slot, sending the opened
 // volume on volumes if successful.  Returns true on success.
-func tryPassphraseAgainstSlots(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, checkSlots []int, password []byte) bool {
+func tryPassphraseAgainstSlots(ctx context.Context, volumes chan *luks.Volume, d luks.Device, checkSlots []int, password []byte) bool {
 	for _, s := range checkSlots {
 		v, err := d.UnsealVolume(s, password)
 		if err == luks.ErrPassphraseDoesNotMatch {
@@ -56,7 +57,7 @@ func tryPassphraseAgainstSlots(volumes chan *luks.Volume, done <-chan struct{}, 
 		}
 		select {
 		case volumes <- v:
-		case <-done:
+		case <-ctx.Done():
 		}
 		return true
 	}
@@ -506,7 +507,7 @@ func tokenNeedsPin(t luks.Token) bool {
 	return false
 }
 
-func recoverTokenPassword(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, t luks.Token, mappingName string) bool {
+func recoverTokenPassword(ctx context.Context, volumes chan *luks.Volume, d luks.Device, t luks.Token, mappingName string) bool {
 	var password []byte
 	var err error
 
@@ -534,7 +535,7 @@ func recoverTokenPassword(volumes chan *luks.Volume, done <-chan struct{}, d luk
 	}
 
 	info("recovered password from %s token #%d", t.Type, t.ID)
-	return tryPassphraseAgainstSlots(volumes, done, d, t.Slots, password)
+	return tryPassphraseAgainstSlots(ctx, volumes, d, t.Slots, password)
 }
 
 // readKeyfile reads a keyfile at path, skipping offset bytes and reading at most
@@ -593,14 +594,14 @@ func acquireKeyfilePassword(mapping *luksMapping) ([]byte, error) {
 	return readKeyfile(path, mapping.keyfileOffset, mapping.keyfileSize)
 }
 
-func recoverKeyfilePassword(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, checkSlots []int, mapping *luksMapping) {
+func recoverKeyfilePassword(ctx context.Context, volumes chan *luks.Volume, d luks.Device, checkSlots []int, mapping *luksMapping) {
 	password, err := acquireKeyfilePassword(mapping)
 	if err != nil {
 		warning("reading keyfile %s: %v", mapping.keyfile, err)
 	}
 
 	if len(password) > 0 {
-		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, password) {
+		if tryPassphraseAgainstSlots(ctx, volumes, d, checkSlots, password) {
 			return
 		}
 	}
@@ -608,28 +609,28 @@ func recoverKeyfilePassword(volumes chan *luks.Volume, done <-chan struct{}, d l
 	warning("password in keyfile %s was unable to unseal %s", mapping.keyfile, mapping.name)
 
 	// fall back to keyboard
-	requestKeyboardPassword(volumes, done, d, checkSlots, mapping.name, mapping.tries)
+	requestKeyboardPassword(ctx, volumes, d, checkSlots, mapping.name, mapping.tries)
 }
 
 // tryCachedPassphrases snapshots passphraseCache and tries each entry against
 // checkSlots. Returns true if any unlocked the volume — caller should return
 // without prompting. The snapshot avoids holding passphraseCache.Lock across
 // the (potentially slow) UnsealVolume calls.
-func tryCachedPassphrases(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, checkSlots []int) bool {
+func tryCachedPassphrases(ctx context.Context, volumes chan *luks.Volume, d luks.Device, checkSlots []int) bool {
 	passphraseCache.Lock()
 	cached := make([][]byte, len(passphraseCache.passwords))
 	copy(cached, passphraseCache.passwords)
 	passphraseCache.Unlock()
 
 	for _, pw := range cached {
-		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, pw) {
+		if tryPassphraseAgainstSlots(ctx, volumes, d, checkSlots, pw) {
 			return true
 		}
 	}
 	return false
 }
 
-func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d luks.Device, checkSlots []int, mappingName string, maxTries int) {
+func requestKeyboardPassword(ctx context.Context, volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, maxTries int) {
 	// Wait for plymouth initialization to complete before attempting to use
 	// it. Without this, udev events can trigger LUKS password prompts while
 	// plymouthd is still starting, causing the graphical prompt to fail.
@@ -637,14 +638,14 @@ func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d 
 
 	// Bail early if the device was already unlocked by a token goroutine.
 	select {
-	case <-done:
+	case <-ctx.Done():
 		return
 	default:
 	}
 
 	// Fast path: try passwords that already unlocked another volume this boot
 	// (e.g. two LUKS members of a btrfs RAID1 with the same passphrase).
-	if tryCachedPassphrases(volumes, done, d, checkSlots) {
+	if tryCachedPassphrases(ctx, volumes, d, checkSlots) {
 		return
 	}
 
@@ -657,12 +658,12 @@ func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d 
 
 	// Re-check after acquiring the lock: another device may have just unlocked.
 	select {
-	case <-done:
+	case <-ctx.Done():
 		return
 	default:
 	}
 
-	if tryCachedPassphrases(volumes, done, d, checkSlots) {
+	if tryCachedPassphrases(ctx, volumes, d, checkSlots) {
 		return
 	}
 
@@ -683,7 +684,7 @@ func requestKeyboardPassword(volumes chan *luks.Volume, done <-chan struct{}, d 
 		}
 		attempts++
 
-		if tryPassphraseAgainstSlots(volumes, done, d, checkSlots, password) {
+		if tryPassphraseAgainstSlots(ctx, volumes, d, checkSlots, password) {
 			passphraseCache.Lock()
 			passphraseCache.passwords = append(passphraseCache.passwords, password)
 			passphraseCache.Unlock()
@@ -789,8 +790,8 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	}
 
 	volumes := make(chan *luks.Volume)
-	done := make(chan struct{})
-	var closeDone sync.Once
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	var senderWg sync.WaitGroup
 	var tokenWg sync.WaitGroup
 
@@ -826,15 +827,15 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		go func() {
 			defer senderWg.Done()
 			defer tokenWg.Done()
-			if recoverTokenPassword(volumes, done, d, t, mapping.name) {
-				closeDone.Do(func() { close(done) })
+			if recoverTokenPassword(ctx, volumes, d, t, mapping.name) {
+				cancel()
 			}
 		}()
 	}
 
 	// PIN tokens: one goroutine walks them in slice order (already sorted by
 	// ID above). A skipped/failed token advances to the next; a successful
-	// unlock closes done and stops iteration. The done check before each
+	// unlock cancels ctx and stops iteration. The ctx check before each
 	// iteration lets a parallel non-PIN unlock cancel the loop without
 	// waiting for the next prompt to time out.
 	if len(pinTokens) > 0 {
@@ -845,12 +846,12 @@ func luksOpen(dev string, mapping *luksMapping) error {
 			defer tokenWg.Done()
 			for _, t := range pinTokens {
 				select {
-				case <-done:
+				case <-ctx.Done():
 					return
 				default:
 				}
-				if recoverTokenPassword(volumes, done, d, t, mapping.name) {
-					closeDone.Do(func() { close(done) })
+				if recoverTokenPassword(ctx, volumes, d, t, mapping.name) {
+					cancel()
 					return
 				}
 			}
@@ -884,28 +885,28 @@ func luksOpen(dev string, mapping *luksMapping) error {
 			tokenWg.Wait()
 		}
 		select {
-		case <-done:
+		case <-ctx.Done():
 			return // already unlocked by a token
 		default:
 		}
 		if len(checkSlotsWithPassword) > 0 {
 			senderWg.Go(func() {
 				if mapping.keyfile != "" {
-					recoverKeyfilePassword(volumes, done, d, checkSlotsWithPassword, mapping)
+					recoverKeyfilePassword(ctx, volumes, d, checkSlotsWithPassword, mapping)
 				} else {
-					requestKeyboardPassword(volumes, done, d, checkSlotsWithPassword, mapping.name, mapping.tries)
+					requestKeyboardPassword(ctx, volumes, d, checkSlotsWithPassword, mapping.name, mapping.tries)
 				}
 			})
 		}
 	})
 
 	// Watcher: when every unlock goroutine has given up, close volumes so luksOpen
-	// unblocks rather than hanging forever. Check done first to avoid closing volumes
+	// unblocks rather than hanging forever. Check ctx first to avoid closing volumes
 	// after a priority token already signalled success.
 	go func() {
 		senderWg.Wait()
 		select {
-		case <-done:
+		case <-ctx.Done():
 			// Already unlocked — volumes will drain naturally.
 		default:
 			close(volumes)
@@ -913,7 +914,6 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	}()
 
 	v, ok := <-volumes
-	closeDone.Do(func() { close(done) })
 
 	if !ok {
 		return fmt.Errorf("failed to unlock %s: all unlock attempts exhausted", dev)

--- a/init/token_orchestration_test.go
+++ b/init/token_orchestration_test.go
@@ -4,9 +4,10 @@ package main
 //
 // The production loop is mirrored here as runPinTokens so it can be exercised
 // without setting up real LUKS devices, swtpm, or hardware tokens. Cancellation
-// uses a chan struct{} matching luksOpen's `done` channel.
+// uses context.Context matching luksOpen's `ctx`.
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"testing"
@@ -59,12 +60,12 @@ func TestTokenNeedsPin(t *testing.T) {
 
 // pinTokenSpec describes one token for runPinTokens. recoverFn is invoked when
 // the token's iteration starts (PIN) or its parallel goroutine starts (non-PIN).
-// It must observe done — production helpers (recoverSystemd*Password,
-// plymouthAskPassword, readPassword) check done to return early on cancellation.
+// It must observe ctx — production helpers (recoverSystemd*Password,
+// plymouthAskPassword, readPassword) check ctx to return early on cancellation.
 type pinTokenSpec struct {
 	id        int
 	pin       bool
-	recoverFn func(done <-chan struct{}) bool
+	recoverFn func(ctx context.Context) bool
 }
 
 // orchestrationEvent records what happened to a token during a runPinTokens
@@ -87,12 +88,11 @@ func runPinTokens(specs []pinTokenSpec) []orchestrationEvent {
 		mu.Unlock()
 	}
 
-	done := make(chan struct{})
-	var closeDone sync.Once
-	closeFn := func() { closeDone.Do(func() { close(done) }) }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	isDone := func() bool {
 		select {
-		case <-done:
+		case <-ctx.Done():
 			return true
 		default:
 			return false
@@ -115,10 +115,10 @@ func runPinTokens(specs []pinTokenSpec) []orchestrationEvent {
 				return
 			}
 			record(t.id, "started")
-			ok := t.recoverFn(done)
+			ok := t.recoverFn(ctx)
 			record(t.id, "completed")
 			if ok {
-				closeFn()
+				cancel()
 			}
 		}()
 	}
@@ -133,10 +133,10 @@ func runPinTokens(specs []pinTokenSpec) []orchestrationEvent {
 					continue
 				}
 				record(t.id, "started")
-				ok := t.recoverFn(done)
+				ok := t.recoverFn(ctx)
 				record(t.id, "completed")
 				if ok {
-					closeFn()
+					cancel()
 					return
 				}
 			}
@@ -183,8 +183,8 @@ func lastEventOf(events []orchestrationEvent, id int) string {
 	return last
 }
 
-func returns(success bool) func(<-chan struct{}) bool {
-	return func(<-chan struct{}) bool { return success }
+func returns(success bool) func(context.Context) bool {
+	return func(context.Context) bool { return success }
 }
 
 // ── PIN-loop ordering & sequencing ───────────────────────────────────────────
@@ -206,7 +206,7 @@ func TestPinTokensAllFailRunInOrder(t *testing.T) {
 
 func TestPinTokensFirstSuccessShortCircuitsRest(t *testing.T) {
 	t.Parallel()
-	// Token 1 succeeds → done closes → loop returns. Tokens 2 and 3 never
+	// Token 1 succeeds → ctx cancelled → loop returns. Tokens 2 and 3 never
 	// have their recoverFn invoked.
 	events := runPinTokens([]pinTokenSpec{
 		{id: 1, pin: true, recoverFn: returns(true)},
@@ -240,11 +240,11 @@ func TestNonPinTokensRunInParallelWithPinLoop(t *testing.T) {
 	pinCanRelease := make(chan struct{})
 
 	specs := []pinTokenSpec{
-		{id: 1, pin: true, recoverFn: func(done <-chan struct{}) bool {
+		{id: 1, pin: true, recoverFn: func(ctx context.Context) bool {
 			<-pinCanRelease // block until test releases
 			return false
 		}},
-		{id: 2, pin: false, recoverFn: func(done <-chan struct{}) bool {
+		{id: 2, pin: false, recoverFn: func(ctx context.Context) bool {
 			close(nonPinDone)
 			return false
 		}},
@@ -266,26 +266,27 @@ func TestNonPinTokensRunInParallelWithPinLoop(t *testing.T) {
 func TestNonPinSuccessCancelsPinLoop(t *testing.T) {
 	t.Parallel()
 	// A non-PIN token (touchless FIDO2 / clevis / auto-TPM2) succeeding mid-
-	// boot must close done so the still-running PIN goroutine exits without
+	// boot must cancel ctx so the still-running PIN goroutine exits without
 	// dispatching the next prompt. The currently-running PIN token observes
-	// done and returns false; subsequent PIN tokens skip via the done check.
+	// ctx cancellation and returns false; subsequent PIN tokens skip via the
+	// ctx check.
 	pinStarted := make(chan struct{})
 	specs := []pinTokenSpec{
-		{id: 1, pin: true, recoverFn: func(done <-chan struct{}) bool {
+		{id: 1, pin: true, recoverFn: func(ctx context.Context) bool {
 			close(pinStarted)
-			<-done // production helpers observe done and return early
+			<-ctx.Done() // production helpers observe ctx and return early
 			return false
 		}},
 		{id: 2, pin: true, recoverFn: returns(false)},
-		{id: 3, pin: false, recoverFn: func(done <-chan struct{}) bool {
+		{id: 3, pin: false, recoverFn: func(ctx context.Context) bool {
 			<-pinStarted // ensure PIN loop is in token 1's recoverFn
 			return true  // non-PIN unlock wins
 		}},
 	}
 	events := runPinTokens(specs)
 	require.Equal(t, "completed", lastEventOf(events, 3), "non-PIN must complete with success")
-	require.Equal(t, "completed", lastEventOf(events, 1), "PIN token 1 must have observed done and returned")
-	require.Equal(t, "skipped-done", eventOf(events, 2), "PIN token 2 must skip after done")
+	require.Equal(t, "completed", lastEventOf(events, 1), "PIN token 1 must have observed ctx cancel and returned")
+	require.Equal(t, "skipped-done", eventOf(events, 2), "PIN token 2 must skip after ctx cancel")
 }
 
 // ── PIN-loop advance on skip / fallback errors ───────────────────────────────


### PR DESCRIPTION
### What this PR does

Pure mechanical conversion of five functions in the LUKS unlock paths from `done <-chan struct{}` to `context.Context`:

- `tryPassphraseAgainstSlots`
- `recoverTokenPassword`
- `recoverKeyfilePassword`
- `tryCachedPassphrases`
- `requestKeyboardPassword`

Plus `luksOpen`'s local cancellation channel: `done := make(chan struct{}) + sync.Once` becomes `ctx, cancel := context.WithCancel(context.Background()) + defer cancel()`. The test mirror in `init/token_orchestration_test.go`'s `runPinTokens` helper tracks the new contract.

Zero observable change. +54/−53 net.

### Why ctx specifically

`done` signals one thing (stop). `ctx` is Go's canonical goroutine-coordination object. The upcoming PRs need cancellation (cancellable keyboard reads, FIDO2-PIN and TPM2-PIN prompt cancellation); ctx's deadline support remains available if later work wants to express the existing `token-timeout=` / `keyfile-timeout=` features through it. Adopting the standard idiom now keeps the cancellation surface uniform instead of layering ad-hoc mechanisms.

### Cleanups that fall out

- Drops the local `sync.Once` around `close(done)` — `context.CancelFunc` is already idempotent.
- Drops the redundant explicit `cancel()` after the `<-volumes` drain — the deferred `cancel()` at the top covers it.

---

### Context: the bug this series fixes

When the cooked-mode keyboard reader is blocked in `read(2)` and a non-interactive token (TPM2 PCR-only, touchless FIDO2, or clevis) wins the unlock race, the keyboard prompt has no way to honor the cancellation: the prompt stays on screen, `inputMutex` / `keyboardMu` stay held, and any subsequent volumes that need keyboard entry block until the user manually presses Enter on the now-pointless prompt. A long-standing dangling-prompt bug that has lived alongside booster's concurrent unlock paths.

This series of PRs fixes that bug and, in the process, brings the keyboard and Plymouth prompt UX into the same concurrency model as the rest of booster's unlock pipeline.

### Companion work already shipped

Recent merged PRs in the prompt and unlock space:

- **#314** — Plymouth boot splash support (the UX layer PRs 4–5 of this series extend).
- **#335** — cache passphrases for multi-device LUKS unlock (single-prompt UX for shared passphrases).
- **#337** — fix `rd.luks.name` suppressing crypttab `fido2-device=` and token unlock race.
- **#347** — TPM2 PIN unlock: 3-attempt retry and empty-PIN skip (PIN-prompt UX consistency).
- **#350** — deterministic token dispatch order (predictable prompt order across boots).
- **#353** — serial PIN-token dispatch (predictable ordering when multiple PIN tokens are enrolled).

This series adds the missing piece: prompts that notice when a sibling unlock has succeeded and get out of the way.

### Upcoming UX plan

A focused series of PRs to fix the bug and complete the prompt UX:

1. **This PR — `done` → `context.Context` in unlock paths.** Pure mechanical, zero observable change. Foundation: ctx becomes the cancellation idiom the rest of the work threads through.
2. **Raw-mode keyboard reader.** Replaces the cooked-termios reader with one that honors ctx cancellation. Keyboard prompt auto-dismisses within ~100 ms of a sibling unlock winning. Also echoes asterisks during passphrase entry (closes #305), fixes Ctrl+S freezing the prompt, and supports paste from password managers (relevant to #320).
3. **Extend cancellation to PIN prompts.** Threads ctx into `recoverFido2Password` / `recoverSystemdFido2Password` / `recoverSystemdTPM2Password`. Closes the console side: every prompt cancels on autounlock win.
4. **Plymouth direct-socket IPC.** Replaces exec-based `plymouth` CLI calls with direct socket I/O. Mechanical foundation for splash-side concurrency-aware UX. No user-visible change. Prompt cancel wired for https://gitlab.freedesktop.org/plymouth/plymouth/-/merge_requests/393
5. **Plymouth state-transition messaging.** Splash messages reflect concurrent unlock state ("Waiting for FIDO2 ...", "FIDO2 PIN incorrect", etc.).