### PR TITLE
LUKS token unlock: avoid the spurious PIN prompt when a non-interactive token can unlock

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -81,6 +81,8 @@ Booster advantages:
 
  * `enable_fido2` is a boolean flag that enables FIDO2 hardware token support.
 
+ * `serialize_tokens` is a scoped block; set `serialize_tokens.enabled: true` (default off) to make booster try a device's LUKS tokens strictly one at a time, in ascending token-ID order, instead of racing them concurrently. Because each token is attempted to completion before the next begins, a non-interactive token (TPM2 PCR-only, touchless FIDO2, clevis) enrolled ahead of a PIN-bearing one unlocks the device before the PIN token is reached, so no PIN prompt is drawn — behaviour closer to `systemd-cryptsetup`. The trade-off is that a slow token, such as clevis waiting on the network, delays the next token instead of running alongside it. The keyboard passphrase fallback still runs last.
+
 Once you are done modifying your config file and want to regenerate booster images under `/boot` please use `/usr/lib/booster/regenerate_images`.
 It is a convenience script that performs the same type of image regeneration as if you installed `booster` with your package manager.
 

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -32,6 +32,10 @@ Booster advantages:
     vconsole: true
     enable_lvm: true
     enable_mdraid: true
+    token_timeout: 30s
+    serialize_tokens:
+      enabled: true
+      clevis_timeout: 45s
 
  * `network` node, if present, initializes the network at the boot time. It is needed if mounting a root fs requires access to the network (e.g. in case of Tang binding).
     The network can be either configured dynamically with DHCPv4 or statically within this config. In the former case `dhcp` is set to `on`.
@@ -81,7 +85,12 @@ Booster advantages:
 
  * `enable_fido2` is a boolean flag that enables FIDO2 hardware token support.
 
- * `serialize_tokens` is a scoped block; set `serialize_tokens.enabled: true` (default off) to make booster try a device's LUKS tokens strictly one at a time, in ascending token-ID order, instead of racing them concurrently. Because each token is attempted to completion before the next begins, a non-interactive token (TPM2 PCR-only, touchless FIDO2, clevis) enrolled ahead of a PIN-bearing one unlocks the device before the PIN token is reached, so no PIN prompt is drawn — behaviour closer to `systemd-cryptsetup`. The trade-off is that a slow token, such as clevis waiting on the network, delays the next token instead of running alongside it. The keyboard passphrase fallback still runs last.
+ * `serialize_tokens` is a scoped block that makes booster try a device's LUKS tokens strictly one at a time, in ascending token-ID order, instead of racing them concurrently. Set `serialize_tokens.enabled: true` to turn it on (default off). Because each token is attempted to completion before the next begins, a non-interactive token (TPM2 PCR-only, touchless FIDO2, clevis) enrolled ahead of a PIN-bearing one unlocks the device before the PIN token is reached, so no PIN prompt is drawn — behaviour closer to `systemd-cryptsetup`. So that one stuck token cannot hang the boot or starve the tokens behind it, each non-interactive token is bounded by a per-type timeout (the keys below); when it expires booster abandons that token and moves to the next. PIN-bearing tokens are not auto-bounded — the user already has the empty-Enter skip. The keyboard passphrase fallback still runs last. The block accepts:
+
+    * `serialize_tokens.enabled` — boolean (default `false`); the opt-out switch itself.
+    * `serialize_tokens.clevis_timeout` / `serialize_tokens.tpm2_timeout` / `serialize_tokens.fido2_timeout` — per-token bounds for clevis, non-PIN `systemd-tpm2` (PCR-only), and non-PIN `systemd-fido2` (touchless) tokens. Each accepts a Go duration string (e.g. `45s`, `2m`). Defaults `45s`, `15s`, `30s` — clevis is generous because it may wait for network/DHCP, TPM2 PCR-only is fast, FIDO2 mostly caps the wait for an absent security key. No effect unless `serialize_tokens.enabled` is set.
+
+ * `token_timeout` is a top-level option (it applies in both concurrent and serialize modes) that sets the device-level timer for how long booster waits for tokens before *also* starting the keyboard passphrase prompt. It is the booster-config equivalent of the standard crypttab/`rd.luks.options` `token-timeout=` option and serves as a global default; an explicit per-device `token-timeout=` in crypttab or on the kernel command line overrides it. Accepts a Go duration string (e.g. `30s`). When unset everywhere: in serialize mode it defaults to the sum of the device's per-token timeouts (so the keyboard prompt never preempts a token that has not had its turn); otherwise it defaults to 30 s as before.
 
 Once you are done modifying your config file and want to regenerate booster images under `/boot` please use `/usr/lib/booster/regenerate_images`.
 It is a convenience script that performs the same type of image regeneration as if you installed `booster` with your package manager.

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -33,6 +33,7 @@ Booster advantages:
     enable_lvm: true
     enable_mdraid: true
     token_timeout: 30s
+    pin_delay: 5s
     serialize_tokens:
       enabled: true
       clevis_timeout: 45s
@@ -85,12 +86,21 @@ Booster advantages:
 
  * `enable_fido2` is a boolean flag that enables FIDO2 hardware token support.
 
- * `serialize_tokens` is a scoped block that makes booster try a device's LUKS tokens strictly one at a time, in ascending token-ID order, instead of racing them concurrently. Set `serialize_tokens.enabled: true` to turn it on (default off). Because each token is attempted to completion before the next begins, a non-interactive token (TPM2 PCR-only, touchless FIDO2, clevis) enrolled ahead of a PIN-bearing one unlocks the device before the PIN token is reached, so no PIN prompt is drawn — behaviour closer to `systemd-cryptsetup`. So that one stuck token cannot hang the boot or starve the tokens behind it, each non-interactive token is bounded by a per-type timeout (the keys below); when it expires booster abandons that token and moves to the next. PIN-bearing tokens are not auto-bounded — the user already has the empty-Enter skip. The keyboard passphrase fallback still runs last. The block accepts:
+ * `serialize_tokens` makes booster try a device's LUKS tokens one at a time in ascending token-ID order instead of racing them concurrently (default off). A non-interactive token (TPM2 PCR-only, touchless FIDO2, clevis) enrolled before a PIN token then unlocks the device before the PIN prompt is reached. Each non-interactive token is bounded by a per-type timeout so a stuck one cannot hang the boot; on expiry booster moves to the next. PIN tokens are not bounded (empty-Enter already skips them). Keys:
 
-    * `serialize_tokens.enabled` — boolean (default `false`); the opt-out switch itself.
-    * `serialize_tokens.clevis_timeout` / `serialize_tokens.tpm2_timeout` / `serialize_tokens.fido2_timeout` — per-token bounds for clevis, non-PIN `systemd-tpm2` (PCR-only), and non-PIN `systemd-fido2` (touchless) tokens. Each accepts a Go duration string (e.g. `45s`, `2m`). Defaults `45s`, `15s`, `30s` — clevis is generous because it may wait for network/DHCP, TPM2 PCR-only is fast, FIDO2 mostly caps the wait for an absent security key. No effect unless `serialize_tokens.enabled` is set.
+    * `serialize_tokens.enabled` — boolean, default `false`.
+    * `serialize_tokens.clevis_timeout` / `serialize_tokens.tpm2_timeout` / `serialize_tokens.fido2_timeout` — per-token bounds for clevis, non-PIN `systemd-tpm2`, and non-PIN `systemd-fido2`. Go duration. Defaults `45s` / `15s` / `30s`. No effect unless `serialize_tokens.enabled` is set.
 
