### PR TITLE
init/plymouth: replace plymouth CLI with direct socket IPC

### DIFF
--- a/generator/plymouth.go
+++ b/generator/plymouth.go
@@ -50,8 +50,9 @@ func (img *Image) addPlymouthSupport(conf *generatorConfig) error {
 	}
 	debug("plymouth paths: plugins=%s themes=%s conf=%s policy=%s", pluginDir, themesDir, confDir, policyDir)
 
-	// Add plymouth binaries (appendExtraFiles auto-resolves ELF deps)
-	if err := img.appendExtraFiles("plymouth", "plymouthd"); err != nil {
+	// Add plymouthd — the init process speaks to it directly via socket.
+	// The plymouth CLI client is no longer bundled.
+	if err := img.appendExtraFiles("plymouthd"); err != nil {
 		return fmt.Errorf("plymouth binaries: %v", err)
 	}
 

--- a/init/luks.go
+++ b/init/luks.go
@@ -653,13 +653,10 @@ func requestKeyboardPassword(ctx context.Context, volumes chan *luks.Volume, d l
 	// Wait for plymouth initialization to complete before attempting to use
 	// it. Without this, udev events can trigger LUKS password prompts while
 	// plymouthd is still starting, causing the graphical prompt to fail.
-	waitForPlymouthInit()
-
-	// Bail early if the device was already unlocked by a token goroutine.
-	select {
-	case <-ctx.Done():
+	// ctx cancellation lets a sibling token unlocking the device dismiss
+	// this wait without forcing it to the plymouth-init timeout.
+	if err := waitForPlymouthInit(ctx); err != nil {
 		return
-	default:
 	}
 
 	// Fast path: try passwords that already unlocked another volume this boot

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -82,15 +82,14 @@ func initPlymouth() {
 	}
 	go cmd.Wait() // reap process in background
 
-	// Wait for plymouthd to be ready. Plymouth's --wait flag has its own
-	// internal retry loop but it only retries on connection failure. If
-	// plymouthd accepts the connection but isn't ready to process pings
-	// (still in device setup), --wait returns failure immediately. So we
-	// implement our own retry loop.
+	// Wait for plymouthd to be ready via direct socket ping. Plymouth's
+	// --wait flag has its own internal retry loop but only retries on
+	// connection failure; if plymouthd accepts the connection but isn't
+	// ready (still in device setup), --wait returns failure immediately.
 	pingDeadline := time.Now().Add(20 * time.Second)
 	pingOK := false
 	for time.Now().Before(pingDeadline) {
-		if exec.Command("plymouth", "--ping").Run() == nil {
+		if plymouthPingOnce() {
 			pingOK = true
 			break
 		}
@@ -103,7 +102,7 @@ func initPlymouth() {
 	}
 
 	// Show splash
-	if err := exec.Command("plymouth", "show-splash").Run(); err != nil {
+	if err := plymouthCmd('$', ""); err != nil {
 		warning("plymouth: failed to show splash: %v", err)
 		// plymouthd is running but splash failed; keep plymouth enabled
 		// for password prompts which may still work
@@ -208,18 +207,19 @@ func statusMessageTimed(msg string, d time.Duration) {
 
 // plymouthMessage displays a message on the plymouth splash screen.
 func plymouthMessage(msg string) {
-	if err := exec.Command("plymouth", "display-message", "--text="+msg).Run(); err != nil {
+	if err := plymouthCmd('M', msg); err != nil {
 		debug("plymouth: display-message failed: %v", err)
 	}
 }
 
-// plymouthQuit tells plymouth to quit with a timeout so it can't hang boot.
+// plymouthQuit tells plymouth to quit.
 func plymouthQuit() {
 	if !plymouthEnabled {
 		return
 	}
 	debug("plymouth: sending quit")
-	if err := exec.Command("plymouth", "quit").Run(); err != nil {
+	// Quit frame: Q + arg-marker + arg-len(1) + retain_splash(0).
+	if _, err := plymouthSendRecv([]byte{'Q', 2, 1, 0}); err != nil {
 		warning("plymouth: quit failed: %v", err)
 	}
 }
@@ -231,7 +231,7 @@ func plymouthNewroot(root string) {
 		return
 	}
 	debug("plymouth: setting newroot to %s", root)
-	if err := exec.Command("plymouth", "update-root-fs", "--new-root-dir="+root).Run(); err != nil {
+	if err := plymouthCmd('R', root); err != nil {
 		warning("plymouth: update-root-fs failed: %v", err)
 	}
 }

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -222,10 +222,17 @@ func statusMessageTimed(msg string, d time.Duration) {
 }
 
 // plymouthMessage displays a message on the plymouth splash screen.
+//
+// Fire-and-forget: send in a goroutine so callers never block on plymouthd.
+// plymouthd is single-threaded and can stall during render setup or while a
+// password prompt is on screen; a synchronous in-process call would block
+// the calling goroutine on splash state, slowing concurrent unlock work.
 func plymouthMessage(msg string) {
-	if err := plymouthCmd('M', msg); err != nil {
-		debug("plymouth: display-message failed: %v", err)
-	}
+	go func() {
+		if err := plymouthCmd('M', msg); err != nil {
+			debug("plymouth: display-message failed: %v", err)
+		}
+	}()
 }
 
 // plymouthQuit tells plymouth to quit.

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -15,10 +15,16 @@ var (
 )
 
 // waitForPlymouthInit blocks until the plymouth initialization phase is
-// complete (either plymouthd is running or plymouth was disabled).
+// complete (either plymouthd is running or plymouth was disabled), or until
+// ctx is cancelled. Returns ctx.Err() on cancellation, nil otherwise.
 // Safe to call multiple times; returns immediately after the first close.
-func waitForPlymouthInit() {
-	<-plymouthInitDone
+func waitForPlymouthInit(ctx context.Context) error {
+	select {
+	case <-plymouthInitDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // initPlymouth starts the plymouth daemon and shows the splash screen.

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -71,14 +71,30 @@ func initPlymouth() {
 
 	cmd := exec.Command("plymouthd", args...)
 	cmd.Env = []string{"PATH=/usr/bin"}
+
+	// Write plymouthd stderr directly to /dev/kmsg rather than inheriting
+	// booster's stderr. Inherited fds are closed (FD_CLOEXEC) when booster
+	// exec's to systemd, causing plymouthd to receive EPIPE on its next
+	// stderr write and die — before systemd's plymouth-start.service can
+	// attach to the existing session.
+	kmsg, err := os.OpenFile("/dev/kmsg", os.O_WRONLY, 0)
+	if err != nil {
+		debug("plymouth: could not open /dev/kmsg for plymouthd stderr: %v", err)
+	} else {
+		cmd.Stderr = kmsg
+	}
+
 	// Use Start() instead of Run(). Plymouthd may not daemonize in debug
 	// mode (plymouth.debug on kernel cmdline), so Run() would block forever
 	// waiting for the foreground process to exit. Start() returns immediately
-	// and we use "plymouth --wait --ping" to detect when the daemon is ready.
+	// and we use a socket ping to detect when the daemon is ready.
 	if err := cmd.Start(); err != nil {
 		warning("plymouth: failed to start plymouthd: %v", err)
 		plymouthEnabled = false
 		return
+	}
+	if kmsg != nil {
+		kmsg.Close() // booster no longer needs this end; plymouthd inherited it
 	}
 	go cmd.Wait() // reap process in background
 

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -1,17 +1,22 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
 var (
 	plymouthEnabled  bool
 	plymouthInitDone = make(chan struct{})
+	// plymouthPasswordMu serializes plymouthAskPassword calls so concurrent
+	// unlock goroutines don't stack two prompts on the splash at once.
+	plymouthPasswordMu sync.Mutex
 )
 
 // waitForPlymouthInit blocks until the plymouth initialization phase is
@@ -151,28 +156,47 @@ func getPlymouthdArgs() []string {
 	}
 }
 
-// plymouthAskPassword prompts the user for a password via plymouth.
-// Returns the password bytes or an error if plymouth fails.
-func plymouthAskPassword(prompt string) ([]byte, error) {
-	cmd := exec.Command("plymouth", "ask-for-password", "--prompt="+prompt)
-	out, err := cmd.Output()
+// plymouthAskPassword displays a password prompt on the splash and blocks
+// until the user submits a password — or ctx is cancelled, in which case
+// the underlying socket is closed. The goroutine returns cleanly either
+// way. plymouthd builds whose connection-hangup handler tears down pending
+// prompts also dismiss the on-screen UI on close; older builds leave the
+// prompt UI visible until the splash is otherwise cleared.
+//
+// Wire ctx to the LUKS unlock done channel so a sibling token unlocking the
+// volume cancels this prompt automatically.
+func plymouthAskPassword(ctx context.Context, prompt string) ([]byte, error) {
+	plymouthPasswordMu.Lock()
+	defer plymouthPasswordMu.Unlock()
+	// Re-check after acquiring: if another goroutine was showing a prompt
+	// and the volume got unlocked while we were waiting on the mutex, skip
+	// our prompt entirely so we don't flash a UI for an already-unlocking
+	// volume.
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	out, err := plymouthAskPasswordSocket(ctx, prompt)
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		return nil, err
 	}
-	// plymouth outputs the password followed by a newline
-	password := strings.TrimRight(string(out), "\n")
-	return []byte(password), nil
+	return bytes.TrimRight(out, "\n"), nil
 }
 
-// askPasswordWithFallback prompts via plymouth when enabled. Any plymouth
-// failure logs a warning and falls through to the console reader. ctx
-// cancellation is honored only by the console reader path; plymouth's IPC
-// is not yet ctx-aware.
+// askPasswordWithFallback prompts via plymouth when enabled, falling back
+// to the console reader on plymouth failure. Returns ctx.Err() without
+// falling back when ctx is cancelled — avoids flashing a console prompt
+// for a volume another unlock path has already won.
 func askPasswordWithFallback(ctx context.Context, prompt, postPrompt string) ([]byte, error) {
 	if plymouthEnabled {
-		password, err := plymouthAskPassword(prompt)
+		password, err := plymouthAskPassword(ctx, prompt)
 		if err == nil {
 			return password, nil
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
 		}
 		warning("Plymouth password prompt failed: %v, falling back to console", err)
 	}

--- a/init/plysocket.go
+++ b/init/plysocket.go
@@ -8,6 +8,65 @@ import (
 	"net"
 )
 
+// Direct IPC client for plymouthd's abstract Unix socket.
+//
+// Plymouth is the graphical boot splash daemon used to render password
+// prompts and progress messages during early boot:
+// https://gitlab.freedesktop.org/plymouth/plymouth
+//
+// The wire protocol verbs and reply byte constants are defined upstream in
+// src/libply-splash-core/ply-boot-protocol.h.
+//
+// Frame format for client → server commands:
+//
+//	[verb byte] [version = 2] [argLen byte] [argLen bytes, NUL-terminated]
+//
+// The server replies with a single byte for most verbs: 0x06 (ACK) on
+// success, 0x15 (NAK) on failure. The ask-password verb '*' is the
+// exception: the server replies with 0x02 (Answer) followed by
+// [uint32 length, little-endian][password bytes, not NUL-terminated].
+// plymouthAskPasswordSocket implements the answer-shaped exchange;
+// plymouthCmd handles the ACK/NAK shape used by ping, message, quit, etc.
+//
+// Verb reference (full set from ply-boot-protocol.h; only the first six are
+// exercised by booster — the rest are listed so future callers don't have
+// to cross-reference upstream):
+//
+//	IMPLEMENTED
+//	  P   PING                 plymouthPingOnce — readiness probe
+//	  $   SHOW_SPLASH          shown once plymouthd is up
+//	  *   PASSWORD             plymouthAskPasswordSocket (Answer reply)
+//	  M   SHOW_MESSAGE         plymouthMessage — status text under the prompt
+//	  Q   QUIT                 sent with retain-splash=1 at switchroot handoff
+//	  R   NEWROOT              advertises the new root path to plymouthd
+//
+//	UNUSED (defined upstream, no booster caller)
+//	  U   UPDATE               progress-bar percent
+//	  C   CHANGE_MODE          boot/shutdown/updates/firmware-upgrade/etc
+//	  u   SYSTEM_UPDATE        system-upgrade DM message
+//	  S   SYSTEM_INITIALIZED   "userspace is up" signal
+//	  D   DEACTIVATE           hand display ownership off (e.g. to systemd)
+//	  r   REACTIVATE           reclaim display ownership
+//	  l   RELOAD               re-read theme after handoff
+//	  c   CACHED_PASSWORD      replay a previously-collected password
+//	  W   QUESTION             free-form prompt (Answer-shaped reply)
+//	  m   HIDE_MESSAGE         clear a message previously shown via M
+//	  K   KEYSTROKE            subscribe to one keystroke
+//	  L   KEYSTROKE_REMOVE     unsubscribe
+//	  A   PROGRESS_PAUSE       freeze the throbber/progress-bar animation
+//	  a   PROGRESS_UNPAUSE     resume it
+//	  H   HIDE_SPLASH          (we use Q with retain=1 instead)
+//	  V   HAS_ACTIVE_VT        boolean reply about VT ownership
+//	  !   ERROR                push an error string into the splash
+//
+// Server response bytes:
+//
+//	0x06 ACK              success for command-shape verbs
+//	0x15 NAK              failure for command-shape verbs
+//	0x02 Answer           single answer (password/question reply)
+//	0x09 Multiple-Answers answer list (rare; multi-line questions)
+//	0x05 No-Answer        user dismissed the prompt without entering one
+
 const (
 	plymouthSocket = "\x00/org/freedesktop/plymouthd"
 	plymouthACK    = '\x06'

--- a/init/plysocket.go
+++ b/init/plysocket.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+)
+
+const (
+	plymouthSocket = "\x00/org/freedesktop/plymouthd"
+	plymouthACK    = '\x06'
+	plymouthAnswer = '\x02'
+)
+
+func plymouthDial() (net.Conn, error) {
+	return net.Dial("unix", plymouthSocket)
+}
+
+// plymouthSendRecv sends a raw frame and reads a 1-byte response.
+func plymouthSendRecv(frame []byte) (byte, error) {
+	conn, err := plymouthDial()
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+	if _, err := conn.Write(frame); err != nil {
+		return 0, err
+	}
+	var resp [1]byte
+	if _, err := io.ReadFull(conn, resp[:]); err != nil {
+		return 0, err
+	}
+	return resp[0], nil
+}
+
+// plymouthCmd sends a command with a NUL-terminated argument and expects ACK.
+// Always encodes the argument — even an empty string — so plymouthd receives
+// a non-NULL argument pointer. Callers that want a genuinely no-argument frame
+// (e.g. ping, show-splash) should use plymouthSendRecv directly.
+func plymouthCmd(typ byte, arg string) error {
+	data := append([]byte(arg), 0) // NUL-terminate; "" becomes ['\0']
+	if len(data) > 255 {
+		data = data[:255]
+	}
+	frame := append([]byte{typ, 2, byte(len(data))}, data...)
+	resp, err := plymouthSendRecv(frame)
+	if err != nil {
+		debug("plymouth: cmd %c failed: %v", rune(typ), err)
+		return err
+	}
+	if resp != plymouthACK {
+		debug("plymouth: cmd %c got NAK", rune(typ))
+		return fmt.Errorf("plymouth NAK for %c", rune(typ))
+	}
+	return nil
+}
+
+// plymouthPingOnce attempts a single ping. Returns true on ACK.
+func plymouthPingOnce() bool {
+	resp, err := plymouthSendRecv([]byte{'P', 0})
+	return err == nil && resp == plymouthACK
+}
+
+// plymouthAskPasswordSocket sends a password request and blocks until the user
+// submits a password or ctx is cancelled. On cancellation the connection is
+// closed; the goroutine returns cleanly either way. plymouthd builds whose
+// connection-hangup handler tears down pending prompts also dismiss the
+// on-screen UI on close — older builds release server-side state but leave
+// the prompt UI visible until the splash is otherwise cleared.
+func plymouthAskPasswordSocket(ctx context.Context, prompt string) ([]byte, error) {
+	conn, err := plymouthDial()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	// Close the connection when ctx fires so plymouthd observes the hangup.
+	go func() {
+		<-ctx.Done()
+		conn.Close()
+	}()
+
+	// Guard against a cancelled context between dial and write — avoids sending
+	// the frame (and flashing a prompt on screen) when the volume is already
+	// being unlocked by another goroutine.
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	data := append([]byte(prompt), 0)
+	if len(data) > 255 {
+		data = data[:255]
+	}
+	frame := append([]byte{'*', 2, byte(len(data))}, data...)
+	if _, err := conn.Write(frame); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, err
+	}
+
+	var hdr [1]byte
+	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, err
+	}
+	if hdr[0] != plymouthAnswer {
+		return nil, fmt.Errorf("plymouth: ask-password unexpected response %#x", hdr[0])
+	}
+
+	// Response: [uint32 length, little-endian][password bytes, not NUL-terminated]
+	var sizeBuf [4]byte
+	if _, err := io.ReadFull(conn, sizeBuf[:]); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, err
+	}
+	size := binary.LittleEndian.Uint32(sizeBuf[:])
+	if size > 4096 {
+		return nil, fmt.Errorf("plymouth: ask-password response size too large: %d", size)
+	}
+	buf := make([]byte, size)
+	if size > 0 {
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			return nil, err
+		}
+	}
+	return buf, nil
+}


### PR DESCRIPTION
## Summary

Talk to plymouthd directly over its abstract Unix socket
(`\x00/org/freedesktop/plymouthd`) instead of fork-exec'ing the
`plymouth` CLI client. The wire protocol is documented in Plymouth's
`ply-boot-protocol.h`.

Carved into 5 commits for review:

1. **`init/plymouth: replace plymouth CLI with direct socket IPC`** —
   add `init/plysocket.go` (transport), swap the 5 exec call sites for
   ping / show-splash / display-message / quit / update-root-fs. Drop
   `/usr/bin/plymouth` from the initramfs (~80KB binary plus
   `glib` + `libply-boot-client` transitive deps). No call-site
   signature changes; `plymouthAskPassword` stays on the exec path
   for now and converts in commit 5 when ctx threading lands.

2. **`init/plymouth: redirect plymouthd stderr to /dev/kmsg`** —
   inherited fds are closed (FD_CLOEXEC) when booster exec's to
   systemd, so a plymouthd that inherits booster's stderr receives
   EPIPE on its next stderr write and dies before
   `plymouth-start.service` can attach. Routing to `/dev/kmsg`
   survives the handoff and lands the diagnostic output in the
   kernel ring buffer.

3. **`init/plymouth: make plymouthMessage fire-and-forget`** —
   plymouthd is single-threaded; a synchronous in-process
   `display-message` call would block on splash state, slowing
   concurrent unlock work. Wrap in a goroutine.

4. **`init/plymouth: thread ctx through waitForPlymouthInit`** —
   small signature change so unlock paths can bail when a sibling
   token has already cleared the volume, instead of blocking on
   plymouthd init for a volume that's already being unlocked.

5. **`init/plymouth: ctx-aware password prompt with cancel-on-hangup`**
   (the headline) — `plymouthAskPassword(ctx, prompt)` plus a
   serialization mutex. On ctx cancel the underlying socket is closed;
   the goroutine returns cleanly. plymouthd builds whose
   connection-hangup handler tears down pending prompts also dismiss
   the on-screen UI on close — older builds leave the UI visible
   until the splash is otherwise cleared, but boot proceeds correctly
   either way (matching upstream's prior behaviour minus the orphaned
   plymouth subprocess and leaked goroutine the exec path produced).
   `askPasswordWithFallback` skips the console fallback when ctx is
   already cancelled, so an already-unlocking volume doesn't flash a
   stray console prompt.

## Why

- Drops `/usr/bin/plymouth` and its transitive deps from the
  initramfs.
- Cancellation hygiene: a sibling-token-wins ctx cancel now closes
  the socket and the prompt goroutine returns immediately. The prior
  exec path left both the subprocess and the goroutine blocked
  indefinitely.
- Ctx-aware Plymouth path completes the cancellation arc started by
  #354 / #356 — keyboard, FIDO2-PIN, and TPM2-PIN prompts already
  cancel on autounlock; this extends the same to the splash prompt.

No new dependencies. Tests for splash messaging (#357) still pass
unchanged.

## Upstream Plymouth dependency

The cancel-on-hangup behavior in commit 5 — dismissing the on-screen
prompt when the booster client disconnects — depends on plymouthd
having a connection-hangup handler that tears down pending prompts.
That fix is Plymouth [MR !393](https://gitlab.freedesktop.org/plymouth/plymouth/-/merge_requests/393),
currently awaiting upstream review (closes Plymouth issues #125 and
#126).

This PR does **not** require !393 to land first. Without it, booster
still cleans up its end of the socket on cancel — boot proceeds
correctly, the goroutine returns, no orphaned subprocess. The only
visible difference is a stale prompt that lingers on the splash until
plymouth quits later in boot. Pure visual polish, not a regression vs.
the exec path.

Once !393 is in users' plymouthd, the splash prompt also dismisses
cleanly, completing the UX that #354 / #355 / #356 brought to the
console side.

## Test plan

- [x] `go build ./init ./generator` clean
- [x] `TestPromptVolumeUnlocked` and `TestTokenFriendlyName` pass
- [x] Image builds with the smaller plymouth payload (no
      `/usr/bin/plymouth` in the cpio)
- [x] Boot test on host with concurrent FIDO2 + TPM2 + keyboard
      unlock paths
- [x] Boot test on a plymouthd build without the connection-hangup
      handler — confirm no behavioural regression vs. exec path