### PR TITLE
init: clear splash status synchronously at switch_root

### DIFF
--- a/init/luks.go
+++ b/init/luks.go
@@ -538,7 +538,7 @@ func recoverTokenPassword(ctx context.Context, volumes chan *luks.Volume, d luks
 	if !tryPassphraseAgainstSlots(ctx, volumes, d, t.Slots, password) {
 		return false
 	}
-	statusMessageTimed(mappingName+" unlocked via "+tokenFriendlyName(t.Type), 3*time.Second)
+	statusMessage(mappingName + " unlocked via " + tokenFriendlyName(t.Type))
 	return true
 }
 

--- a/init/main.go
+++ b/init/main.go
@@ -859,6 +859,8 @@ func deleteRamfs() error {
 
 // https://github.com/mirror/busybox/blob/9aa751b08ab03d6396f86c3df77937a19687981b/util-linux/switch_root.c#L297
 func switchRoot() error {
+	clearSplashStatusSync()
+
 	// Tell plymouth about the new root before moving mounts
 	plymouthNewroot(newRoot)
 

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -240,15 +240,18 @@ func promptVolumeUnlocked() bool {
 	}
 }
 
-// statusMessageTimed shows msg and clears it after d. Use for transient status
-// updates that have no other natural dismissal point (skip confirmations,
-// success notifications).
-func statusMessageTimed(msg string, d time.Duration) {
-	statusMessage(msg)
-	go func() {
-		time.Sleep(d)
-		statusMessage("")
-	}()
+// clearSplashStatusSync synchronously clears the splash status line. Used at
+// boot handoff (switchRoot) so the last "unlocked via …" frame isn't left
+// behind on the splash after we exec to systemd. Synchronous because
+// goroutine-deferred work doesn't survive exec — a fire-and-forget clear
+// can be cancelled by the exec before plymouthd ever sees it.
+func clearSplashStatusSync() {
+	if !plymouthEnabled {
+		return
+	}
+	if err := plymouthCmd('M', ""); err != nil {
+		debug("plymouth: clear status failed: %v", err)
+	}
 }
 
 // plymouthMessage displays a message on the plymouth splash screen.


### PR DESCRIPTION
statusMessageTimed deferred its clear via a goroutine sleeping for the timeout duration. At switch_root the exec races that goroutine. This meant that in practice the exec wins and the sleep goroutine fails leaving the final "unlocked via <token>" frame visible on the splash after we hand off to systemd.

Replace with a synchronous clearSplashStatusSync() invoked at the top of switchRoot, and drop the deferred-clear from recoverTokenPassword (which was the only caller of statusMessageTimed).

As a reminder the intent is that these plymouth status messages will be removed completely once !393 makes its way to the live plymouth repo. It's interim purpose is to inform the user the prompt for the current luks partition is already unlocked via concurrent token and may be dismissed to allow for another device or the graphical splash.