### PR TITLE
init,generator: surface crypttab failure modes and fix cmdRoot remap

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -132,7 +132,7 @@ Some parts of booster boot functionality can be modified with kernel boot parame
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
 
 Booster supports unlocking LUKS volumes declared in `/etc/crypttab` (see **crypttab(5)**).
-Only entries marked with the `x-initrd.attach` option are bundled into the initramfs at image build time. `rd.luks.*` kernel parameters take precedence — if a cmdline parameter already covers a device, its crypttab entry is skipped.
+Only entries marked with the `x-initrd.attach` option are bundled into the initramfs at image build time. When both a `rd.luks.*` cmdline parameter and a crypttab entry cover the same device, the cmdline takes precedence for the device reference and mapping name; the crypttab entry's security options (keyfile, header, tries, token-timeout, …) are merged in. Crypttab entries for devices not covered by `rd.luks.*` are appended as new mappings.
 
 Booster-specific behaviour for selected options:
  * **keyfile** `/path:UUID=xxx` (or `LABEL=`, `PARTUUID=`, `PARTLABEL=`) — keyfile on a separate device. Booster mounts the device read-only at boot, reads the key, then unmounts. The file is not bundled into the initramfs.

--- a/generator/crypttab_test.go
+++ b/generator/crypttab_test.go
@@ -51,6 +51,32 @@ func TestAppendCrypttabAbsent(t *testing.T) {
 	img, _ := newTestImage(t)
 	_, err := img.appendCrypttab(filepath.Join(t.TempDir(), "no-such-file"))
 	require.Error(t, err)
+	require.True(t, os.IsNotExist(err), "expected IsNotExist, got %v", err)
+}
+
+// A crypttab that exists but is unreadable must surface as a permission
+// error from appendCrypttab so the caller (generateInitRamfs) can
+// distinguish absent-file (silent skip) from present-but-unreadable
+// (warn-and-continue when path is the default, fail when --crypttab is
+// explicit). Regression coverage for v0.13: a generator running
+// unprivileged on a system that DOES use /etc/crypttab must not silently
+// produce an image lacking LUKS unlock specs.
+func TestAppendCrypttabUnreadable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits ignored when running as root")
+	}
+	dir := t.TempDir()
+	crypttab := filepath.Join(dir, "crypttab")
+	require.NoError(t, os.WriteFile(crypttab, []byte(
+		"cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none x-initrd.attach\n",
+	), 0o000))
+
+	img, _ := newTestImage(t)
+	_, err := img.appendCrypttab(crypttab)
+	require.Error(t, err)
+	require.True(t, os.IsPermission(err), "expected IsPermission, got %v", err)
+	require.False(t, os.IsNotExist(err), "must not look like an absent file")
+	require.False(t, img.contains["/etc/crypttab"])
 }
 
 func TestAppendCrypttabBundled(t *testing.T) {

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -123,9 +123,14 @@ func generateInitRamfs(conf *generatorConfig) error {
 		crypttabPath = "/etc/crypttab"
 	}
 	if hasFido2, err := img.appendCrypttab(crypttabPath); err != nil {
-		if !explicitCrypttab && (os.IsNotExist(err) || os.IsPermission(err)) {
-			// default path unavailable — crypttab is optional, skip silently
-		} else {
+		switch {
+		case explicitCrypttab:
+			return err
+		case os.IsNotExist(err):
+			// optional file
+		case os.IsPermission(err):
+			warning("crypttab: %s exists but is unreadable (%v) — image will lack /etc/crypttab-derived LUKS unlock specs; re-run with sufficient privileges to include them", crypttabPath, err)
+		default:
 			return err
 		}
 	} else if hasFido2 {

--- a/init/luks.go
+++ b/init/luks.go
@@ -974,6 +974,12 @@ func loadRequiredCryptoModules(encryption string) error {
 func matchLuksMapping(blk *blkInfo) *luksMapping {
 	for _, m := range luksMappings {
 		if blk.matchesRef(m.ref) {
+			// Mirror the synthesis-fallback remap so root=UUID=<luks-uuid>
+			// keeps working after a crypttab/rd.luks.* entry adds the mapping.
+			if blk.matchesRef(cmdRoot) {
+				info("LUKS device %s matches root=, re-pointing root to /dev/mapper/%s", blk.path, m.name)
+				cmdRoot = &deviceRef{format: refPath, data: "/dev/mapper/" + m.name}
+			}
 			return m
 		}
 	}

--- a/init/luks.go
+++ b/init/luks.go
@@ -971,6 +971,27 @@ func loadRequiredCryptoModules(encryption string) error {
 	return nil
 }
 
+// unreachableMapperName reports the basename of cmdRoot when it is a
+// /dev/mapper/<name> path-ref AND no luksMapping exists with that name. Used
+// to surface a diagnostic for the boot pattern that silently hangs when a
+// LUKS unlock spec is missing.
+func unreachableMapperName() (string, bool) {
+	if cmdRoot == nil || cmdRoot.format != refPath {
+		return "", false
+	}
+	p, ok := cmdRoot.data.(string)
+	if !ok || !strings.HasPrefix(p, "/dev/mapper/") {
+		return "", false
+	}
+	name := strings.TrimPrefix(p, "/dev/mapper/")
+	for _, m := range luksMappings {
+		if m.name == name {
+			return "", false
+		}
+	}
+	return name, true
+}
+
 func matchLuksMapping(blk *blkInfo) *luksMapping {
 	for _, m := range luksMappings {
 		if blk.matchesRef(m.ref) {

--- a/init/luks_test.go
+++ b/init/luks_test.go
@@ -224,3 +224,60 @@ func TestMatchLuksMappingNoMatchReturnsNil(t *testing.T) {
 	require.Same(t, rootRef, cmdRoot)
 }
 
+// unreachableMapperName fires only when cmdRoot is /dev/mapper/<name> and no
+// luksMapping covers <name>. Any other shape is silent so we don't spam LVM
+// or RAID setups.
+func TestUnreachableMapperName(t *testing.T) {
+	cases := []struct {
+		desc     string
+		root     *deviceRef
+		mappings []*luksMapping
+		wantName string
+		wantOK   bool
+	}{
+		{
+			desc:     "root=/dev/mapper/cryptroot with empty luksMappings",
+			root:     &deviceRef{format: refPath, data: "/dev/mapper/cryptroot"},
+			wantName: "cryptroot",
+			wantOK:   true,
+		},
+		{
+			desc:   "no cmdRoot",
+			root:   nil,
+			wantOK: false,
+		},
+		{
+			desc:   "root=UUID=… is silent",
+			root:   &deviceRef{format: refFsUUID, data: UUID{}},
+			wantOK: false,
+		},
+		{
+			desc:   "root=/dev/sda1 (non-mapper path) is silent",
+			root:   &deviceRef{format: refPath, data: "/dev/sda1"},
+			wantOK: false,
+		},
+		{
+			desc:     "root=/dev/mapper/cryptroot WITHOUT covering mapping",
+			root:     &deviceRef{format: refPath, data: "/dev/mapper/cryptroot"},
+			mappings: []*luksMapping{{name: "swap"}},
+			wantName: "cryptroot",
+			wantOK:   true,
+		},
+		{
+			desc:     "root=/dev/mapper/cryptroot WITH covering mapping",
+			root:     &deviceRef{format: refPath, data: "/dev/mapper/cryptroot"},
+			mappings: []*luksMapping{{name: "cryptroot"}},
+			wantOK:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			withLuksGlobals(t)
+			cmdRoot = tc.root
+			luksMappings = tc.mappings
+			name, ok := unreachableMapperName()
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantName, name)
+		})
+	}
+}

--- a/init/luks_test.go
+++ b/init/luks_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"testing"
+	"time"
 
 	"github.com/google/go-tpm/tpmutil"
 	"github.com/stretchr/testify/require"
@@ -84,3 +85,142 @@ func TestParseSystemdTPM2BlobRejectsTruncatedData(t *testing.T) {
 	_, _, err = parseSystemdTPM2Blob([]byte{0x00, 0x01, 0x01, 0x00, 0x02, 0x04})
 	require.Error(t, err)
 }
+// withLuksGlobals saves and restores the package-global cmdRoot and luksMappings
+// so each test can mutate them in isolation.
+func withLuksGlobals(t *testing.T) {
+	t.Helper()
+	origRoot := cmdRoot
+	origMappings := luksMappings
+	t.Cleanup(func() {
+		cmdRoot = origRoot
+		luksMappings = origMappings
+	})
+}
+
+// Regular-loop match where cmdRoot identifies the same LUKS partition:
+// matchLuksMapping must rewrite cmdRoot to /dev/mapper/<m.name>. This is the
+// crypttab-introduced regression scenario — without the rewrite, a crypttab
+// entry covering the root LUKS UUID makes `root=UUID=<luks-uuid>` boot fail.
+func TestMatchLuksMappingRewritesCmdRootOnRegularLoopMatch(t *testing.T) {
+	withLuksGlobals(t)
+
+	uuid, err := parseUUID("ab6d7d78-b816-4495-928d-766d6607035e")
+	require.NoError(t, err)
+
+	m := &luksMapping{
+		ref:          &deviceRef{format: refFsUUID, data: uuid},
+		name:         "cryptroot",
+		keySlot:      -1,
+		tokenTimeout: 30 * time.Second,
+	}
+	luksMappings = []*luksMapping{m}
+	cmdRoot = &deviceRef{format: refFsUUID, data: uuid}
+
+	blk := &blkInfo{path: "/dev/sda2", format: "luks", uuid: uuid}
+	got := matchLuksMapping(blk)
+	require.Same(t, m, got)
+
+	require.Equal(t, refPath, cmdRoot.format, "cmdRoot must be rewritten to a path-ref")
+	require.Equal(t, "/dev/mapper/cryptroot", cmdRoot.data.(string))
+}
+
+// Regular-loop match where cmdRoot points at a *different* device:
+// matchLuksMapping must return the matching mapping but leave cmdRoot alone.
+// (e.g. swap or data partition unlocked while root lives elsewhere.)
+func TestMatchLuksMappingLeavesCmdRootAloneWhenItDoesNotMatch(t *testing.T) {
+	withLuksGlobals(t)
+
+	swapUUID, err := parseUUID("ab6d7d78-b816-4495-928d-766d6607035e")
+	require.NoError(t, err)
+	rootUUID, err := parseUUID("7843d77f-cdd6-4289-a4de-a708c4aacede")
+	require.NoError(t, err)
+
+	swap := &luksMapping{
+		ref:          &deviceRef{format: refFsUUID, data: swapUUID},
+		name:         "cryptswap",
+		keySlot:      -1,
+		tokenTimeout: 30 * time.Second,
+	}
+	luksMappings = []*luksMapping{swap}
+
+	rootRef := &deviceRef{format: refFsUUID, data: rootUUID}
+	cmdRoot = rootRef
+
+	blk := &blkInfo{path: "/dev/sda3", format: "luks", uuid: swapUUID}
+	got := matchLuksMapping(blk)
+	require.Same(t, swap, got)
+
+	require.Same(t, rootRef, cmdRoot, "cmdRoot must be untouched when the matched mapping is not the root device")
+}
+
+// Synthesis-fallback path: no entry in luksMappings, but cmdRoot points at the
+// LUKS partition. matchLuksMapping must synthesise a mapping named "root" and
+// rewrite cmdRoot to /dev/mapper/root (autodiscoverable-partition behaviour).
+func TestMatchLuksMappingSynthesisFallbackUnchanged(t *testing.T) {
+	withLuksGlobals(t)
+
+	uuid, err := parseUUID("7f28c723-fd6b-4640-bc94-9366edd8880d")
+	require.NoError(t, err)
+
+	luksMappings = nil
+	rootRef := &deviceRef{format: refFsUUID, data: uuid}
+	cmdRoot = rootRef
+
+	blk := &blkInfo{path: "/dev/sda2", format: "luks", uuid: uuid}
+	got := matchLuksMapping(blk)
+	require.NotNil(t, got)
+	require.Equal(t, "root", got.name)
+	require.Equal(t, -1, got.keySlot)
+	require.Equal(t, 30*time.Second, got.tokenTimeout)
+	require.Same(t, rootRef, got.ref, "synthesised mapping must keep the original cmdRoot ref")
+
+	require.Equal(t, refPath, cmdRoot.format)
+	require.Equal(t, "/dev/mapper/root", cmdRoot.data.(string))
+}
+
+// Regression guard for the "user wrote root=/dev/mapper/cryptroot themselves"
+// case. blk is the underlying LUKS partition (/dev/sda2); cmdRoot is a path-ref
+// to the future mapper node. matchesRef compares paths/symlinks, so it returns
+// false — the rewrite branch must not fire, and cmdRoot must be preserved.
+func TestMatchLuksMappingPreservesExplicitMapperPath(t *testing.T) {
+	withLuksGlobals(t)
+
+	uuid, err := parseUUID("ab6d7d78-b816-4495-928d-766d6607035e")
+	require.NoError(t, err)
+
+	m := &luksMapping{
+		ref:          &deviceRef{format: refFsUUID, data: uuid},
+		name:         "cryptroot",
+		keySlot:      -1,
+		tokenTimeout: 30 * time.Second,
+	}
+	luksMappings = []*luksMapping{m}
+
+	mapperRef := &deviceRef{format: refPath, data: "/dev/mapper/cryptroot"}
+	cmdRoot = mapperRef
+
+	blk := &blkInfo{path: "/dev/sda2", format: "luks", uuid: uuid}
+	got := matchLuksMapping(blk)
+	require.Same(t, m, got)
+	require.Same(t, mapperRef, cmdRoot, "explicit /dev/mapper/... cmdRoot must not be rewritten")
+}
+
+// No mapping and cmdRoot does not match the device: matchLuksMapping returns
+// nil and leaves cmdRoot alone (the device is just not ours to unlock).
+func TestMatchLuksMappingNoMatchReturnsNil(t *testing.T) {
+	withLuksGlobals(t)
+
+	blkUUID, err := parseUUID("ab6d7d78-b816-4495-928d-766d6607035e")
+	require.NoError(t, err)
+	rootUUID, err := parseUUID("7843d77f-cdd6-4289-a4de-a708c4aacede")
+	require.NoError(t, err)
+
+	luksMappings = nil
+	rootRef := &deviceRef{format: refFsUUID, data: rootUUID}
+	cmdRoot = rootRef
+
+	blk := &blkInfo{path: "/dev/sdb1", format: "luks", uuid: blkUUID}
+	require.Nil(t, matchLuksMapping(blk))
+	require.Same(t, rootRef, cmdRoot)
+}
+

--- a/init/main.go
+++ b/init/main.go
@@ -1081,6 +1081,14 @@ func boost() error {
 		}
 	}
 
+	// Diagnostic for the silent-hang case where root= names a /dev/mapper/<name>
+	// device but nothing in our config will create that mapper. Emitted as a
+	// warning rather than a fatal because LVM / RAID / dm-integrity can also
+	// produce mapper nodes via paths outside luksMappings.
+	if name, ok := unreachableMapperName(); ok {
+		warning("root=/dev/mapper/%s but no LUKS unlock spec was found for %q — if this is a LUKS root, image is missing rd.luks.name=, an /etc/crypttab entry with x-initrd.attach, or a DPS-tagged LUKS root partition; if this is LVM/RAID/dm-integrity this warning is benign", name, name)
+	}
+
 	// Check if plymouth should be enabled: needs both config and "splash" kernel param
 	if config.EnablePlymouth {
 		cmdlineBytes, err := os.ReadFile("/proc/cmdline")


### PR DESCRIPTION
## Summary

Three crypttab-adjacent failure modes that manifest as silent boot
hangs, plus the docs fix to match current behavior.

## Commits

- **generator: warn on unreadable /etc/crypttab instead of silent skip**
  93df14f conflated ENOENT (legitimately optional) with EACCES (almost
  always operator running the generator unprivileged). The latter now
  warns at build time so a broken initramfs surfaces immediately
  instead of as a hung boot.

- **init: rewrite cmdRoot to /dev/mapper/<name> on regular-loop match**
  The synthesis-fallback in `matchLuksMapping` rewrote cmdRoot to the
  post-unlock mapper path; the regular loop didn't, so adding a
  crypttab/rd.luks.* entry covering the LUKS header UUID broke any
  `root=UUID=<luks-uuid>` that previously worked via fallback.

- **init: warn when root=/dev/mapper/<name> has no LUKS unlock spec**
  Diagnostic for the silent-hang where root= names a mapper but
  nothing in cmdline or crypttab will produce it. Warning, not fatal,
  because LVM/RAID/dm-integrity also create mapper nodes outside
  luksMappings.

- **docs/manpage: correct crypttab merge behaviour (skipped → merged)**
  Wording predates 42d81fd. Crypttab options are merged into
  rd.luks.*-derived mappings, not skipped.

## Test plan

- [x] \`go test ./init/ ./generator/\` passes (sudo-only LVM/MdRaid
      tests pre-existing skip)
- [x] new unit tests: \`TestMatchLuks*\`, \`TestUnreachableMapperName\`,
      \`TestAppendCrypttabUnreadable\`
- [x] live boot: baseline (rd.luks.name= + root=/dev/mapper/cryptroot)
      boots normally
- [x] live boot: cmdRoot remap path (rd.luks.name= + root=UUID=...)
      boots normally; expect \`re-pointing root to /dev/mapper/...\`
      in dmesg
- [x] live boot: unreachable warning (root=/dev/mapper/cryptroot, no
      unlock spec) prints diagnostic before hang

## Follow-up

Discovery of these failure modes made me want to try DPS LUKS-root
partition autodiscovery as a new feature. Planning a separate PR for
that — this one is fix-only.