- * `token_timeout` is a top-level option (it applies in both concurrent and serialize modes) that sets the device-level timer for how long booster waits for tokens before *also* starting the keyboard passphrase prompt. It is the booster-config equivalent of the standard crypttab/`rd.luks.options` `token-timeout=` option and serves as a global default; an explicit per-device `token-timeout=` in crypttab or on the kernel command line overrides it. Accepts a Go duration string (e.g. `30s`). When unset everywhere: in serialize mode it defaults to the sum of the device's per-token timeouts (so the keyboard prompt never preempts a token that has not had its turn); otherwise it defaults to 30 s as before.
+ * `token_timeout` (top-level, applies in both modes) bounds how long booster waits for tokens before it *also* starts the keyboard passphrase prompt. The tokens keep racing after the prompt appears; whichever path wins first dismisses the other (see **LUKS unlock concurrency and prompt order** in NOTES). It is the booster-config equivalent of the crypttab/`rd.luks.options` `token-timeout=` (see `rd.luks.options` under **BOOT TIME KERNEL PARAMETERS**). Go duration. Precedence, highest first:
+
+    1. an explicit per-device `token-timeout=` — on the kernel cmdline (`rd.luks.options`) or in crypttab; the cmdline value wins when both set it for the same device.
+    2. this `token_timeout`.
+    3. in serialize mode, the sum of the device's per-token timeouts (so the keyboard prompt never preempts a token that has not had its turn).
+    4. the `30s` default.
+
+    In serialize mode prefer leaving `token_timeout` unset so tier 3 applies: a fixed value shorter than the token chain can start the keyboard prompt before a token has had its turn.
+
+ * `pin_delay` is the concurrent-mode counterpart to `serialize_tokens`: it holds the first interactive PIN prompt (TPM2-PIN, FIDO2-PIN) this long so a parallel non-interactive token can unlock first and the prompt is never drawn — cancelled before render if a token wins, shown as normal if the delay expires (no unlock path is lost; the delay only postpones the prompt). Go duration; unset (the default) means no delay. No effect in serialize mode, or when no parallel non-PIN token is enrolled (a PIN-only device prompts immediately). Set it longer than the racing token's real unlock time — TPM2/FIDO2 hardware bring-up, or for clevis the network/DHCP round-trip — but well below `token_timeout`; otherwise the prompt is still drawn. A few seconds suits a fast PCR-only TPM2 unseal; clevis-over-network or a universal image with slow module loading needs more.
 
 Once you are done modifying your config file and want to regenerate booster images under `/boot` please use `/usr/lib/booster/regenerate_images`.
 It is a convenience script that performs the same type of image regeneration as if you installed `booster` with your package manager.
@@ -230,8 +240,9 @@ copy.
 
 When both a `rd.luks.*` cmdline parameter and a crypttab entry cover the
 same device, the cmdline takes precedence for the device reference and
-mapper name; the crypttab entry's security options (keyfile, header,
-tries, token-timeout, …) are merged in. Crypttab entries for devices not
+mapper name, and for any security option (keyfile, header, tries,
+token-timeout, …) it sets explicitly; the crypttab entry supplies only
+the options the cmdline left unset. Crypttab entries for devices not
 covered by `rd.luks.*` are appended as new mappings.
 
 Booster-specific behaviour for selected options:

--- a/generator/config.go
+++ b/generator/config.go
@@ -42,6 +42,13 @@ type UserConfig struct {
 	EnablePlymouth       bool   `yaml:"enable_plymouth"`
 	CrypttabPath         string `yaml:"crypttab_path,omitempty"` // path to crypttab file, defaults to /etc/crypttab
 	EnableFido2          bool   `yaml:"enable_fido2"`
+
+	// SerializeTokens opts out of booster's token concurrency: tokens are
+	// tried one at a time in ID order. A scoped block (like network:) so the
+	// per-token timeouts can hang off it.
+	SerializeTokens *struct {
+		Enabled bool `yaml:",omitempty"` // process LUKS tokens one at a time instead of concurrently
+	} `yaml:"serialize_tokens,omitempty"`
 }
 
 func parseCommaList(raw string) []string {
@@ -170,6 +177,9 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 		conf.crypttabFile = u.CrypttabPath
 	}
 	conf.enableFido2 = u.EnableFido2
+	if st := u.SerializeTokens; st != nil {
+		conf.serializeTokens = st.Enabled
+	}
 
 	return &conf, nil
 }

--- a/generator/config.go
+++ b/generator/config.go
@@ -42,12 +42,16 @@ type UserConfig struct {
 	EnablePlymouth       bool   `yaml:"enable_plymouth"`
 	CrypttabPath         string `yaml:"crypttab_path,omitempty"` // path to crypttab file, defaults to /etc/crypttab
 	EnableFido2          bool   `yaml:"enable_fido2"`
+	TokenTimeout         string `yaml:"token_timeout,omitempty"` // device-level keyboard-fallback timer (e.g. 30s); applies in both modes; global default, overridable by crypttab/cmdline
 
 	// SerializeTokens opts out of booster's token concurrency: tokens are
-	// tried one at a time in ID order. A scoped block (like network:) so the
-	// per-token timeouts can hang off it.
+	// tried one at a time in ID order. The per-type timeouts are scoped here
+	// because they only take effect in serialize mode.
 	SerializeTokens *struct {
-		Enabled bool `yaml:",omitempty"` // process LUKS tokens one at a time instead of concurrently
+		Enabled       bool   `yaml:",omitempty"`               // process LUKS tokens one at a time instead of concurrently
+		ClevisTimeout string `yaml:"clevis_timeout,omitempty"` // per-token bound for clevis (e.g. 45s); default 45s
+		Tpm2Timeout   string `yaml:"tpm2_timeout,omitempty"`   // per-token bound for non-PIN systemd-tpm2 (e.g. 15s); default 15s
+		Fido2Timeout  string `yaml:"fido2_timeout,omitempty"`  // per-token bound for non-PIN systemd-fido2 (e.g. 30s); default 30s
 	} `yaml:"serialize_tokens,omitempty"`
 }
 
@@ -177,8 +181,32 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 		conf.crypttabFile = u.CrypttabPath
 	}
 	conf.enableFido2 = u.EnableFido2
+	var clevisT, tpm2T, fido2T string
 	if st := u.SerializeTokens; st != nil {
 		conf.serializeTokens = st.Enabled
+		clevisT, tpm2T, fido2T = st.ClevisTimeout, st.Tpm2Timeout, st.Fido2Timeout
+	}
+	for _, f := range []struct {
+		name string
+		val  string
+		dst  *int
+	}{
+		{"token_timeout", u.TokenTimeout, &conf.tokenTimeout},
+		{"serialize_tokens.clevis_timeout", clevisT, &conf.clevisTimeout},
+		{"serialize_tokens.tpm2_timeout", tpm2T, &conf.tpm2Timeout},
+		{"serialize_tokens.fido2_timeout", fido2T, &conf.fido2Timeout},
+	} {
+		if f.val == "" {
+			continue
+		}
+		d, err := time.ParseDuration(f.val)
+		if err != nil {
+			return nil, fmt.Errorf("config: unable to parse %s value %q: %v", f.name, f.val, err)
+		}
+		if d <= 0 {
+			return nil, fmt.Errorf("config: %s must be positive, got %q", f.name, f.val)
+		}
+		*f.dst = int(d.Seconds())
 	}
 
 	return &conf, nil

