### PR TITLE
docs/manpage: restructure root discovery/crypttab and add worked examples

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -365,6 +365,21 @@ The bootloader entry points `root=` at the future mapper node:
     initrd /booster-linux.img
     options root=/dev/mapper/cryptroot rw
 
+Boot with no `root=` on the kernel cmdline at all using GPT autodiscovery. Tag the root partition with the per-architecture GUID — on x86-64 that's `4f68bce3-e8cd-4db1-96e7-fbcaf984b709`:
+
+    $ sgdisk --typecode=2:4f68bce3-e8cd-4db1-96e7-fbcaf984b709 /dev/sda
+
+For a LUKS-encrypted root, add a `/etc/crypttab` entry naming the mapper (otherwise booster synthesises `/dev/mapper/root`):
+
+    cryptroot  UUID=e122d09e-87a9-4b35-83f7-2592ef40cefa  none  x-initrd.attach
+
+The bootloader entry then carries only the mount-style flags:
+
+    title Linux with Booster
+    linux /vmlinuz-linux
+    initrd /booster-linux.img
+    options rw
+
 Users of the Btrfs filesystem with a system installed on a subvolume should add rootflags corresponding to their entry in /etc/fstab. In this example 69bc4dd2-7f6c-4821-aa6b-d80d9c97d470 is a UUID for Btrfs partition, with the system installed on subvolume called root and /etc/fstab looks like this:
 
     UUID=69bc4dd2-7f6c-4821-aa6b-d80d9c97d470	/         	btrfs     	rw,relatime,autodefrag,compress=zstd:2,space_cache,subvol=root	0 0

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -259,9 +259,14 @@ Editing keys beyond the standard:
  * **Ctrl+U** — erase the entire entry.
  * **Tab** — toggle visibility of the typed characters (asterisks ↔ literal).
 
