### PR TITLE
init/luks: extend ctx cancellation to FIDO2-PIN and TPM2-PIN prompts

### DIFF
--- a/init/console_input.go
+++ b/init/console_input.go
@@ -531,7 +531,7 @@ func readPasswordLocked(ctx context.Context, prompt, postPrompt string) ([]byte,
 // they can exercise termios setup, the Poll loop, and ctx cancellation
 // end-to-end. See TestReadPasswordOn* in console_input_pty_test.go.
 //
-// Read-loop design (the cancellable-read primitive K is built on):
+// Read-loop design (the cancellable-read primitive):
 //   - Termios is set to VMIN=1, VTIME=0: read(2) would block until 1 byte.
 //   - Instead of calling Read directly, we poll(2) with a 100ms timeout.
 //   - Between polls we check ctx.Err() — if cancelled, return ctx.Err()

--- a/init/luks.go
+++ b/init/luks.go
@@ -172,7 +172,7 @@ func isHidRawFido2(devName string) (bool, error) {
 	return false, nil
 }
 
-func recoverFido2Password(devName string, credential string, salt string, relyingParty string, pinRequired bool, userPresenceRequired bool, userVerificationRequired bool, mappingName string, promptPrefix string) ([]byte, error) {
+func recoverFido2Password(ctx context.Context, devName string, credential string, salt string, relyingParty string, pinRequired bool, userPresenceRequired bool, userVerificationRequired bool, mappingName string, promptPrefix string) ([]byte, error) {
 	usbhidWg.Wait()
 
 	isFido2, err := isHidRawFido2(devName)
@@ -204,8 +204,7 @@ func recoverFido2Password(devName string, credential string, salt string, relyin
 	var pin string
 	if pinRequired {
 		prompt := promptPrefix + "Enter FIDO2 PIN for " + mappingName + " (empty to skip to passphrase):"
-		// FIDO2 PIN call site: pass Background until L2 threads ctx into recoverFido2Password.
-		pinBytes, err := askPasswordWithFallback(context.Background(), prompt, "")
+		pinBytes, err := askPasswordWithFallback(ctx, prompt, "")
 		if err != nil {
 			return nil, err
 		}
@@ -255,7 +254,7 @@ var errFido2TouchTimeout = errors.New("FIDO2 touch timed out")
 var errFido2FallbackToKeyboard = errors.New("FIDO2 falling back to keyboard")
 var errTPM2Skipped = errors.New("TPM2 skipped by user")
 
-func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, error) {
+func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName string) ([]byte, error) {
 	var node struct {
 		Credential               string `json:"fido2-credential"` // base64
 		Salt                     string `json:"fido2-salt"`       // base64
@@ -320,7 +319,7 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 		promptPrefix := ""
 		attempt := 0
 		for attempt < maxAttempts {
-			password, err = recoverFido2Password(devName, node.Credential, node.Salt, node.RelyingParty, pinRequired, node.UserPresenceRequired, node.UserVerificationRequired, mappingName, promptPrefix)
+			password, err = recoverFido2Password(ctx, devName, node.Credential, node.Salt, node.RelyingParty, pinRequired, node.UserPresenceRequired, node.UserVerificationRequired, mappingName, promptPrefix)
 			if err == nil {
 				break
 			}
@@ -378,7 +377,7 @@ func recoverSystemdFido2Password(t luks.Token, mappingName string) ([]byte, erro
 	return nil, errFido2FallbackToKeyboard
 }
 
-func recoverSystemdTPM2Password(t luks.Token, mappingName string) ([]byte, error) {
+func recoverSystemdTPM2Password(ctx context.Context, t luks.Token, mappingName string) ([]byte, error) {
 	var node struct {
 		Blob       string `json:"tpm2-blob"` // base64
 		PCRs       []int  `json:"tpm2-pcrs"`
@@ -438,8 +437,7 @@ func recoverSystemdTPM2Password(t luks.Token, mappingName string) ([]byte, error
 		var authValue []byte
 		if node.Pin {
 			prompt := promptPrefix + "Enter TPM2 PIN for " + mappingName + ":"
-			// TPM2 PIN call site: pass Background until L2 threads ctx into recoverSystemdTPM2Password.
-			pin, err := askPasswordWithFallback(context.Background(), prompt, "")
+			pin, err := askPasswordWithFallback(ctx, prompt, "")
 			if err != nil {
 				return nil, err
 			}
@@ -517,9 +515,9 @@ func recoverTokenPassword(ctx context.Context, volumes chan *luks.Volume, d luks
 	case "clevis":
 		password, err = recoverClevisPassword(t, d.Version())
 	case "systemd-fido2":
-		password, err = recoverSystemdFido2Password(t, mappingName)
+		password, err = recoverSystemdFido2Password(ctx, t, mappingName)
 	case "systemd-tpm2":
-		password, err = recoverSystemdTPM2Password(t, mappingName)
+		password, err = recoverSystemdTPM2Password(ctx, t, mappingName)
 	default:
 		info("token #%d has unknown type: %s", t.ID, t.Type)
 		return false

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -146,8 +146,7 @@ func plymouthAskPassword(prompt string) ([]byte, error) {
 // askPasswordWithFallback prompts via plymouth when enabled. Any plymouth
 // failure logs a warning and falls through to the console reader. ctx
 // cancellation is honored only by the console reader path; plymouth's IPC
-// is not yet ctx-aware. Pass context.Background() if cancellation is not
-// needed (e.g. FIDO2-PIN / TPM2-PIN call sites until L2 lands).
+// is not yet ctx-aware.
 func askPasswordWithFallback(ctx context.Context, prompt, postPrompt string) ([]byte, error) {
 	if plymouthEnabled {
 		password, err := plymouthAskPassword(prompt)


### PR DESCRIPTION
### What this PR does

Threads `ctx context.Context` into `recoverFido2Password`, `recoverSystemdFido2Password`, and `recoverSystemdTPM2Password`. The PIN prompts in those functions previously called `askPasswordWithFallback(context.Background(), ...)` and could not be cancelled when a sibling unlock succeeded. With ctx propagated, every console password prompt — keyboard-passphrase, FIDO2-PIN, TPM2-PIN — now dismisses cleanly when a non-interactive token (TPM2 PCR-only, touchless FIDO2, or clevis) wins the unlock race.

Closes the gap acknowledged in #355: the keyboard-passphrase prompt cancellation that landed there now extends to PIN prompts as well.

### Scope

Pure additive — no behavioural change beyond extending the cancellation reach:
- `recoverFido2Password` / `recoverSystemdFido2Password` / `recoverSystemdTPM2Password` take `ctx context.Context` as their first parameter.
- `recoverTokenPassword` (already ctx-aware after #354) passes ctx through to its two systemd-token call sites.
- The `context.Background()` placeholders #355 added at the FIDO2-PIN and TPM2-PIN call sites are replaced with the threaded `ctx`.

### Cleanup

Drops three stale comments left in #355 that referenced this upcoming work in internal-planning vocabulary. Reworded to factually describe the current state — most of them were already going to be edited by this PR (the `context.Background()` placeholders they accompanied are now gone), and one in `console_input.go` is fixed in passing.