### PR TITLE
init: prompt-aware status-message redraw and token-unlock confirmation

### DIFF
--- a/init/console_input.go
+++ b/init/console_input.go
@@ -494,11 +494,10 @@ var consoleMu sync.Mutex
 //     it to skip a redraw once the volume is unlocked by another method
 //     (avoids redrawing a prompt that's about to be dismissed)
 var consolePrompt struct {
+	active    bool
+	text      string
 	asterisks int
-	// Foreshadowed for the upcoming Plymouth splash UX work — see comment above.
-	// active bool
-	// text   string
-	// done   <-chan struct{}
+	done      <-chan struct{}
 }
 
 // consolePrint writes msg without acquiring consoleMu. Callers must hold consoleMu.
@@ -591,17 +590,28 @@ func readPasswordOn(ctx context.Context, tty *os.File, prompt, postPrompt string
 
 	consoleMu.Lock()
 	consolePrint(prompt)
+	consolePrompt.active = true
+	consolePrompt.text = prompt
 	consolePrompt.asterisks = 0
+	consolePrompt.done = ctx.Done()
 	consoleMu.Unlock()
 
+	defer func() {
+		consoleMu.Lock()
+		consolePrompt.active = false
+		consolePrompt.done = nil
+		consoleMu.Unlock()
+	}()
+
 	// cancelRead is the cleanup hook for ctx-cancellation mid-prompt: flush
-	// type-ahead so partial bytes don't bleed into the next prompt, erase the
-	// prompt line so it doesn't linger on screen, and return ctx.Err() so the
-	// caller can distinguish cancel from "user pressed Enter". Termios
-	// restoration happens via defer above.
+	// type-ahead so partial bytes don't bleed into the next prompt, mark the
+	// prompt inactive, erase the prompt line so it doesn't linger on screen,
+	// and return ctx.Err() so the caller can distinguish cancel from "user
+	// pressed Enter". Termios restoration happens via defer above.
 	cancelRead := func() ([]byte, error) {
 		_ = unix.IoctlSetInt(fd, unix.TCFLSH, unix.TCIFLUSH)
 		consoleMu.Lock()
+		consolePrompt.active = false
 		consolePrint(eraseLineAndAdvance)
 		consoleMu.Unlock()
 		return nil, ctx.Err()

--- a/init/luks.go
+++ b/init/luks.go
@@ -535,7 +535,26 @@ func recoverTokenPassword(ctx context.Context, volumes chan *luks.Volume, d luks
 	}
 
 	info("recovered password from %s token #%d", t.Type, t.ID)
-	return tryPassphraseAgainstSlots(ctx, volumes, d, t.Slots, password)
+	if !tryPassphraseAgainstSlots(ctx, volumes, d, t.Slots, password) {
+		return false
+	}
+	statusMessageTimed(mappingName+" unlocked via "+tokenFriendlyName(t.Type), 3*time.Second)
+	return true
+}
+
+// tokenFriendlyName returns a short human-readable label for a token type, used
+// in the unlock-confirmation status message.
+func tokenFriendlyName(typ string) string {
+	switch typ {
+	case "systemd-fido2":
+		return "FIDO2"
+	case "systemd-tpm2":
+		return "TPM2"
+	case "clevis":
+		return "clevis"
+	default:
+		return typ
+	}
 }
 
 // readKeyfile reads a keyfile at path, skipping offset bytes and reading at most

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -160,12 +160,50 @@ func askPasswordWithFallback(ctx context.Context, prompt, postPrompt string) ([]
 
 // statusMessage shows msg on the Plymouth splash, or on the console if Plymouth
 // is disabled. Passing an empty string clears the Plymouth message (no-op on console).
+//
+// On the console, if a password prompt is active and its volume hasn't been
+// unlocked yet, the current line is erased and the prompt is reprinted beneath
+// the message so the cursor stays at the bottom. Once the prompt's done channel
+// closes (volume unlocked by another token), the redraw is skipped — otherwise
+// the unlock status message would reprint a stale prompt that ctx-cancel hasn't
+// torn down yet.
 func statusMessage(msg string) {
 	if plymouthEnabled {
 		plymouthMessage(msg)
 	} else if msg != "" {
-		console(msg + "\n")
+		consoleMu.Lock()
+		if consolePrompt.active && !promptVolumeUnlocked() {
+			consolePrint("\n\n" + msg + "\n\n" + consolePrompt.text + strings.Repeat("*", consolePrompt.asterisks))
+		} else {
+			consolePrint("\n\n" + msg + "\n\n")
+		}
+		consoleMu.Unlock()
 	}
+}
+
+// promptVolumeUnlocked reports whether the active prompt's volume has been
+// unlocked already (its done channel has closed). Caller must hold consoleMu.
+func promptVolumeUnlocked() bool {
+	if consolePrompt.done == nil {
+		return false
+	}
+	select {
+	case <-consolePrompt.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// statusMessageTimed shows msg and clears it after d. Use for transient status
+// updates that have no other natural dismissal point (skip confirmations,
+// success notifications).
+func statusMessageTimed(msg string, d time.Duration) {
+	statusMessage(msg)
+	go func() {
+		time.Sleep(d)
+		statusMessage("")
+	}()
 }
 
 // plymouthMessage displays a message on the plymouth splash screen.

--- a/init/plymouth_test.go
+++ b/init/plymouth_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPromptVolumeUnlocked covers the three states promptVolumeUnlocked can
+// observe: no done channel set, an open done channel, and a closed done channel.
+// The third case is what statusMessage uses to skip a redraw when the volume's
+// already been unlocked by a sibling token.
+func TestPromptVolumeUnlocked(t *testing.T) {
+	// Save and restore consolePrompt around each subtest so they can mutate it
+	// without leaking state.
+	saved := consolePrompt
+	t.Cleanup(func() { consolePrompt = saved })
+
+	t.Run("nil done returns false", func(t *testing.T) {
+		consolePrompt.done = nil
+		require.False(t, promptVolumeUnlocked())
+	})
+
+	t.Run("open done returns false", func(t *testing.T) {
+		ch := make(chan struct{})
+		consolePrompt.done = ch
+		require.False(t, promptVolumeUnlocked())
+	})
+
+	t.Run("closed done returns true", func(t *testing.T) {
+		ch := make(chan struct{})
+		close(ch)
+		consolePrompt.done = ch
+		require.True(t, promptVolumeUnlocked())
+	})
+}
+
+// TestTokenFriendlyName pins down the labels used in the unlock-confirmation
+// status message — these are user-visible strings so a typo would ship.
+func TestTokenFriendlyName(t *testing.T) {
+	cases := []struct {
+		typ  string
+		want string
+	}{
+		{"systemd-fido2", "FIDO2"},
+		{"systemd-tpm2", "TPM2"},
+		{"clevis", "clevis"},
+		{"unknown-token-type", "unknown-token-type"}, // fallback: pass through
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.typ, func(t *testing.T) {
+			require.Equal(t, tc.want, tokenFriendlyName(tc.typ))
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does

Two changes that together close out the console UX for booster's concurrent unlock pipeline:

**1. Prompt-aware `statusMessage` redraw.** When `statusMessage` fires during an active console password prompt, the current line is erased, the message prints, and the prompt is reprinted below — cursor stays at the bottom, asterisk count preserved. Without this a status message printed mid-prompt tears through the prompt line.

The new `promptVolumeUnlocked` helper lets `statusMessage` skip the redraw when the prompt's volume is already unlocked (its `ctx.Done()` has fired), avoiding reprinting a stale prompt that the cancellation logic hasn't yet torn down.

`readPasswordOn` now sets `consolePrompt.{active, text, done}` during each prompt — fields declared in #355 that become load-bearing only now that `statusMessage` consumes them.

**2. Token-unlock confirmation.** `recoverTokenPassword` fires `statusMessageTimed("X unlocked via Y", 3s)` on success. After #355 (keyboard prompt cancellation) and #356 (PIN-prompt cancellation) cleanly dismiss prompts when a sibling token wins the race, the user previously saw nothing telling them what happened — boot just continued. This adds the missing confirmation: "cryptroot unlocked via FIDO2", "swap unlocked via TPM2", etc.

`tokenFriendlyName` provides the short label per token type. `statusMessageTimed` clears the message after 3 seconds so it doesn't linger on the splash.

### Scope

Console UX only. Plymouth users get these messages too (`statusMessage` routes to plymouthd when enabled), but Plymouth-side polish — splash banner styling, native timed-message support, dismissing prompts on socket hangup — is separate work upstream of plymouthd.

### Testing

- `TestPromptVolumeUnlocked`: covers all three observable states of the active-prompt's `ctx.Done()` — nil, open, closed.
- `TestTokenFriendlyName`: pins down the labels in the unlock-confirmation message.
- The redraw protocol's visual correctness (line-erase + reprint with preserved asterisk count) is covered by live test rather than unit test — the relevant output goes through `fmt.Print`, which the pty harness can't capture.

Live-tested on local tty1: token-unlock confirmation appears after autounlock; status messages don't tear through prompts during PIN-incorrect retry.