-When any unlock method wins the race (a TPM2 PCR-only or FIDO2 touchless token completes, or a sibling volume's keyfile reads successfully), the keyboard prompt auto-dismisses and boot continues.
+### LUKS unlock concurrency and prompt order
+Booster runs LUKS unlock paths concurrently per volume — multiple enrolled tokens dispatch in parallel where possible, and the keyboard passphrase prompt runs alongside them as a fallback. This subsection summarises the deterministic ordering and the cancel-on-win behaviour that ties them together.
 
-PIN prompts (TPM2-PIN, FIDO2-PIN) accept up to 3 attempts; press Enter empty PIN to skip the token to the next unlock prompt.
+**PIN-token serialization.** Tokens that need a PIN (TPM2-PIN, FIDO2-PIN) prompt serially, in ascending LUKS2 token-ID order — booster never races two PIN prompts for the same keyboard. Tokens that do not need a PIN (TPM2 PCR-only, FIDO2 touchless) dispatch in parallel and can win the race without user interaction. To preview the PIN prompt order for a volume, run `cryptsetup luksDump <device>` and read the token IDs.
+
+**Cancel-on-win.** Any prompt — keyboard passphrase, FIDO2-PIN, or TPM2-PIN — is dismissed automatically when a parallel unlock path wins (a touchless token completes, a sibling volume's keyfile reads successfully, etc.). This applies on both the kernel console and the Plymouth splash. On Plymouth the on-screen prompt clears immediately on the server side once Plymouth MR !393 is picked up; older Plymouth builds release the prompt server-side but leave its UI drawn until the splash is otherwise cleared.
+
+**PIN attempt caps.** Each PIN-bearing token accepts up to 3 attempts; submit an empty PIN (just press Enter) to skip the token and dispatch the next one.
 
 ### Modules selection
 It is a note to summarize the algorithm that computes what modules are going to end up in the generated booster image.

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -116,9 +116,7 @@ Unpack image. Usage: `booster [OPTIONS] unpack image output-dir`
 ## BOOT TIME KERNEL PARAMETERS
 Some parts of booster boot functionality can be modified with kernel boot parameters. These parameters are usually set through bootloader config. Booster boot uses following kernel parameters:
 
- * `root=$deviceref` device reference to root device. See notes below for how to specify the device reference.
-    If `root=` points to a LUKS partition then it automatically unlocked as a device `/dev/mapper/root` and mounted to root.
-    Booster also supports root [partition autodiscovery](https://systemd.io/DISCOVERABLE_PARTITIONS/) - if no `root=` parameter is specified then booster checks for partitions with specific GPT type and uses it to mount as root.
+ * `root=$deviceref` device reference to root device. See "Device Reference" in NOTES for how to specify it, and "ROOT PARTITION DISCOVERY" for how booster handles unencrypted, LUKS, and autodiscovered roots.
  * `rootfstype=$TYPE` (e.g. rootfstype=ext4). By default booster tries to detect the root filesystem type. But if the autodetection does not work then this kernel parameter is useful. Also please file a ticket so we can improve the code that detects filetypes.
  * `rootflags=$OPTIONS` mount options for the root filesystem, e.g. rootflags=user_xattr,nobarrier. In partition autodiscovery mode GPT attribute 60 ("read-only") is taken into account.
  * `rd.luks.uuid=$UUID` UUID of the LUKS partition where the root partition is enclosed. booster will try to unlock this LUKS device.
@@ -130,17 +128,6 @@ Some parts of booster boot functionality can be modified with kernel boot parame
     * **File on a separate device** — `$path:$deviceref` where `$deviceref` is `UUID=...`, `LABEL=...`, `PARTUUID=...`, or `PARTLABEL=...`. Booster mounts the device read-only, reads the header file, then unmounts before unlocking.
  * `rd.luks.options=opt1,opt2` a comma-separated list of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`. `token-timeout=<duration>` sets how long to wait for hardware tokens (FIDO2, TPM2) before also prompting for a keyboard passphrase. Accepts a decimal number followed by a unit (`s`, `m`, `h`), or a bare integer treated as seconds. Default is 30 s.
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
-
-Booster supports unlocking LUKS volumes declared in `/etc/crypttab` (see **crypttab(5)**).
-Only entries marked with the `x-initrd.attach` option are bundled into the initramfs at image build time. When both a `rd.luks.*` cmdline parameter and a crypttab entry cover the same device, the cmdline takes precedence for the device reference and mapping name; the crypttab entry's security options (keyfile, header, tries, token-timeout, …) are merged in. Crypttab entries for devices not covered by `rd.luks.*` are appended as new mappings.
-
-Booster-specific behaviour for selected options:
- * **keyfile** `/path:UUID=xxx` (or `LABEL=`, `PARTUUID=`, `PARTLABEL=`) — keyfile on a separate device. Booster mounts the device read-only at boot, reads the key, then unmounts. The file is not bundled into the initramfs.
- * **`header=`** — if the path is a plain absolute path the generator bundles the file into the initramfs automatically. The `/path:deviceref` form mounts the device at boot; `/dev/...` uses the raw block device directly.
- * **`fido2-device=auto`** — when present the generator automatically bundles `fido2plugin.so`; no `enable_fido2: true` in the config file is required.
- * **`fido2-device=auto`** / **`tpm2-device=auto`** — accepted for compatibility. Booster detects enrolled tokens directly from the LUKS2 header, so these flags are no longer required to activate token-aware behaviour. The keyboard passphrase prompt is deferred for any LUKS2 volume that has enrolled tokens until the token attempt completes or `token-timeout=` elapses.
- * **`keyfile-timeout=`** / **`token-timeout=`** — accept a bare integer (seconds) or any duration string accepted by Go's `time.ParseDuration` (e.g. `30s`, `2m`).
-
  * `rd.modules_force_load` a comma-separated list of extra kernel modules which should be force loaded.
  * `resume=$deviceref` device reference to suspend-to-disk device.
  * `zfs=$pool/$dataset` specifies what ZFS dataset needs to be used for root partition. This option is only used if ZFS config option is enabled. If ZFS filesystem is enabled then `root=` boot param is ignored.
@@ -157,6 +144,91 @@ Booster-specific behaviour for selected options:
  * `booster.debug` an obsolete option that is equivalent to `booster.log=debug,console`.
  * `quiet` Set booster init verbosity to minimum. This option is ignored if `booster.debug` or `booster.log` is set.
  * `init=$PATH` path to user-space init binary. If not specified then default value `/sbin/init` is used.
+
+## ROOT PARTITION DISCOVERY
+
+Booster identifies the root filesystem from the kernel cmdline and, if it
+is encrypted, unlocks the LUKS container before mounting. Most setups land
+on one of the configurations below.
+
+### Unencrypted root
+
+    root=UUID=<filesystem-uuid>
+
+`PARTUUID=`, `LABEL=`, or a `/dev/...` path also work.
+
+### Encrypted (LUKS) root
+
+There are four ways to set it up. Pick whichever fits your bootloader
+and existing tooling.
+
+**Named via cmdline.**
+
+    rd.luks.name=<luks-partition-uuid>=<name> root=/dev/mapper/<name>
+
+See `rd.luks.name`, `rd.luks.uuid`, and friends under BOOT TIME KERNEL
+PARAMETERS for the full set.
+
+**Named via /etc/crypttab.** Add an entry marked `x-initrd.attach`; the
+first column becomes the mapper name. Pair with `root=/dev/mapper/<name>`
+on the cmdline. See CRYPTTAB below for syntax and bundling rules.
+
+**Auto-named.** With no `rd.luks.*` on the cmdline and no crypttab entry
+covering this volume, point `root=` at the LUKS container itself:
+
+    root=UUID=<luks-partition-uuid>
+
+Booster unlocks it as `/dev/mapper/root` and mounts that. `PARTUUID=`,
+`LABEL=`, or a `/dev/...` path resolving to the container also work.
+
+**Zero kernel parameters.** Tag the partition with the per-architecture
+root GUID and booster discovers it with no `root=` argument at all. See
+GPT autodiscovery below.
+
+### GPT autodiscovery (no cmdline at all)
+
+Set the root partition's GPT type to "Linux root" for your CPU architecture
+using any GPT editor (gdisk, sgdisk, fdisk, cfdisk, parted, ...). On x86-64
+with gdisk, for instance, the type code is `8304`. Other tools and
+architectures use different shortcuts; consult your editor's type list.
+The full per-architecture GUID list is in the [Discoverable Partitions Specification](https://uapi-group.org/specifications/specs/discoverable_partitions_specification/).
+
+The same GUID covers both plain-filesystem and LUKS-encrypted roots —
+booster handles either. Booster scans only the disk that holds the
+active EFI System Partition; root-tagged partitions on other disks are
+ignored. Tag exactly one partition on that disk.
+
+### When boot stalls
+
+If `root=/dev/mapper/<name>` is set but no source above produces that
+mapper, booster prints
+
+    root=/dev/mapper/<name> but no LUKS unlock spec was found for "<name>"
+
+before stalling at the mount-timeout. Add any of the unlock recipes above
+and rebuild.
+
+## CRYPTTAB
+
+Booster supports unlocking LUKS volumes declared in `/etc/crypttab` (see
+[crypttab(5)](https://man7.org/linux/man-pages/man5/crypttab.5.html)).
+Only entries marked with the `x-initrd.attach` option are bundled into
+the initramfs at image build time. The generator must be able to read
+the file — run as root, or pass `--crypttab <path>` to a user-readable
+copy.
+
+When both a `rd.luks.*` cmdline parameter and a crypttab entry cover the
+same device, the cmdline takes precedence for the device reference and
+mapper name; the crypttab entry's security options (keyfile, header,
+tries, token-timeout, …) are merged in. Crypttab entries for devices not
+covered by `rd.luks.*` are appended as new mappings.
+
+Booster-specific behaviour for selected options:
+
+ * **keyfile** `/path:UUID=xxx` (or `LABEL=`, `PARTUUID=`, `PARTLABEL=`) — keyfile on a separate device. Booster mounts the device read-only at boot, reads the key, then unmounts. The file is not bundled into the initramfs.
+ * **`header=`** — if the path is a plain absolute path the generator bundles the file into the initramfs automatically. The `/path:deviceref` form mounts the device at boot; `/dev/...` uses the raw block device directly.
+ * **`fido2-device=`** — when this option appears in a crypttab entry, the generator automatically bundles `fido2plugin.so`; no `enable_fido2: true` in the config file is required. Both `fido2-device=` and `tpm2-device=` are otherwise accepted for compatibility; booster discovers enrolled tokens from the LUKS2 header, not from the crypttab option value.
+ * **`keyfile-timeout=`** / **`token-timeout=`** — accept a bare integer (seconds) or any duration string accepted by Go's `time.ParseDuration` (e.g. `30s`, `2m`).
 
 ## NOTES
 

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -8,8 +8,8 @@ Booster advantages:
 
  * Fast image build time and fast boot time.
  * Out-of-box support for LUKS-based full disk encryption setup.
- * Clevis style data binding. The encrypted filesystem can be bound to TPM2 chip or to a network service. This helps to unlock the drive automatically but only if the TPM2/network service presents.
- * Automatically detects and unlocks systemd-cryptenroll (fido2 and tpm2) type of partition encryption.
+ * Clevis style data binding. The encrypted filesystem can be bound to a TPM2 chip or to a network service. This helps to unlock the drive automatically but only if the TPM2/network service is present.
+ * Automatically detects and unlocks systemd-cryptenroll (fido2 and tpm2) types of partition encryption.
  * Easy to configure.
  * Automatic host configuration discovery. This helps to create minimalistic images specific for the current host.
 
@@ -54,17 +54,17 @@ Booster advantages:
 
  * `append_all_modaliases` is a boolean flag that instructs booster to add all hosts's module aliases to the booster image. This flag is useful for debugging boot timeout issues when some important modules are missed from the image. Setting the flag to `true` will help to print module names for aliases that were requested by kernel but missed in the image.
 
- * `compression` is a flag that specifies compression for the output initramfs file. Currently supported algorithms are "zstd", "gzip", "xz", "lz4", "none". If no option specified then "zstd" is used as a default compression.
+ * `compression` is a flag that specifies compression for the output initramfs file. Currently supported algorithms are "zstd", "gzip", "xz", "lz4", "none". If no option is specified, "zstd" is used as the default compression.
 
- * `mount_timeout` timeout for waiting for the root filesystem to appear. The field format is a decimal number and then unit number. Valid units are "s", "m", "h". If no value specified then default timeout (3 minutes) is used. To disable the timeout completely specify "0s".
+ * `mount_timeout` timeout for waiting for the root filesystem to appear. The field format is a decimal number and then unit number. Valid units are "s", "m", "h". If no value is specified, the default timeout (3 minutes) is used. To disable the timeout completely specify "0s".
 
- * `strip` is a boolean flag that enables ELF files stripping before adding it to the image. Binaries, shared libraries and kernel modules are examples of ELF files that get processed with strip UNIX tool.
+ * `strip` is a boolean flag that enables stripping of ELF files before adding them to the image. Binaries, shared libraries and kernel modules are examples of ELF files that get processed with the strip UNIX tool.
 
-   This options is not compatible with signed modules. If you see `booster: finit(crc32,generic): key was rejected by service` boot error please set the `strip` config option to `false`.
+   This option is not compatible with signed modules. If you see `booster: finit(crc32,generic): key was rejected by service` boot error please set the `strip` config option to `false`.
 
  * `extra_files` is a comma-separated list of extra files to add to the image. If an item starts with slash ("/") then it is considered an absolute path. Otherwise it is a path relative to /usr/bin. If the item is a directory then its content is added recursively. There are a few special cases:
     * adding `busybox` to the image enables an emergency shell in case of a panic during the boot process.
-    * adding `fsck` enables boot time filesystem check. It also requires filesystem specific binary called `fsck.$rootfstype` to be added to the image. Filesystems are corrected automatically and if it fails then boot stops and it is responsibility of the user to fix the root filesystem.
+    * adding `fsck` enables boot time filesystem check. It also requires filesystem specific binary called `fsck.$rootfstype` to be added to the image. Filesystems are corrected automatically and if it fails then boot stops and it is the responsibility of the user to fix the root filesystem.
 
  * `vconsole` is a flag that enables early-user console configuration. If it is set to `true` then booster reads configuration from `/etc/vconsole.conf` and `/etc/locale.conf` and adds required keymap and fonts to the generated image.
     The following config properties are taken into account: `KEYMAP`, `KEYMAP_TOGGLE`, `FONT`, `FONT_MAP`, `FONT_UNIMAP`. See also [man vconsole.conf](https://man.archlinux.org/man/vconsole.conf.5.en).
@@ -176,7 +176,7 @@ Device reference has one of the following values:
 
 ### UUID parameters
 Boot parameters such as `root=UUID=$UUID` and `rd.luks.uuid=$UUID` allow you to specify the block device by its UUID.
-The UUID format is `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` where `x` is a hexadecimal symbol either in lower of upper case.
+The UUID format is `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` where `x` is a hexadecimal symbol either in lower or upper case.
 UUID parameter can optionally be enclosed with quote symbol `"` though it is not recommended. Following examples show correct parameters format:
 `root=UUID=ac8299a8-91ce-4bf6-a524-55a62844b787`, `root=UUID="ac8299a8-91ce-4bf6-a524-55a62844b787"` (not recommended),
 `rd.luks.uuid=ac8299a8-91ce-4bf6-a524-55a62844b787`, `rd.luks.uuid="ac8299a8-91ce-4bf6-a524-55a62844b787"` (not recommended).
@@ -194,7 +194,7 @@ PIN prompts (TPM2-PIN, FIDO2-PIN) accept up to 3 attempts; press Enter empty PIN
 ### Modules selection
 It is a note to summarize the algorithm that computes what modules are going to end up in the generated booster image.
 Initial module list for booster is `defaultModulesList` - a set of predefined hard-coded modules defined at `generator.go`.
-These are selected modules  that most likely cover most system boot needs - disk, filesystem, keyboard, tpm, ethernet, usb drivers.
+These are selected modules that most likely cover most system boot needs - disk, filesystem, keyboard, tpm, ethernet, usb drivers.
 
 If the `universal` config option is set to false (default value) then so-called host mode is used.
 I.e. image is generated with the drivers needed for current host hardware only.
@@ -235,7 +235,7 @@ Please note that to boot the UKI by default, it may be necessary to configure yo
 ## DEBUGGING
 If you have a problem with booster boot tool you can enable debug mode to get more
 information about what is going on. Just add `booster.log=debug,console` kernel parameter and booster
-provide additional logs.
+provides additional logs.
 
 ### Use TFTP to download logs for unbootable device
 In case of a boot failure, when the devices are missing, logs can still be retrieved from busybox using the network.
@@ -277,7 +277,7 @@ Users of the Btrfs filesystem with a system installed on a subvolume should add 
 
     UUID=69bc4dd2-7f6c-4821-aa6b-d80d9c97d470	/         	btrfs     	rw,relatime,autodefrag,compress=zstd:2,space_cache,subvol=root	0 0
 
-So /boot/loader/entries/booster.conf should looks like this:
+So /boot/loader/entries/booster.conf should look like this:
 
     title Linux with Booster
     linux /vmlinuz-linux

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -77,7 +77,7 @@ Booster advantages:
 
  * `crypttab_path` path to the crypttab file to read at image build time. Defaults to `/etc/crypttab` if not set. Can be overridden by the `--crypttab` flag. If set, any read error is reported as a failure.
 
- * `enable_plymouth` is a flag that enables Plymouth boot splash support. When enabled, booster bundles the Plymouth daemon, plugins, theme, and fonts into the initramfs. GPU driver must be included in `modules_force_load`. The `splash` kernel parameter is also required. Note that `booster.log=console` conflicts with Plymouth's graphical display; when console logging is active, Plymouth reverts to the details plugin (text-based fallback).
+ * `enable_plymouth` is a flag that enables Plymouth boot splash support. When enabled, booster bundles the Plymouth daemon, plugins, theme, and fonts into the initramfs. GPU driver must be included in `modules_force_load`. The `quiet splash` kernel parameters are also required. Note that `booster.log=console` conflicts with Plymouth's graphical display; when console logging is active, Plymouth reverts to the details plugin (text-based fallback).
 
  * `enable_fido2` is a boolean flag that enables FIDO2 hardware token support.
 

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -350,6 +350,21 @@ Here is a `systemd-boot` configuration stored at /boot/loader/entries/booster.co
     initrd /booster-linux.img
     options rd.luks.uuid=e122d09e-87a9-4b35-83f7-2592ef40cefa root=UUID=08684949-bcbb-47bb-1c17-089aaa59e17e rw
 
+For hardware-token unlock with a FIDO2 device, enroll the LUKS slot once with `systemd-cryptenroll`:
+
+    $ systemd-cryptenroll --fido2-device=auto /dev/sda2
+
+Then add a `/etc/crypttab` entry. Booster takes the mapper name from the first column; the generator auto-bundles `fido2plugin.so` whenever it sees `fido2-device=`. `token-timeout=` sets how long booster waits for the FIDO2 touch before also opening the keyboard passphrase prompt (default 30s; `0` waits forever):
+
+    cryptroot  UUID=e122d09e-87a9-4b35-83f7-2592ef40cefa  none  fido2-device=auto,token-timeout=60s,x-initrd.attach
+
+The bootloader entry points `root=` at the future mapper node:
+
+    title Linux with Booster
+    linux /vmlinuz-linux
+    initrd /booster-linux.img
+    options root=/dev/mapper/cryptroot rw
+
 Users of the Btrfs filesystem with a system installed on a subvolume should add rootflags corresponding to their entry in /etc/fstab. In this example 69bc4dd2-7f6c-4821-aa6b-d80d9c97d470 is a UUID for Btrfs partition, with the system installed on subvolume called root and /etc/fstab looks like this:
 
     UUID=69bc4dd2-7f6c-4821-aa6b-d80d9c97d470	/         	btrfs     	rw,relatime,autodefrag,compress=zstd:2,space_cache,subvol=root	0 0

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -361,6 +361,8 @@ So /boot/loader/entries/booster.conf should look like this:
     initrd /booster-linux.img
     options root=UUID=69bc4dd2-7f6c-4821-aa6b-d80d9c97d470 rw rootflags=relatime,autodefrag,compress=zstd:2,space_cache,subvol=root
 
+Booster has no built-in Btrfs subvolume default. If `subvol=` (or `subvolid=`) is omitted, the kernel mounts the filesystem's configured default subvolume — set with `btrfs subvolume set-default <id> <path>` — falling back to the top-level subvolume (ID 5) when no default has been configured. Distro conventions like `@` (Arch), `root` (some Debian-derived installers), or `@/.snapshots/N/snapshot` (openSUSE) must be set explicitly in your bootloader entry; both `subvol=NAME` and `subvolid=ID` are accepted.
+
 Create a Unified Kernel Image and write the result to /boot/EFI/Linux:
 
     $ /usr/lib/booster/regenerate_uki build /boot/EFI/Linux


### PR DESCRIPTION
Several independent manpage improvements; each commit stands alone, so feel free to cherry-pick or drop any of them.

- **Typo sweep** in pre-existing sections (config file, UUID notes, DEBUGGING, btrfs example).
- **`enable_plymouth`** line: `splash` → `quiet splash` (both are needed in practice).
- **Dedicated `ROOT PARTITION DISCOVERY` and `CRYPTTAB` sections** pulled out of `BOOT TIME KERNEL PARAMETERS`. Covers the four LUKS-root recipes (rd.luks.name=, crypttab, auto-named /dev/mapper/root, GPT autodiscovery) in one place, plus a "when boot stalls" pointer matching the unreachable-mapper warning from `init/main.go`.
- **New NOTES subsection on LUKS unlock concurrency** documenting the model from #350/#353/#355/#356/#357/#358/#362: PIN-token serialization, cancel-on-win semantics, the 3-attempt PIN cap, and the MR !393 caveat for older Plymouth builds.
- **Btrfs subvolume default clarified**: booster has no built-in default; the kernel picks whatever `btrfs subvolume set-default` set, falling back to top-level ID 5.
- **Two new EXAMPLES**: FIDO2 token unlock, and zero-kernel-parameters GPT autodiscovery boot.

Pure docs; no code changes.