--- a/generator/config.go
+++ b/generator/config.go
@@ -43,6 +43,7 @@ type UserConfig struct {
 	CrypttabPath         string `yaml:"crypttab_path,omitempty"` // path to crypttab file, defaults to /etc/crypttab
 	EnableFido2          bool   `yaml:"enable_fido2"`
 	TokenTimeout         string `yaml:"token_timeout,omitempty"` // device-level keyboard-fallback timer (e.g. 30s); applies in both modes; global default, overridable by crypttab/cmdline
+	PinDelay             string `yaml:"pin_delay,omitempty"`     // concurrent-mode only: hold an interactive PIN prompt (TPM2-PIN/FIDO2-PIN) this long (e.g. 3s) so a parallel non-interactive token can win first; default unset (off)
 
 	// SerializeTokens opts out of booster's token concurrency: tokens are
 	// tried one at a time in ID order. The per-type timeouts are scoped here
@@ -192,6 +193,7 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 		dst  *int
 	}{
 		{"token_timeout", u.TokenTimeout, &conf.tokenTimeout},
+		{"pin_delay", u.PinDelay, &conf.pinDelay},
 		{"serialize_tokens.clevis_timeout", clevisT, &conf.clevisTimeout},
 		{"serialize_tokens.tpm2_timeout", tpm2T, &conf.tpm2Timeout},
 		{"serialize_tokens.fido2_timeout", fido2T, &conf.fido2Timeout},
@@ -205,6 +207,11 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 		}
 		if d <= 0 {
 			return nil, fmt.Errorf("config: %s must be positive, got %q", f.name, f.val)
+		}
+		// Stored as whole seconds (0 means "unset" downstream), so a positive
+		// sub-second value would silently truncate to 0 and disable the option.
+		if d < time.Second {
+			return nil, fmt.Errorf("config: %s must be at least 1s, got %q", f.name, f.val)
 		}
 		*f.dst = int(d.Seconds())
 	}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -55,6 +55,7 @@ type generatorConfig struct {
 
 	serializeTokens bool // dispatch LUKS tokens serially instead of concurrently; default false
 	tokenTimeout    int  // device-level keyboard-fallback timer (seconds); 0 = unset
+	pinDelay        int  // concurrent-mode PIN-prompt pre-delay (seconds); 0 = off
 	clevisTimeout   int  // serialize-mode per-token bound for clevis (seconds); 0 = default
 	tpm2Timeout     int  // serialize-mode per-token bound for non-PIN systemd-tpm2 (seconds); 0 = default
 	fido2Timeout    int  // serialize-mode per-token bound for non-PIN systemd-fido2 (seconds); 0 = default
@@ -505,6 +506,7 @@ func (img *Image) appendInitConfig(conf *generatorConfig, kmod *Kmod, vconsole *
 	initConfig.EnablePlymouth = conf.enablePlymouth
 	initConfig.SerializeTokens = conf.serializeTokens
 	initConfig.TokenTimeout = conf.tokenTimeout
+	initConfig.PinDelay = conf.pinDelay
 	initConfig.ClevisTimeout = conf.clevisTimeout
 	initConfig.Tpm2Timeout = conf.tpm2Timeout
 	initConfig.Fido2Timeout = conf.fido2Timeout

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -52,6 +52,8 @@ type generatorConfig struct {
 
 	crypttabFile string // path to host crypttab; empty = use /etc/crypttab
 	enableFido2  bool
+
+	serializeTokens bool // dispatch LUKS tokens serially instead of concurrently; default false
 }
 
 type networkStaticConfig struct {
@@ -497,6 +499,7 @@ func (img *Image) appendInitConfig(conf *generatorConfig, kmod *Kmod, vconsole *
 	initConfig.EnableZfs = conf.enableZfs
 	initConfig.ZfsImportParams = conf.zfsImportParams
 	initConfig.EnablePlymouth = conf.enablePlymouth
+	initConfig.SerializeTokens = conf.serializeTokens
 
 	if conf.networkConfigType == netDhcp {
 		initConfig.Network = &InitNetworkConfig{}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -54,6 +54,10 @@ type generatorConfig struct {
 	enableFido2  bool
 
 	serializeTokens bool // dispatch LUKS tokens serially instead of concurrently; default false
+	tokenTimeout    int  // device-level keyboard-fallback timer (seconds); 0 = unset
+	clevisTimeout   int  // serialize-mode per-token bound for clevis (seconds); 0 = default
+	tpm2Timeout     int  // serialize-mode per-token bound for non-PIN systemd-tpm2 (seconds); 0 = default
+	fido2Timeout    int  // serialize-mode per-token bound for non-PIN systemd-fido2 (seconds); 0 = default
 }
 
 type networkStaticConfig struct {
@@ -500,6 +504,10 @@ func (img *Image) appendInitConfig(conf *generatorConfig, kmod *Kmod, vconsole *
 	initConfig.ZfsImportParams = conf.zfsImportParams
 	initConfig.EnablePlymouth = conf.enablePlymouth
 	initConfig.SerializeTokens = conf.serializeTokens
+	initConfig.TokenTimeout = conf.tokenTimeout
+	initConfig.ClevisTimeout = conf.clevisTimeout
+	initConfig.Tpm2Timeout = conf.tpm2Timeout
+	initConfig.Fido2Timeout = conf.fido2Timeout
 
 	if conf.networkConfigType == netDhcp {
 		initConfig.Network = &InitNetworkConfig{}

--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -359,6 +359,7 @@ func parseParams(params string) error {
 		}
 		if tokenTimeoutExplicit {
 			luksMappings[i].tokenTimeout = tokenTimeout
+			luksMappings[i].tokenTimeoutExplicit = true
 		}
 	}
 

--- a/init/config.go
+++ b/init/config.go
@@ -36,6 +36,10 @@ type InitConfig struct {
 	ZfsImportParams        string              `yaml:",omitempty"` // TODO: remove it
 	EnablePlymouth         bool                `yaml:",omitempty"`
 	SerializeTokens        bool                `yaml:",omitempty"` // dispatch LUKS tokens serially instead of concurrently; default false
+	TokenTimeout           int                 `yaml:",omitempty"` // device-level keyboard-fallback timer in seconds; 0 = unset (crypttab/cmdline or derived default applies)
+	ClevisTimeout          int                 `yaml:",omitempty"` // serialize-mode per-token bound for clevis tokens in seconds; 0 = default 45
+	Tpm2Timeout            int                 `yaml:",omitempty"` // serialize-mode per-token bound for non-PIN systemd-tpm2 tokens in seconds; 0 = default 15
+	Fido2Timeout           int                 `yaml:",omitempty"` // serialize-mode per-token bound for non-PIN systemd-fido2 tokens in seconds; 0 = default 30
 }
 
 const initConfigPath = "/etc/booster.init.yaml"

--- a/init/config.go
+++ b/init/config.go
@@ -35,6 +35,7 @@ type InitConfig struct {
 	EnableZfs              bool                `yaml:",omitempty"`
 	ZfsImportParams        string              `yaml:",omitempty"` // TODO: remove it
 	EnablePlymouth         bool                `yaml:",omitempty"`
+	SerializeTokens        bool                `yaml:",omitempty"` // dispatch LUKS tokens serially instead of concurrently; default false
 }
 
 const initConfigPath = "/etc/booster.init.yaml"

--- a/init/config.go
+++ b/init/config.go
@@ -37,6 +37,7 @@ type InitConfig struct {
 	EnablePlymouth         bool                `yaml:",omitempty"`
 	SerializeTokens        bool                `yaml:",omitempty"` // dispatch LUKS tokens serially instead of concurrently; default false
 	TokenTimeout           int                 `yaml:",omitempty"` // device-level keyboard-fallback timer in seconds; 0 = unset (crypttab/cmdline or derived default applies)
+	PinDelay               int                 `yaml:",omitempty"` // concurrent-mode PIN-prompt pre-delay in seconds so a parallel non-interactive token can win first; 0 = off
 	ClevisTimeout          int                 `yaml:",omitempty"` // serialize-mode per-token bound for clevis tokens in seconds; 0 = default 45
 	Tpm2Timeout            int                 `yaml:",omitempty"` // serialize-mode per-token bound for non-PIN systemd-tpm2 tokens in seconds; 0 = default 15
 	Fido2Timeout           int                 `yaml:",omitempty"` // serialize-mode per-token bound for non-PIN systemd-fido2 tokens in seconds; 0 = default 30

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -143,6 +143,7 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 						return nil, fmt.Errorf("crypttab: entry %q: invalid token-timeout= value %q", name, opt[14:])
 					}
 					m.tokenTimeout = d
+					m.tokenTimeoutExplicit = true
 					tokenTimeoutExplicit = true
 				default:
 					debug("crypttab: entry %q: unknown option %q, ignoring", name, opt)
@@ -194,6 +195,7 @@ func mergeCrypttabOptions(dst, src *luksMapping) {
 	// default (30 s) and the crypttab entry carries an explicit value.
 	if src.tokenTimeout > 0 && src.tokenTimeout != dst.tokenTimeout {
 		dst.tokenTimeout = src.tokenTimeout
+		dst.tokenTimeoutExplicit = dst.tokenTimeoutExplicit || src.tokenTimeoutExplicit
 	}
 	if dst.keyfile == "" && src.keyfile != "" {
 		dst.keyfile = src.keyfile

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -191,11 +191,15 @@ func findLuksMapping(ref *deviceRef) *luksMapping {
 // into a cmdline-derived mapping (dst). dst's ref and name are preserved; crypttab
 // supplies keyfile, header, and other unlock options that rd.luks.* params cannot express.
 func mergeCrypttabOptions(dst, src *luksMapping) {
-	// Adopt crypttab's token timeout when the cmdline mapping still has the
-	// default (30 s) and the crypttab entry carries an explicit value.
-	if src.tokenTimeout > 0 && src.tokenTimeout != dst.tokenTimeout {
+	// Adopt crypttab's token-timeout only when the cmdline mapping did not
+	// carry an explicit token-timeout= of its own. Mirrors the keyfile/
+	// header/tries merges below: an explicit cmdline value always wins;
+	// crypttab fills in only what the cmdline left unset. (src.tokenTimeout
+	// is always >0 here — the crypttab parser fills a 30 s implicit default
+	// — so the gate must be the explicit flags, not the values.)
+	if !dst.tokenTimeoutExplicit && src.tokenTimeoutExplicit {
 		dst.tokenTimeout = src.tokenTimeout
-		dst.tokenTimeoutExplicit = dst.tokenTimeoutExplicit || src.tokenTimeoutExplicit
+		dst.tokenTimeoutExplicit = true
 	}
 	if dst.keyfile == "" && src.keyfile != "" {
 		dst.keyfile = src.keyfile

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -302,13 +302,14 @@ func TestFindLuksMapping(t *testing.T) {
 func TestMergeCrypttabOptions(t *testing.T) {
 	dst := &luksMapping{name: "cmdline-name", keySlot: -1, tokenTimeout: 30 * time.Second}
 	src := &luksMapping{
-		tries:        3,
-		tokenTimeout: 45 * time.Second,
+		tries:                3,
+		tokenTimeout:         45 * time.Second,
+		tokenTimeoutExplicit: true, // as parseCrypttabReader sets it for an explicit token-timeout=
 	}
 	mergeCrypttabOptions(dst, src)
 	require.Equal(t, 3, dst.tries)
-	require.Equal(t, 45*time.Second, dst.tokenTimeout)
-	require.Equal(t, "cmdline-name", dst.name) // name must not be overwritten
+	require.Equal(t, 45*time.Second, dst.tokenTimeout) // cmdline mapping was not explicit → crypttab's explicit value adopted
+	require.Equal(t, "cmdline-name", dst.name)         // name must not be overwritten
 }
 
 func TestMergeCrypttabOptionsDstWins(t *testing.T) {
@@ -319,6 +320,38 @@ func TestMergeCrypttabOptionsDstWins(t *testing.T) {
 	require.Equal(t, 2, dst.keySlot)              // cmdline key-slot wins
 	require.Equal(t, 5, dst.tries)                // cmdline tries wins
 	require.Equal(t, "/cmdline/hdr", dst.header)  // cmdline header wins
+}
+
+// An explicit token-timeout= on the kernel cmdline must outrank a crypttab
+// entry for the same device — both when crypttab omits token-timeout (its
+// parser still fills the 30s implicit default) and when crypttab sets a
+// different explicit value. This mirrors the keyfile/header/tries merges:
+// an explicit cmdline value always wins; crypttab fills only what the
+// cmdline left unset. Regression for the pre-existing `src != dst` merge
+// that let crypttab's implicit 30s clobber an explicit cmdline value.
+func TestMergeCrypttabOptionsExplicitCmdlineTokenTimeoutWins(t *testing.T) {
+	t.Run("crypttab omits token-timeout (implicit 30s) → cmdline 10s survives", func(t *testing.T) {
+		dst := &luksMapping{tokenTimeout: 10 * time.Second, tokenTimeoutExplicit: true}
+		src := &luksMapping{tokenTimeout: 30 * time.Second} // crypttab parser's implicit default; not explicit
+		mergeCrypttabOptions(dst, src)
+		require.Equal(t, 10*time.Second, dst.tokenTimeout)
+		require.True(t, dst.tokenTimeoutExplicit)
+	})
+
+	t.Run("crypttab sets a different explicit value → cmdline still wins", func(t *testing.T) {
+		dst := &luksMapping{tokenTimeout: 10 * time.Second, tokenTimeoutExplicit: true}
+		src := &luksMapping{tokenTimeout: 60 * time.Second, tokenTimeoutExplicit: true}
+		mergeCrypttabOptions(dst, src)
+		require.Equal(t, 10*time.Second, dst.tokenTimeout, "explicit cmdline token-timeout outranks explicit crypttab")
+	})
+
+	t.Run("cmdline not explicit → explicit crypttab is adopted", func(t *testing.T) {
+		dst := &luksMapping{tokenTimeout: 30 * time.Second} // findOrCreateLuksMapping default, not explicit
+		src := &luksMapping{tokenTimeout: 60 * time.Second, tokenTimeoutExplicit: true}
+		mergeCrypttabOptions(dst, src)
+		require.Equal(t, 60*time.Second, dst.tokenTimeout)
+		require.True(t, dst.tokenTimeoutExplicit)
+	})
 }
 
 // rd.luks.name= on the kernel cmdline creates a mapping before crypttab is parsed.

--- a/init/luks.go
+++ b/init/luks.go
@@ -95,6 +95,21 @@ var rdLuksOptions = map[string]string{
 	"no-write-workqueue":     luks.FlagNoWriteWorkqueue,
 }
 
+// ctxSleep blocks for d, or returns ctx.Err() as soon as ctx is done, whichever
+// comes first. Used to make fixed waits (clevis network-retry backoff, the
+// concurrent-mode PIN-prompt pre-delay) abort immediately on a cancel-on-win or
+// a serialize-mode per-token timeout instead of sleeping out the full duration.
+func ctxSleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 func recoverClevisPassword(ctx context.Context, t luks.Token, luksVersion int) ([]byte, error) {
 	var payload []byte
 	// Note that token metadata stored differently in LUKS v1 and v2
@@ -112,19 +127,6 @@ func recoverClevisPassword(ctx context.Context, t luks.Token, luksVersion int) (
 
 	deadline := time.Now().Add(60 * time.Second) // wait for network readiness for 60 seconds max
 	waitedForTpm := false
-	// ctxSleep waits d or returns ctx.Err() early — lets the serialize-mode
-	// per-token timeout (or a cancel-on-win) abort a network-stuck clevis
-	// retry instead of grinding to the 60 s internal deadline.
-	ctxSleep := func(d time.Duration) error {
-		timer := time.NewTimer(d)
-		defer timer.Stop()
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-timer.C:
-			return nil
-		}
-	}
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -148,7 +150,7 @@ func recoverClevisPassword(ctx context.Context, t luks.Token, luksVersion int) (
 				if time.Now().After(deadline) {
 					return nil, fmt.Errorf("timeout waiting for USB device")
 				}
-				if err := ctxSleep(500 * time.Millisecond); err != nil {
+				if err := ctxSleep(ctx, 500*time.Millisecond); err != nil {
 					return nil, err
 				}
 				continue
@@ -161,7 +163,7 @@ func recoverClevisPassword(ctx context.Context, t luks.Token, luksVersion int) (
 				return nil, fmt.Errorf("timeout waiting for network")
 			}
 			// else let's sleep and retry
-			if err := ctxSleep(time.Second); err != nil {
+			if err := ctxSleep(ctx, time.Second); err != nil {
 				return nil, err
 			}
 			continue
@@ -577,7 +579,10 @@ func perTokenTimeout(t luks.Token) time.Duration {
 //  2. booster.yaml token_timeout (config.TokenTimeout)
 //  3. serialize mode: sum of the enrolled tokens' per-token bounds, so the
 //     keyboard never preempts a serial token that hasn't had its turn (PIN
-//     tokens contribute 0 — they're interactive and covered by tokenWg)
+//     tokens contribute 0 — they're interactive and covered by tokenWg). A
+//     zero sum (only PIN/unknown tokens) falls through to case 4 — otherwise
+//     a FIDO2-PIN goroutine parked on absent hardware would never release the
+//     keyboard fallback and the boot would hang.
 //  4. otherwise the mapping's implicit default (30 s; unchanged behaviour)
 //
 // A return of 0 means "wait for the token goroutines (tokenWg) with no timer".
@@ -593,9 +598,23 @@ func effectiveTokenTimeout(mapping *luksMapping, serialTokens []luks.Token) time
 		for _, t := range serialTokens {
 			sum += perTokenTimeout(t)
 		}
-		return sum
+		if sum > 0 {
+			return sum
+		}
 	}
 	return mapping.tokenTimeout
+}
+
+// pinDelay returns how long luksOpen holds the first interactive PIN prompt so
+// a parallel non-interactive token can win first and spare the user the PIN.
+// Returns 0 unless pin_delay is set, in serialize mode (strict ID order
+// already), or with no parallel non-PIN token (nothing could make the prompt
+// unnecessary).
+func pinDelay(serialize, hasParallelToken bool) time.Duration {
+	if config.PinDelay <= 0 || serialize || !hasParallelToken {
+		return 0
+	}
+	return time.Duration(config.PinDelay) * time.Second
 }
 
 func recoverTokenPassword(ctx context.Context, volumes chan *luks.Volume, d luks.Device, t luks.Token, mappingName string) bool {
@@ -930,6 +949,10 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	serialize := config.SerializeTokens
 	var serialTokens []luks.Token
 	slotsWithTokens := make(map[int]bool)
+	// hasParallelToken: a non-PIN token is racing in parallel. Gates the
+	// PIN-prompt pre-delay — holding the prompt only helps when a
+	// non-interactive token could still win and make it unnecessary.
+	hasParallelToken := false
 	for _, t := range tokens {
 		if t.Type == "systemd-recovery" {
 			continue // skipped: entered via keyboard later
@@ -942,6 +965,7 @@ func luksOpen(dev string, mapping *luksMapping) error {
 			continue
 		}
 		t := t
+		hasParallelToken = true
 		senderWg.Add(1)
 		tokenWg.Add(1)
 		go func() {
@@ -952,6 +976,8 @@ func luksOpen(dev string, mapping *luksMapping) error {
 			}
 		}()
 	}
+
+	delay := pinDelay(serialize, hasParallelToken)
 
 	// Serial tokens: one goroutine walks them in slice order (already sorted by
 	// ID above). A skipped/failed token advances to the next; a successful
@@ -964,11 +990,26 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		go func() {
 			defer senderWg.Done()
 			defer tokenWg.Done()
+			pinDelayed := false
 			for _, t := range serialTokens {
 				select {
 				case <-ctx.Done():
 					return
 				default:
+				}
+				// Hold the first PIN prompt for pin_delay so the parallel
+				// non-interactive token race can win before any prompt is
+				// drawn; if it wins (here or later) ctx is cancelled and we
+				// return. Applied only once: the delay just buys the race a
+				// head start before the user is first interrupted. The race
+				// goroutines keep running regardless, and cancel-on-win still
+				// dismisses a later prompt — re-paying the delay per PIN token
+				// would only add boot latency with no extra benefit.
+				if delay > 0 && !pinDelayed && tokenNeedsPin(t) {
+					pinDelayed = true
+					if err := ctxSleep(ctx, delay); err != nil {
+						return // cancel-on-win during the delay
+					}
 				}
 				// Per-token timeout (serialize mode only): bound a
 				// non-interactive token so a dead clevis/absent-FIDO2

--- a/init/luks.go
+++ b/init/luks.go
@@ -821,10 +821,14 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	// which token (TPM2 vs FIDO2 vs clevis) tries to unlock first.
 	sort.Slice(tokens, func(i, j int) bool { return tokens[i].ID < tokens[j].ID })
 
-	// PIN-bearing tokens (TPM2 with PIN, FIDO2 with PIN) go into pinTokens for
-	// serial dispatch by a single goroutine so prompts never interleave when
-	// more than one is enrolled. Non-PIN tokens fan out as today.
-	var pinTokens []luks.Token
+	// Tokens dispatched serially go into serialTokens; a single goroutine walks
+	// them in ID order so attempts never interleave. PIN-bearing tokens (TPM2
+	// with PIN, FIDO2 with PIN) always serialize so prompts never overlap when
+	// more than one is enrolled. When serialize_tokens is set every token
+	// serializes — the user opted out of booster's token concurrency entirely.
+	// Otherwise non-PIN tokens fan out in parallel.
+	serialize := config.SerializeTokens
+	var serialTokens []luks.Token
 	slotsWithTokens := make(map[int]bool)
 	for _, t := range tokens {
 		if t.Type == "systemd-recovery" {
@@ -833,8 +837,8 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		for _, s := range t.Slots {
 			slotsWithTokens[s] = true
 		}
-		if tokenNeedsPin(t) {
-			pinTokens = append(pinTokens, t)
+		if serialize || tokenNeedsPin(t) {
+			serialTokens = append(serialTokens, t)
 			continue
 		}
 		t := t
@@ -849,18 +853,18 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		}()
 	}
 
-	// PIN tokens: one goroutine walks them in slice order (already sorted by
+	// Serial tokens: one goroutine walks them in slice order (already sorted by
 	// ID above). A skipped/failed token advances to the next; a successful
 	// unlock cancels ctx and stops iteration. The ctx check before each
-	// iteration lets a parallel non-PIN unlock cancel the loop without
-	// waiting for the next prompt to time out.
-	if len(pinTokens) > 0 {
+	// iteration lets a parallel non-PIN unlock (when any exist) cancel the loop
+	// without waiting for the next prompt to time out.
+	if len(serialTokens) > 0 {
 		senderWg.Add(1)
 		tokenWg.Add(1)
 		go func() {
 			defer senderWg.Done()
 			defer tokenWg.Done()
-			for _, t := range pinTokens {
+			for _, t := range serialTokens {
 				select {
 				case <-ctx.Done():
 					return

--- a/init/luks.go
+++ b/init/luks.go
@@ -34,6 +34,12 @@ type luksMapping struct {
 	headerDeviceRef *deviceRef    // non-nil when header is a file on a separate device
 	tokenTimeout    time.Duration // how long to wait for tokens before also starting keyboard; 0 = wait forever
 
+	// tokenTimeoutExplicit is set when tokenTimeout came from an explicit
+	// crypttab/cmdline token-timeout= (not the implicit 30s default). It lets
+	// luksOpen know whether a booster.yaml token_timeout or the serialize-mode
+	// derived sum may be substituted instead.
+	tokenTimeoutExplicit bool
+
 	keyfileDeviceRef *deviceRef    // non-nil when keyfile is on a separate device
 	keyfileTimeout   time.Duration // device wait timeout for keyfile device (0 = use MountTimeout)
 
@@ -89,7 +95,7 @@ var rdLuksOptions = map[string]string{
 	"no-write-workqueue":     luks.FlagNoWriteWorkqueue,
 }
 
-func recoverClevisPassword(t luks.Token, luksVersion int) ([]byte, error) {
+func recoverClevisPassword(ctx context.Context, t luks.Token, luksVersion int) ([]byte, error) {
 	var payload []byte
 	// Note that token metadata stored differently in LUKS v1 and v2
 	if luksVersion == 1 {
@@ -106,7 +112,23 @@ func recoverClevisPassword(t luks.Token, luksVersion int) ([]byte, error) {
 
 	deadline := time.Now().Add(60 * time.Second) // wait for network readiness for 60 seconds max
 	waitedForTpm := false
+	// ctxSleep waits d or returns ctx.Err() early — lets the serialize-mode
+	// per-token timeout (or a cancel-on-win) abort a network-stuck clevis
+	// retry instead of grinding to the 60 s internal deadline.
+	ctxSleep := func(d time.Duration) error {
+		timer := time.NewTimer(d)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return nil
+		}
+	}
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		password, err := clevis.Decrypt(payload)
 		if err != nil {
 			var netError *net.OpError
@@ -126,7 +148,9 @@ func recoverClevisPassword(t luks.Token, luksVersion int) ([]byte, error) {
 				if time.Now().After(deadline) {
 					return nil, fmt.Errorf("timeout waiting for USB device")
 				}
-				time.Sleep(500 * time.Millisecond)
+				if err := ctxSleep(500 * time.Millisecond); err != nil {
+					return nil, err
+				}
 				continue
 			} else if !errors.As(err, &netError) {
 				return nil, err
@@ -137,7 +161,9 @@ func recoverClevisPassword(t luks.Token, luksVersion int) ([]byte, error) {
 				return nil, fmt.Errorf("timeout waiting for network")
 			}
 			// else let's sleep and retry
-			time.Sleep(time.Second)
+			if err := ctxSleep(time.Second); err != nil {
+				return nil, err
+			}
 			continue
 		}
 
@@ -298,7 +324,15 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 
 	seenHidrawDevices := make(set)
 
-	for devName := range hidrawDevices {
+	for {
+		var devName string
+		select {
+		case <-ctx.Done():
+			// serialize-mode per-token timeout (or cancel-on-win) fired
+			// while waiting for a FIDO2 device to appear — stop waiting.
+			return nil, ctx.Err()
+		case devName = <-hidrawDevices:
+		}
 		if seenHidrawDevices[devName] {
 			continue
 		}
@@ -507,13 +541,70 @@ func tokenNeedsPin(t luks.Token) bool {
 	return false
 }
 
+// secondsOr returns cfg seconds as a Duration, or def seconds when cfg is 0
+// (unset). Used to resolve the per-token-type serialize-mode bounds.
+func secondsOr(cfg, def int) time.Duration {
+	if cfg > 0 {
+		return time.Duration(cfg) * time.Second
+	}
+	return time.Duration(def) * time.Second
+}
+
+// perTokenTimeout returns the serialize-mode per-token bound for t, or 0 when t
+// must not be auto-cancelled. PIN-bearing tokens (interactive — the user has
+// the empty-Enter skip) and unknown token types are never bounded. Only used
+// when SerializeTokens is set; in concurrent mode tokens race so a blocker
+// can't starve siblings.
+func perTokenTimeout(t luks.Token) time.Duration {
+	if !config.SerializeTokens || tokenNeedsPin(t) {
+		return 0
+	}
+	switch t.Type {
+	case "clevis":
+		return secondsOr(config.ClevisTimeout, 45)
+	case "systemd-tpm2":
+		return secondsOr(config.Tpm2Timeout, 15)
+	case "systemd-fido2":
+		return secondsOr(config.Fido2Timeout, 30)
+	}
+	return 0
+}
+
+// effectiveTokenTimeout resolves how long luksOpen waits for tokens before the
+// keyboard/keyfile fallback also starts. Precedence, highest first:
+//
+//  1. explicit crypttab/cmdline token-timeout= (mapping.tokenTimeoutExplicit)
+//  2. booster.yaml token_timeout (config.TokenTimeout)
+//  3. serialize mode: sum of the enrolled tokens' per-token bounds, so the
+//     keyboard never preempts a serial token that hasn't had its turn (PIN
+//     tokens contribute 0 — they're interactive and covered by tokenWg)
+//  4. otherwise the mapping's implicit default (30 s; unchanged behaviour)
+//
+// A return of 0 means "wait for the token goroutines (tokenWg) with no timer".
+func effectiveTokenTimeout(mapping *luksMapping, serialTokens []luks.Token) time.Duration {
+	if mapping.tokenTimeoutExplicit {
+		return mapping.tokenTimeout
+	}
+	if config.TokenTimeout > 0 {
+		return time.Duration(config.TokenTimeout) * time.Second
+	}
+	if config.SerializeTokens {
+		var sum time.Duration
+		for _, t := range serialTokens {
+			sum += perTokenTimeout(t)
+		}
+		return sum
+	}
+	return mapping.tokenTimeout
+}
+
 func recoverTokenPassword(ctx context.Context, volumes chan *luks.Volume, d luks.Device, t luks.Token, mappingName string) bool {
 	var password []byte
 	var err error
 
 	switch t.Type {
 	case "clevis":
-		password, err = recoverClevisPassword(t, d.Version())
+		password, err = recoverClevisPassword(ctx, t, d.Version())
 	case "systemd-fido2":
 		password, err = recoverSystemdFido2Password(ctx, t, mappingName)
 	case "systemd-tpm2":
@@ -528,6 +619,15 @@ func recoverTokenPassword(ctx context.Context, volumes chan *luks.Volume, d luks
 	}
 	if errors.Is(err, errTPM2Skipped) {
 		return false // intentional fallback; message already shown in recoverSystemdTPM2Password
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		// serialize-mode per-token timeout — not a failure, advance the
+		// serial loop to the next token (or the keyboard fallback).
+		info("%s token #%d timed out, moving on", t.Type, t.ID)
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return false // another unlock path won (cancel-on-win); stay quiet
 	}
 	if err != nil {
 		warning("recovering %s token #%d failed: %v", t.Type, t.ID, err)
@@ -870,7 +970,21 @@ func luksOpen(dev string, mapping *luksMapping) error {
 					return
 				default:
 				}
-				if recoverTokenPassword(ctx, volumes, d, t, mapping.name) {
+				// Per-token timeout (serialize mode only): bound a
+				// non-interactive token so a dead clevis/absent-FIDO2
+				// can't stall the chain or starve later tokens. PIN
+				// tokens return 0 here (interactive, user has empty-Enter
+				// escape) and run under the parent ctx unbounded.
+				tctx := ctx
+				var tcancel context.CancelFunc
+				if pt := perTokenTimeout(t); pt > 0 {
+					tctx, tcancel = context.WithTimeout(ctx, pt)
+				}
+				ok := recoverTokenPassword(tctx, volumes, d, t, mapping.name)
+				if tcancel != nil {
+					tcancel()
+				}
+				if ok {
 					cancel()
 					return
 				}
@@ -899,8 +1013,8 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	// elapses). This gives hardware tokens priority over the keyboard prompt.
 	// senderWg ensures volumes is closed if this goroutine is the last sender.
 	senderWg.Go(func() {
-		if mapping.tokenTimeout > 0 {
-			waitTimeout(&tokenWg, mapping.tokenTimeout)
+		if tt := effectiveTokenTimeout(mapping, serialTokens); tt > 0 {
+			waitTimeout(&tokenWg, tt)
 		} else {
 			tokenWg.Wait()
 		}

--- a/init/token_orchestration_test.go
+++ b/init/token_orchestration_test.go
@@ -76,10 +76,19 @@ type orchestrationEvent struct {
 	event string // "started", "completed", "skipped-done"
 }
 
-// runPinTokens mirrors the dispatch in luksOpen: non-PIN tokens fan out in
-// parallel, PIN tokens are walked sequentially in slice order by one goroutine.
-// Returns the recorded events.
+// runPinTokens mirrors the dispatch in luksOpen with serialize_tokens off:
+// non-PIN tokens fan out in parallel, PIN tokens are walked sequentially in
+// slice order by one goroutine.
 func runPinTokens(specs []pinTokenSpec) []orchestrationEvent {
+	return runTokens(specs, false)
+}
+
+// runTokens mirrors the token dispatch in luksOpen. When serialize is false,
+// non-PIN tokens fan out in parallel and only PIN tokens serialize. When
+// serialize is true, every token serializes (the serialize_tokens opt-out of
+// booster's token concurrency) — matching the `serialize || tokenNeedsPin(t)`
+// gate in luksOpen. Returns the recorded events.
+func runTokens(specs []pinTokenSpec, serialize bool) []orchestrationEvent {
 	var events []orchestrationEvent
 	var mu sync.Mutex
 	record := func(id int, ev string) {
@@ -102,7 +111,7 @@ func runPinTokens(specs []pinTokenSpec) []orchestrationEvent {
 
 	var pinSpecs []pinTokenSpec
 	for _, t := range specs {
-		if t.pin {
+		if serialize || t.pin {
 			pinSpecs = append(pinSpecs, t)
 			continue
 		}
@@ -340,4 +349,72 @@ func TestPinTokensPreserveInputSliceOrderWhenUnsorted(t *testing.T) {
 	events := runPinTokens(specs)
 	require.Equal(t, []int{3, 1, 0, 2, 4}, orderOf(events),
 		"without sort, loop must run tokens in input-slice order")
+}
+
+// ── serialize_tokens opt-out ─────────────────────────────────────────────────
+//
+// With serialize_tokens set, luksOpen routes every token (including non-PIN
+// clevis / touchless-FIDO2 / auto-TPM2) through the single serial loop. These
+// tests assert that opt-out: no parallel fan-out, strict slice-order, and the
+// short-circuit-on-success behaviour still holds.
+
+func TestSerializeTokensRunsNonPinTokensSerially(t *testing.T) {
+	t.Parallel()
+	// All three tokens are non-PIN. Without serialize they would fan out in
+	// parallel; with serialize each must fully complete before the next starts.
+	specs := []pinTokenSpec{
+		{id: 1, pin: false, recoverFn: returns(false)},
+		{id: 2, pin: false, recoverFn: returns(false)},
+		{id: 3, pin: false, recoverFn: returns(false)},
+	}
+	events := runTokens(specs, true)
+	require.Equal(t, []int{1, 2, 3}, orderOf(events), "serialize must run tokens in slice order")
+	require.Equal(t, []orchestrationEvent{
+		{1, "started"}, {1, "completed"},
+		{2, "started"}, {2, "completed"},
+		{3, "started"}, {3, "completed"},
+	}, events, "serialize must not interleave non-PIN tokens")
+}
+
+func TestSerializeTokensNonPinSuccessShortCircuits(t *testing.T) {
+	t.Parallel()
+	// A non-PIN token succeeding under serialize must cancel the loop so
+	// trailing tokens never run — same short-circuit as the PIN loop.
+	specs := []pinTokenSpec{
+		{id: 1, pin: false, recoverFn: returns(false)},
+		{id: 2, pin: false, recoverFn: returns(true)},
+		{id: 3, pin: false, recoverFn: returns(false)},
+	}
+	events := runTokens(specs, true)
+	require.Equal(t, []int{1, 2}, orderOf(events))
+	require.Equal(t, "", eventOf(events, 3), "token 3 must not run after a serial success")
+}
+
+func TestSerializeTokensBlockingTokenDelaysNext(t *testing.T) {
+	t.Parallel()
+	// Under serialize a blocking non-PIN token (e.g. clevis waiting on the
+	// network) must hold up the next token — proving there is no parallel
+	// goroutine. This is the deliberate trade-off of opting out of concurrency.
+	release := make(chan struct{})
+	secondStarted := make(chan struct{})
+	specs := []pinTokenSpec{
+		{id: 1, pin: false, recoverFn: func(ctx context.Context) bool {
+			<-release
+			return false
+		}},
+		{id: 2, pin: false, recoverFn: func(ctx context.Context) bool {
+			close(secondStarted)
+			return false
+		}},
+	}
+	resultCh := make(chan []orchestrationEvent, 1)
+	go func() { resultCh <- runTokens(specs, true) }()
+
+	select {
+	case <-secondStarted:
+		t.Fatal("token 2 started before token 1 finished — serialize is not serial")
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(release)
+	<-resultCh
 }

--- a/init/token_timeout_test.go
+++ b/init/token_timeout_test.go
@@ -1,0 +1,113 @@
+package main
+
+// Tests for the serialize-mode per-token timeout helpers (secondsOr,
+// perTokenTimeout) and the keyboard-fallback timer resolver
+// (effectiveTokenTimeout). These are pure functions over the global config and
+// a luksMapping, so they exercise the precedence rules without LUKS devices.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/anatol/luks.go"
+	"github.com/stretchr/testify/require"
+)
+
+// withConfig swaps the global config for the duration of fn and restores it.
+func withConfig(c InitConfig, fn func()) {
+	saved := config
+	config = c
+	defer func() { config = saved }()
+	fn()
+}
+
+func TestSecondsOr(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, 10*time.Second, secondsOr(10, 45), "explicit cfg wins")
+	require.Equal(t, 45*time.Second, secondsOr(0, 45), "0 falls back to default")
+	require.Equal(t, 1*time.Second, secondsOr(1, 45), "smallest positive honoured")
+}
+
+func tok(typ, payload string) luks.Token {
+	return luks.Token{Type: typ, Payload: []byte(payload)}
+}
+
+func TestPerTokenTimeout(t *testing.T) {
+	clevis := tok("clevis", `{}`)
+	tpm2 := tok("systemd-tpm2", `{"tpm2-pin":false}`)
+	tpm2Pin := tok("systemd-tpm2", `{"tpm2-pin":true}`)
+	fido2 := tok("systemd-fido2", `{"fido2-clientPin-required":false}`)
+	fido2Pin := tok("systemd-fido2", `{"fido2-clientPin-required":true}`)
+	unknown := tok("weird", `{}`)
+
+	t.Run("serialize off → never bounded", func(t *testing.T) {
+		withConfig(InitConfig{SerializeTokens: false}, func() {
+			for _, tk := range []luks.Token{clevis, tpm2, fido2, fido2Pin, unknown} {
+				require.Zero(t, perTokenTimeout(tk), "type %s", tk.Type)
+			}
+		})
+	})
+
+	t.Run("serialize on → type defaults", func(t *testing.T) {
+		withConfig(InitConfig{SerializeTokens: true}, func() {
+			require.Equal(t, 45*time.Second, perTokenTimeout(clevis))
+			require.Equal(t, 15*time.Second, perTokenTimeout(tpm2))
+			require.Equal(t, 30*time.Second, perTokenTimeout(fido2))
+			require.Zero(t, perTokenTimeout(tpm2Pin), "PIN tpm2 exempt")
+			require.Zero(t, perTokenTimeout(fido2Pin), "PIN fido2 exempt")
+			require.Zero(t, perTokenTimeout(unknown), "unknown type unbounded")
+		})
+	})
+
+	t.Run("serialize on → config overrides defaults", func(t *testing.T) {
+		withConfig(InitConfig{SerializeTokens: true, ClevisTimeout: 90, Tpm2Timeout: 5, Fido2Timeout: 12}, func() {
+			require.Equal(t, 90*time.Second, perTokenTimeout(clevis))
+			require.Equal(t, 5*time.Second, perTokenTimeout(tpm2))
+			require.Equal(t, 12*time.Second, perTokenTimeout(fido2))
+			require.Zero(t, perTokenTimeout(tpm2Pin), "PIN still exempt despite config")
+		})
+	})
+}
+
+func TestEffectiveTokenTimeout(t *testing.T) {
+	clevis := tok("clevis", `{}`)
+	tpm2 := tok("systemd-tpm2", `{"tpm2-pin":false}`)
+	tpm2Pin := tok("systemd-tpm2", `{"tpm2-pin":true}`)
+
+	t.Run("explicit crypttab/cmdline wins over everything", func(t *testing.T) {
+		m := &luksMapping{tokenTimeout: 7 * time.Second, tokenTimeoutExplicit: true}
+		withConfig(InitConfig{SerializeTokens: true, TokenTimeout: 99}, func() {
+			require.Equal(t, 7*time.Second, effectiveTokenTimeout(m, []luks.Token{clevis}))
+		})
+	})
+
+	t.Run("booster.yaml token_timeout when not explicit", func(t *testing.T) {
+		m := &luksMapping{tokenTimeout: 30 * time.Second} // implicit default, not explicit
+		withConfig(InitConfig{SerializeTokens: true, TokenTimeout: 25}, func() {
+			require.Equal(t, 25*time.Second, effectiveTokenTimeout(m, []luks.Token{clevis}))
+		})
+	})
+
+	t.Run("serialize derived sum of per-token bounds", func(t *testing.T) {
+		m := &luksMapping{tokenTimeout: 30 * time.Second} // implicit, ignored in serialize
+		withConfig(InitConfig{SerializeTokens: true}, func() {
+			// clevis 45 + tpm2 15 + PIN tpm2 0 = 60s
+			got := effectiveTokenTimeout(m, []luks.Token{clevis, tpm2, tpm2Pin})
+			require.Equal(t, 60*time.Second, got)
+		})
+	})
+
+	t.Run("serialize, only PIN tokens → 0 (wait on tokenWg)", func(t *testing.T) {
+		m := &luksMapping{tokenTimeout: 30 * time.Second}
+		withConfig(InitConfig{SerializeTokens: true}, func() {
+			require.Zero(t, effectiveTokenTimeout(m, []luks.Token{tpm2Pin}))
+		})
+	})
+
+	t.Run("non-serialize, nothing explicit → mapping implicit default", func(t *testing.T) {
+		m := &luksMapping{tokenTimeout: 30 * time.Second}
+		withConfig(InitConfig{SerializeTokens: false}, func() {
+			require.Equal(t, 30*time.Second, effectiveTokenTimeout(m, nil))
+		})
+	})
+}

--- a/init/token_timeout_test.go
+++ b/init/token_timeout_test.go
@@ -6,6 +6,7 @@ package main
 // a luksMapping, so they exercise the precedence rules without LUKS devices.
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -97,10 +98,15 @@ func TestEffectiveTokenTimeout(t *testing.T) {
 		})
 	})
 
-	t.Run("serialize, only PIN tokens → 0 (wait on tokenWg)", func(t *testing.T) {
+	t.Run("serialize, only PIN tokens → mapping default (keyboard-fallback safety net)", func(t *testing.T) {
+		// Every serial token is PIN-bearing so the derived sum is 0. Returning
+		// 0 here means tokenWg.Wait() with no timer; a FIDO2-PIN goroutine
+		// parked on absent hardware would then never release the keyboard
+		// fallback and the boot would hang. Must fall through to the mapping's
+		// implicit default instead.
 		m := &luksMapping{tokenTimeout: 30 * time.Second}
 		withConfig(InitConfig{SerializeTokens: true}, func() {
-			require.Zero(t, effectiveTokenTimeout(m, []luks.Token{tpm2Pin}))
+			require.Equal(t, 30*time.Second, effectiveTokenTimeout(m, []luks.Token{tpm2Pin}))
 		})
 	})
 
@@ -108,6 +114,82 @@ func TestEffectiveTokenTimeout(t *testing.T) {
 		m := &luksMapping{tokenTimeout: 30 * time.Second}
 		withConfig(InitConfig{SerializeTokens: false}, func() {
 			require.Equal(t, 30*time.Second, effectiveTokenTimeout(m, nil))
+		})
+	})
+}
+
+// TestCtxSleep covers the wait primitive behind the pin_delay hold. The
+// safety property of pin_delay is that a cancel-on-win (or a serialize-mode
+// per-token timeout) during the hold aborts the sleep *immediately* so the
+// PIN prompt is never drawn — that is the cancel cases below, not the
+// timer-elapsed one.
+func TestCtxSleep(t *testing.T) {
+	t.Parallel()
+
+	t.Run("timer elapses → nil after the full duration", func(t *testing.T) {
+		t.Parallel()
+		start := time.Now()
+		require.NoError(t, ctxSleep(context.Background(), 30*time.Millisecond))
+		require.GreaterOrEqual(t, time.Since(start), 30*time.Millisecond)
+	})
+
+	t.Run("already-cancelled ctx → returns immediately, prompt never held", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		start := time.Now()
+		require.ErrorIs(t, ctxSleep(ctx, time.Hour), context.Canceled)
+		require.Less(t, time.Since(start), 50*time.Millisecond, "must not sleep out the hold")
+	})
+
+	t.Run("cancel-on-win during the hold → aborts well before the delay", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancel() // a parallel non-interactive token won the race
+		}()
+		start := time.Now()
+		require.ErrorIs(t, ctxSleep(ctx, time.Hour), context.Canceled)
+		require.Less(t, time.Since(start), 200*time.Millisecond)
+	})
+
+	t.Run("deadline exceeded surfaces as the ctx error", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		require.ErrorIs(t, ctxSleep(ctx, time.Hour), context.DeadlineExceeded)
+	})
+}
+
+func TestPinDelay(t *testing.T) {
+	t.Run("unset → no delay", func(t *testing.T) {
+		withConfig(InitConfig{}, func() {
+			require.Zero(t, pinDelay(false, true))
+		})
+	})
+
+	t.Run("set, concurrent, parallel token racing → delay applies", func(t *testing.T) {
+		withConfig(InitConfig{PinDelay: 3}, func() {
+			require.Equal(t, 3*time.Second, pinDelay(false, true))
+		})
+	})
+
+	t.Run("set but serialize mode → no delay (strict ID order)", func(t *testing.T) {
+		withConfig(InitConfig{PinDelay: 3}, func() {
+			require.Zero(t, pinDelay(true, true))
+		})
+	})
+
+	t.Run("set but no parallel token → no delay (nothing to wait for)", func(t *testing.T) {
+		withConfig(InitConfig{PinDelay: 3}, func() {
+			require.Zero(t, pinDelay(false, false))
+		})
+	})
+
+	t.Run("negative config treated as off", func(t *testing.T) {
+		withConfig(InitConfig{PinDelay: -1}, func() {
+			require.Zero(t, pinDelay(false, true))
 		})
 	})
 }


### PR DESCRIPTION
Closes #255.

## Problem

When a LUKS2 device has both a PIN-bearing token (TPM2-PIN, FIDO2-PIN) and a non-interactive one (TPM2 PCR-only, touchless FIDO2, clevis), booster races them concurrently and draws the interactive PIN prompt the instant the PIN token dispatches — even though the non-interactive token would unlock the device silently. The reporter asked for a way to let the silent path win first.

## Changes

Two independent, opt-in mechanisms plus a related precedence fix. All are off / behaviour-preserving by default — no change unless configured.

- **`pin_delay`** (concurrent mode — what the issue literally asks for): briefly holds the *first* PIN prompt so a parallel non-interactive token can unlock first; if it does, the prompt is never rendered (cancelled before draw). If the delay expires the prompt appears as before — no unlock path is lost, the delay only postpones it.
- **`serialize_tokens`**: opts out of token concurrency entirely — tokens are tried one at a time in ascending token-ID order, so a non-interactive token enrolled before a PIN token unlocks first (behaviour closer to `systemd-cryptsetup`). Per-type bounds (`clevis_timeout` / `tpm2_timeout` / `fido2_timeout`) keep one stuck token from hanging the chain.
- **`token_timeout`** (top-level): the device keyboard-fallback timer, booster-config peer of crypttab/`rd.luks.options` `token-timeout=`, with a documented precedence order.
- **crypttab precedence fix**: an explicit kernel-cmdline `token-timeout=` was being silently overridden by a crypttab entry's *implicit* 30s default; now an explicit cmdline value wins, consistent with the keyfile/header/tries merges in `mergeCrypttabOptions`.

## Verification

Unit tests for each path (`TestPinDelay`, `TestCtxSleep`, `TestMergeCrypttabOptionsExplicitCmdlineTokenTimeoutWins`, the existing `token_timeout` suite). The `pin_delay` path is QEMU-verified end-to-end against a PIN + parallel TPM2-PCR fixture: without the option the PIN prompt is drawn (the reported symptom); with `pin_delay` long enough to outlast the racing token's unseal it is never drawn, the device unlocks silently and `switch_root` completes.

Manpage updated (CONFIG FILE bullets + the `## CRYPTTAB` precedence sentence).
