### PR TITLE
Add SSH remote LUKS unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Booster advantages:
  * [Systemd-cryptenroll](http://0pointer.net/blog/unlocking-luks2-volumes-with-tpm2-fido2-pkcs11-security-hardware-on-systemd-248.html)
    type of binding. Booster is able to detect and unlock systemd-fido2 and systemd-tpm2 style partitions.
  * Supports [autodiscoverable root partition](https://systemd.io/DISCOVERABLE_PARTITIONS/)
+ * Remote LUKS unlock via SSH (see manpage REMOTE UNLOCK section).
  * Easy to configure.
  * Automatic host configuration discovery. This helps to create minimalistic images specific for the current host.
 

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -23,6 +23,9 @@ Booster advantages:
       ip: 10.0.2.15/24
       gateway: 10.0.2.255
       dns_servers: 192.168.1.1,8.8.8.8
+      ssh_host_key: /etc/booster/ssh_host_ed25519_key
+      ssh_authorized_keys: /etc/booster/authorized_keys
+      ssh_listen: :22
     universal: false
     modules: -*,hid_apple,kernel/sound/usb/,kernel/fs/btrfs/btrfs.ko,kernel/lib/crc4.ko.xz
     compression: zstd
@@ -44,6 +47,7 @@ Booster advantages:
     The `network` node also accepts `interfaces` property - a comma-separated list of network interfaces (specified either with name or MAC address) to enable at the boot time.
     Network names like `enp0s31f6` get resolved to MAC addresses at generation time and then passed to init.
     If `interfaces` node is not specified then all the interfaces are activated at boot.
+    The `network` node also accepts `ssh_host_key`, `ssh_authorized_keys`, and `ssh_listen` to enable remote LUKS unlock over SSH. `ssh_host_key` is a path to an OpenSSH- or PEM-encoded SSH host private key, `ssh_authorized_keys` is a path to an authorized_keys file, and `ssh_listen` is the listen address (default `:22`). Both `ssh_host_key` and `ssh_authorized_keys` must be set together, and SSH requires `dhcp: true` or a static `ip`. See REMOTE UNLOCK below.
 
  * `universal` is a boolean flag that tells booster to generate a universal image. By default booster generates a host-specific image that includes kernel modules used at the current host. For example if the host does not have a TPM2 chip then tpm modules are ignored. Universal image includes many kernel modules and tools that might be needed at a broad range of hardware configurations.
 
@@ -251,6 +255,74 @@ Booster-specific behaviour for selected options:
  * **`header=`** — if the path is a plain absolute path the generator bundles the file into the initramfs automatically. The `/path:deviceref` form mounts the device at boot; `/dev/...` uses the raw block device directly.
  * **`fido2-device=`** — when this option appears in a crypttab entry, the generator automatically bundles `fido2plugin.so`; no `enable_fido2: true` in the config file is required. Both `fido2-device=` and `tpm2-device=` are otherwise accepted for compatibility; booster discovers enrolled tokens from the LUKS2 header, not from the crypttab option value.
  * **`keyfile-timeout=`** / **`token-timeout=`** — accept a bare integer (seconds) or any duration string accepted by Go's `time.ParseDuration` (e.g. `30s`, `2m`).
+
+## REMOTE UNLOCK
+
+Booster can unlock LUKS volumes from a remote SSH client during early boot.
+The SSH server starts once networking is up (DHCP lease acquired or static
+`ip` configured) and prompts the connecting client for a LUKS passphrase.
+The submitted passphrase is broadcast to every LUKS device currently
+waiting at a keyboard prompt; a successful unlock seeds the in-boot
+passphrase cache so sibling volumes with the same key unlock without
+further prompts. Equivalent to Debian's `dropbear-initramfs` setup but
+native to booster — uses Go's `golang.org/x/crypto/ssh` rather than
+bundling dropbear.
+
+Generate a host key once (kept on the host, embedded into the image at
+build time):
+
+    $ ssh-keygen -t ed25519 -f /etc/booster/ssh_host_ed25519_key -N ''
+
+Build an `authorized_keys` file with one or more public keys, one per
+line:
+
+    ssh-ed25519 AAAAC3Nz...user1@laptop
+    ssh-ed25519 AAAAC3Nz...user2@phone
+
+Wire both files into `/etc/booster.yaml`:
+
+    network:
+      dhcp: on
+      ssh_host_key: /etc/booster/ssh_host_ed25519_key
+      ssh_authorized_keys: /etc/booster/authorized_keys
+      ssh_listen: :22
+
+Both `ssh_host_key` and `ssh_authorized_keys` are read at image build
+time and embedded into the initramfs; one without the other is a config
+error. SSH also requires `network.dhcp: true` or a static `network.ip`.
+
+From a client, connect as `root` and paste the passphrase at the prompt:
+
+    $ ssh -p 22 root@<host>
+
+Security notes:
+
+ * Pubkey-only authentication; password auth is not supported.
+   Per-session attempts are capped at 10 wrong submissions before
+   disconnect; the SSH handshake itself must complete within 15
+   seconds (slow-loris guard).
+ * The host private key and the enrolled `authorized_keys` are read
+   at image build time and embedded into the initramfs. Anyone with
+   read access to `/boot` (or the image file) can extract both. Treat
+   them as compromised whenever `/boot` is exposed; rebuild the image
+   to rotate the host key.
+ * The host key fingerprint is stable across reboots (no auto-regen),
+   so `known_hosts` does not churn.
+ * The SSH port plus a stolen copy of any private key listed in
+   `authorized_keys` is enough for an attacker to keep guessing LUKS
+   passphrases against the live server. We disconnect a session after
+   10 wrong submissions, but nothing stops the attacker from
+   reconnecting and trying 10 more. The cap slows brute force, it
+   does not stop it — anyone who can reach the SSH port is in a
+   position roughly equivalent to direct LUKS keyslot exposure.
+ * `ssh_listen: :22` listens on every network interface that comes
+   up at boot, on both IPv4 and IPv6 — including link-local IPv6
+   addresses (`fe80::...`) that auto-configure without DHCP. Pin
+   `ssh_listen` to an exact address (for example `10.0.0.5:22`) so
+   only the interface you actually intend to expose is reachable,
+   and firewall the port at the network boundary.
+ * The session is restricted to the passphrase prompt — no shell, no
+   command execution, no port forwarding, no PAM, no PTY allocation.
 
 ## NOTES
 

--- a/generator/config.go
+++ b/generator/config.go
@@ -9,9 +9,32 @@ import (
 	"strings"
 	"time"
 
+	gossh "golang.org/x/crypto/ssh"
 	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 )
+
+// validateAuthorizedKeys mirrors init/ssh.go:parseAuthorizedKeys so a missing
+// or garbage authorized_keys file fails the build loudly instead of silently
+// disabling the SSH server at boot — the same "fail at build, not as a
+// locked-out boot" posture as the crypttab unreadable-warning (commit
+// cebca35). Keep this in sync with the init-side parser.
+func validateAuthorizedKeys(data []byte) error {
+	rest := data
+	n := 0
+	for len(bytes.TrimSpace(rest)) > 0 {
+		_, _, _, next, err := gossh.ParseAuthorizedKey(rest)
+		if err != nil {
+			return fmt.Errorf("no parseable SSH public key found: %v", err)
+		}
+		n++
+		rest = next
+	}
+	if n == 0 {
+		return fmt.Errorf("contains no SSH public keys")
+	}
+	return nil
+}
 
 // UserConfig is a format for /etc/booster.yaml config that is interface between user and booster generator
 type UserConfig struct {
@@ -23,6 +46,14 @@ type UserConfig struct {
 		IP         string `yaml:",omitempty"`            // e.g. 10.0.2.15/24
 		Gateway    string `yaml:",omitempty"`            // e.g. 10.0.2.255
 		DNSServers string `yaml:"dns_servers,omitempty"` // comma-separated list of ips, e.g. 10.0.1.1,8.8.8.8
+
+		// SSH-based remote LUKS unlock. Both SshHostKey and SshAuthorizedKeys
+		// must point to readable files at build time; their contents are
+		// embedded into the initramfs config. Setting SshAuthorizedKeys
+		// enables the SSH server during early boot.
+		SshHostKey        string `yaml:"ssh_host_key,omitempty"`        // path to OpenSSH- or PEM-encoded host private key
+		SshAuthorizedKeys string `yaml:"ssh_authorized_keys,omitempty"` // path to authorized_keys file
+		SshListen         string `yaml:"ssh_listen,omitempty"`          // listen address, default :22
 	}
 	Universal            bool   `yaml:",omitempty"`
 	Modules              string `yaml:",omitempty"`                   // comma separated list of extra modules to add to initramfs
@@ -87,6 +118,14 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 			if n.Dhcp && (n.IP != "" || n.Gateway != "") {
 				return nil, fmt.Errorf("config: option network.(ip|gateway) cannot be used together with network.dhcp")
 			}
+			if n.SshHostKey != "" || n.SshAuthorizedKeys != "" {
+				if n.SshHostKey == "" || n.SshAuthorizedKeys == "" {
+					return nil, fmt.Errorf("config: network.ssh_host_key and network.ssh_authorized_keys must both be set")
+				}
+				if !n.Dhcp && n.IP == "" {
+					return nil, fmt.Errorf("config: network.ssh_* requires network.dhcp or network.ip")
+				}
+			}
 		}
 	}
 
@@ -120,6 +159,31 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 			// TODO: or maybe instead of resolving it to MAC address here we should compute predictable interface names
 			// in init? See the algorithm https://github.com/systemd/systemd/blob/main/src/udev/udev-builtin-net_id.c
 			conf.networkActiveInterfaces = append(conf.networkActiveInterfaces, ifc.HardwareAddr)
+		}
+
+		if n.SshAuthorizedKeys != "" {
+			// The host private key is embedded verbatim into the
+			// (unencrypted) initramfs by design — it must be available
+			// before any disk is unlocked. A group/other-accessible source
+			// key is almost always operator error; OpenSSH itself refuses
+			// loose private-key perms. Warn (don't fail) at build time.
+			if fi, err := os.Stat(n.SshHostKey); err == nil && fi.Mode().Perm()&0o077 != 0 {
+				warning("network.ssh_host_key: %s is accessible by group/other (mode %#o) — this SSH host private key gets embedded in the initramfs; tighten it to 0600", n.SshHostKey, fi.Mode().Perm())
+			}
+			hostKey, err := os.ReadFile(n.SshHostKey)
+			if err != nil {
+				return nil, fmt.Errorf("network.ssh_host_key: %v", err)
+			}
+			authKeys, err := os.ReadFile(n.SshAuthorizedKeys)
+			if err != nil {
+				return nil, fmt.Errorf("network.ssh_authorized_keys: %v", err)
+			}
+			if err := validateAuthorizedKeys(authKeys); err != nil {
+				return nil, fmt.Errorf("network.ssh_authorized_keys: %s %v", n.SshAuthorizedKeys, err)
+			}
+			conf.sshHostKey = string(hostKey)
+			conf.sshAuthorizedKeys = string(authKeys)
+			conf.sshListen = n.SshListen
 		}
 	}
 	conf.universal = u.Universal || opts.BuildCommand.Universal

--- a/generator/config_test.go
+++ b/generator/config_test.go
@@ -44,3 +44,215 @@ network:
 	require.Equal(t, []string{"/bin/ls", "/bin/cat"}, c.extraFiles)
 	require.Len(t, c.networkActiveInterfaces, 2)
 }
+
+// writeSshFixtures creates a host key + authorized_keys pair in tmp and
+// returns their paths. Tests that need a *valid* SSH config can rely on
+// these files existing on disk so readGeneratorConfig can read them.
+func writeSshFixtures(t *testing.T) (hostKey, authKeys string) {
+	t.Helper()
+	dir := t.TempDir()
+	hostKey = filepath.Join(dir, "host_key")
+	authKeys = filepath.Join(dir, "authorized_keys")
+	// Real ed25519 PEM so any future parsing in the generator stays green;
+	// content of authorized_keys is only validated by init, not the generator.
+	require.NoError(t, os.WriteFile(hostKey, []byte(`-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACA6u0iSOLuwKGJ0oMlOvuT8lbDHDlHptyebFZpDx48pfgAAAJgQJZmvECWZ
+rwAAAAtzc2gtZWQyNTUxOQAAACA6u0iSOLuwKGJ0oMlOvuT8lbDHDlHptyebFZpDx48pfg
+AAAEALEOT+7djjMoPheTuZeoYdZ34c7Gt+9r+eiMuurYRZ5jq7SJI4u7AoYnSgyU6+5PyV
+sMcOUem3J5sVmkPHjyl+AAAAEWJvb3N0ZXItdGVzdC1ob3N0AQIDBA==
+-----END OPENSSH PRIVATE KEY-----
+`), 0o600))
+	require.NoError(t, os.WriteFile(authKeys, []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHwZ1qsGgu31resaunq1bwZOM++27lQyeCsI4lCYBTh test@example\n"), 0o600))
+	return
+}
+
+func TestReadConfigAcceptsValidSshConfig(t *testing.T) {
+	t.Parallel()
+	hostKey, authKeys := writeSshFixtures(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "booster.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+network:
+  dhcp: true
+  ssh_host_key: `+hostKey+`
+  ssh_authorized_keys: `+authKeys+`
+  ssh_listen: ":2222"
+`), 0o644))
+
+	c, err := readGeneratorConfig(cfgPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, c.sshHostKey)
+	require.NotEmpty(t, c.sshAuthorizedKeys)
+	require.Equal(t, ":2222", c.sshListen)
+}
+
+func TestReadConfigRejectsSshHostKeyWithoutAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+	hostKey, _ := writeSshFixtures(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "booster.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+network:
+  dhcp: true
+  ssh_host_key: `+hostKey+`
+`), 0o644))
+
+	_, err := readGeneratorConfig(cfgPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ssh_host_key and network.ssh_authorized_keys must both be set")
+}
+
+func TestReadConfigRejectsSshAuthorizedKeysWithoutHostKey(t *testing.T) {
+	t.Parallel()
+	_, authKeys := writeSshFixtures(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "booster.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+network:
+  dhcp: true
+  ssh_authorized_keys: `+authKeys+`
+`), 0o644))
+
+	_, err := readGeneratorConfig(cfgPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ssh_host_key and network.ssh_authorized_keys must both be set")
+}
+
+func TestReadConfigRejectsSshWithoutNetwork(t *testing.T) {
+	t.Parallel()
+	hostKey, authKeys := writeSshFixtures(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "booster.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+network:
+  ssh_host_key: `+hostKey+`
+  ssh_authorized_keys: `+authKeys+`
+`), 0o644))
+
+	_, err := readGeneratorConfig(cfgPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "network.ssh_* requires network.dhcp or network.ip")
+}
+
+func TestReadConfigRejectsMissingSshHostKeyFile(t *testing.T) {
+	t.Parallel()
+	_, authKeys := writeSshFixtures(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "booster.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+network:
+  dhcp: true
+  ssh_host_key: `+filepath.Join(dir, "does-not-exist")+`
+  ssh_authorized_keys: `+authKeys+`
+`), 0o644))
+
+	_, err := readGeneratorConfig(cfgPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "network.ssh_host_key")
+}
+
+const validSshPubKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHwZ1qsGgu31resaunq1bwZOM++27lQyeCsI4lCYBTh test@example"
+
+// TestValidateAuthorizedKeys pins the build-time gate that mirrors
+// init/ssh.go:parseAuthorizedKeys (item 1: fail at build, not as a
+// locked-out boot).
+func TestValidateAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"single valid key", validSshPubKey + "\n", false},
+		{"two valid keys", validSshPubKey + "\n" + validSshPubKey + "\n", false},
+		{"comment then valid key", "# my key\n" + validSshPubKey + "\n", false},
+		{"empty", "", true},
+		{"whitespace only", "  \n\t\n", true},
+		{"comments only", "# just a comment\n# another\n", true},
+		{"garbage only", "this is not a key\n", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateAuthorizedKeys([]byte(tc.input))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestReadConfigRejectsEmptyAuthorizedKeys exercises item 1 end-to-end: an
+// authorized_keys file with no usable keys must fail the build rather than
+// silently disable the SSH server at boot.
+func TestReadConfigRejectsEmptyAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+	hostKey, _ := writeSshFixtures(t)
+
+	dir := t.TempDir()
+	emptyAuth := filepath.Join(dir, "authorized_keys")
+	require.NoError(t, os.WriteFile(emptyAuth, []byte("   \n\t\n"), 0o600))
+	cfgPath := filepath.Join(dir, "booster.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+network:
+  dhcp: true
+  ssh_host_key: `+hostKey+`
+  ssh_authorized_keys: `+emptyAuth+`
+`), 0o644))
+
+	_, err := readGeneratorConfig(cfgPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "network.ssh_authorized_keys")
+	require.Contains(t, err.Error(), "no SSH public keys")
+}
+
+// TestReadConfigRejectsGarbageAuthorizedKeys covers the unparseable-content
+// variant of item 1.
+func TestReadConfigRejectsGarbageAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+	hostKey, _ := writeSshFixtures(t)
+
+	dir := t.TempDir()
+	garbageAuth := filepath.Join(dir, "authorized_keys")
+	require.NoError(t, os.WriteFile(garbageAuth, []byte("not a valid ssh key at all\n"), 0o600))
+	cfgPath := filepath.Join(dir, "booster.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+network:
+  dhcp: true
+  ssh_host_key: `+hostKey+`
+  ssh_authorized_keys: `+garbageAuth+`
+`), 0o644))
+
+	_, err := readGeneratorConfig(cfgPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no parseable SSH public key")
+}
+
+// TestReadConfigAcceptsLooseHostKeyPerms exercises item 2: a group/other
+// readable host key triggers a warning but must NOT fail the build —
+// the warning is advisory, the config still loads.
+func TestReadConfigAcceptsLooseHostKeyPerms(t *testing.T) {
+	t.Parallel()
+	hostKey, authKeys := writeSshFixtures(t)
+	require.NoError(t, os.Chmod(hostKey, 0o644))
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "booster.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+network:
+  dhcp: true
+  ssh_host_key: `+hostKey+`
+  ssh_authorized_keys: `+authKeys+`
+`), 0o644))
+
+	c, err := readGeneratorConfig(cfgPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, c.sshHostKey)
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -46,6 +46,11 @@ type generatorConfig struct {
 
 	enablePlymouth bool
 
+	// SSH-based remote LUKS unlock. Empty sshHostKey means feature disabled.
+	sshHostKey        string
+	sshAuthorizedKeys string
+	sshListen         string
+
 	// virtual console configs
 	enableVirtualConsole     bool
 	vconsolePath, localePath string
@@ -522,6 +527,11 @@ func (img *Image) appendInitConfig(conf *generatorConfig, kmod *Kmod, vconsole *
 	}
 	if conf.networkActiveInterfaces != nil {
 		initConfig.Network.Interfaces = conf.networkActiveInterfaces
+	}
+	if conf.sshHostKey != "" && initConfig.Network != nil {
+		initConfig.Network.SshHostKey = conf.sshHostKey
+		initConfig.Network.SshAuthorizedKeys = conf.sshAuthorizedKeys
+		initConfig.Network.SshListen = conf.sshListen
 	}
 
 	content, err := yaml.Marshal(initConfig)

--- a/init/config.go
+++ b/init/config.go
@@ -10,6 +10,14 @@ type InitNetworkConfig struct {
 	IP         string `yaml:",omitempty"`            // e.g. 10.0.2.15/24
 	Gateway    string `yaml:",omitempty"`            // e.g. 10.0.2.255
 	DNSServers string `yaml:"dns_servers,omitempty"` // comma-separated list of ips, e.g. 10.0.1.1,8.8.8.8
+
+	// SshHostKey is the OpenSSH- or PEM-encoded SSH server private key
+	// (gossh.ParsePrivateKey accepts both). SshAuthorizedKeys is the
+	// contents of an authorized_keys file. SSH remote unlock is enabled
+	// when both are non-empty.
+	SshHostKey        string `yaml:"ssh_host_key,omitempty"`
+	SshAuthorizedKeys string `yaml:"ssh_authorized_keys,omitempty"`
+	SshListen         string `yaml:"ssh_listen,omitempty"`
 }
 
 type VirtualConsole struct {

--- a/init/luks.go
+++ b/init/luks.go
@@ -102,6 +102,12 @@ type promptRegistration struct {
 	d           luks.Device
 	checkSlots  []int
 	mappingName string
+	// inflight counts goroutines that submitted via trySubmitPassphraseToPending
+	// (today: SSH remote unlock) and may still be mid-UnsealVolume after
+	// senderWg.Wait() returns. luksOpen's watcher waits on this before
+	// close(volumes) so the goroutine can't send on a closed channel and
+	// panic pid 1.
+	inflight sync.WaitGroup
 }
 
 func registerPendingPrompt(p *promptRegistration) {
@@ -134,6 +140,14 @@ func trySubmitPassphraseToPending(password []byte) []string {
 	pendingPrompts.Lock()
 	snapshot := make([]*promptRegistration, 0, len(pendingPrompts.entries))
 	for p := range pendingPrompts.entries {
+		if p.ctx.Err() != nil {
+			continue
+		}
+		// Bump inflight under the same lock that owns entries — luksOpen's
+		// watcher takes this lock to remove the entry before waiting on
+		// inflight, so a snapshot-then-spawn that races the close-volumes
+		// path can't sneak in unaccounted.
+		p.inflight.Add(1)
 		snapshot = append(snapshot, p)
 	}
 	pendingPrompts.Unlock()
@@ -144,11 +158,9 @@ func trySubmitPassphraseToPending(password []byte) []string {
 		wg       sync.WaitGroup
 	)
 	for _, p := range snapshot {
-		if p.ctx.Err() != nil {
-			continue
-		}
 		wg.Add(1)
 		go func(p *promptRegistration) {
+			defer p.inflight.Done()
 			defer wg.Done()
 			if tryPassphraseAgainstSlots(p.ctx, p.volumes, p.d, p.checkSlots, password) {
 				mu.Lock()
@@ -850,19 +862,6 @@ func tryCachedPassphrases(ctx context.Context, volumes chan *luks.Volume, d luks
 }
 
 func requestKeyboardPassword(ctx context.Context, volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, maxTries int) {
-	// Register this prompt so out-of-band sources (SSH remote unlock) can
-	// submit against the same device. Done before the plymouth-init wait
-	// so a remote unlock can race ahead of the splash coming up.
-	reg := &promptRegistration{
-		ctx:         ctx,
-		volumes:     volumes,
-		d:           d,
-		checkSlots:  checkSlots,
-		mappingName: mappingName,
-	}
-	registerPendingPrompt(reg)
-	defer unregisterPendingPrompt(reg)
-
 	// Wait for plymouth initialization to complete before attempting to use
 	// it. Without this, udev events can trigger LUKS password prompts while
 	// plymouthd is still starting, causing the graphical prompt to fail.
@@ -1144,6 +1143,25 @@ func luksOpen(dev string, mapping *luksMapping) error {
 		}
 	}
 
+	// Register the passphrase target for the full lifetime of luksOpen so
+	// out-of-band sources (SSH remote unlock) can submit a passphrase against
+	// the passphrase slots concurrently with token attempts — not gated behind
+	// tokenWg.Wait() like the local keyboard prompt. A successful out-of-band
+	// unlock cancels ctx, which dismisses any in-flight token / keyboard
+	// prompt via the existing ctx-cancellation path.
+	var reg *promptRegistration
+	if len(checkSlotsWithPassword) > 0 {
+		reg = &promptRegistration{
+			ctx:         ctx,
+			volumes:     volumes,
+			d:           d,
+			checkSlots:  checkSlotsWithPassword,
+			mappingName: mapping.name,
+		}
+		registerPendingPrompt(reg)
+		defer unregisterPendingPrompt(reg)
+	}
+
 	// Start keyboard/keyfile unlock after all token goroutines finish (or tokenTimeout
 	// elapses). This gives hardware tokens priority over the keyboard prompt.
 	// senderWg ensures volumes is closed if this goroutine is the last sender.
@@ -1174,6 +1192,19 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	// after a priority token already signalled success.
 	go func() {
 		senderWg.Wait()
+		// Race fence: remove the registration so no new submitter can grab
+		// this entry, then wait for already-snapshotted submitters to finish
+		// their UnsealVolume + channel send. Without this, an in-flight SSH
+		// submission whose UnsealVolume succeeds after close(volumes) would
+		// panic pid 1 with "send on closed channel" at tryPassphraseAgainstSlots.
+		// Skipped when reg is nil (no passphrase slots — no OOB submitter
+		// can target this device).
+		if reg != nil {
+			pendingPrompts.Lock()
+			delete(pendingPrompts.entries, reg)
+			pendingPrompts.Unlock()
+			reg.inflight.Wait()
+		}
 		select {
 		case <-ctx.Done():
 			// Already unlocked — volumes will drain naturally.

--- a/init/luks.go
+++ b/init/luks.go
@@ -97,7 +97,14 @@ var pendingPrompts struct {
 }
 
 type promptRegistration struct {
-	ctx         context.Context
+	ctx context.Context
+	// cancel is luksOpen's own cancel — calling it ends this device's unlock
+	// orchestration (same effect as a token-success cancel). SSH submissions
+	// invoke it after a successful UnsealVolume so pendingDeviceNames stops
+	// listing the device on the very next prompt-loop iteration. Without it,
+	// the entry lingers until luksOpen returns past SetupMapper (~tens of ms),
+	// and the next prompt redundantly names the already-unlocked device.
+	cancel      context.CancelFunc
 	volumes     chan *luks.Volume
 	d           luks.Device
 	checkSlots  []int
@@ -161,6 +168,12 @@ func trySubmitPassphraseToPending(password []byte) []string {
 		wg.Go(func() {
 			defer p.inflight.Done()
 			if tryPassphraseAgainstSlots(p.ctx, p.volumes, p.d, p.checkSlots, password) {
+				// Dismiss this device's unlock orchestration now that the
+				// volume is in hand — mirrors the token-success cancel.
+				// pendingDeviceNames filters by ctx.Err(), so the next
+				// sshPromptLoop iteration won't re-list this device while
+				// luksOpen is still finishing SetupMapper.
+				p.cancel()
 				mu.Lock()
 				unlocked = append(unlocked, p.mappingName)
 				mu.Unlock()
@@ -175,6 +188,24 @@ func trySubmitPassphraseToPending(password []byte) []string {
 		passphraseCache.Unlock()
 	}
 	return unlocked
+}
+
+// pendingDeviceNames returns a sorted snapshot of mapping names currently
+// registered for unlock whose ctx is still live. Used by the SSH prompt so
+// the operator can see which devices a submission will be broadcast against,
+// and so the loop can detect "everything unlocked" and disconnect cleanly.
+func pendingDeviceNames() []string {
+	pendingPrompts.Lock()
+	names := make([]string, 0, len(pendingPrompts.entries))
+	for p := range pendingPrompts.entries {
+		if p.ctx.Err() != nil {
+			continue
+		}
+		names = append(names, p.mappingName)
+	}
+	pendingPrompts.Unlock()
+	sort.Strings(names)
+	return names
 }
 
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
@@ -1151,6 +1182,7 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	if len(checkSlotsWithPassword) > 0 {
 		reg = &promptRegistration{
 			ctx:         ctx,
+			cancel:      cancel,
 			volumes:     volumes,
 			d:           d,
 			checkSlots:  checkSlotsWithPassword,

--- a/init/luks.go
+++ b/init/luks.go
@@ -86,6 +86,87 @@ var passphraseCache struct {
 // stored its passphrase.
 var keyboardMu sync.Mutex
 
+// pendingPrompts holds the set of keyboard prompts currently awaiting a
+// passphrase. Out-of-band password sources (SSH remote unlock) submit through
+// this registry so they share the unlock orchestration (ctx cancellation,
+// passphraseCache seeding) with the local keyboard path rather than walking
+// devices themselves.
+var pendingPrompts struct {
+	sync.Mutex
+	entries map[*promptRegistration]struct{}
+}
+
+type promptRegistration struct {
+	ctx         context.Context
+	volumes     chan *luks.Volume
+	d           luks.Device
+	checkSlots  []int
+	mappingName string
+}
+
+func registerPendingPrompt(p *promptRegistration) {
+	pendingPrompts.Lock()
+	defer pendingPrompts.Unlock()
+	if pendingPrompts.entries == nil {
+		pendingPrompts.entries = make(map[*promptRegistration]struct{})
+	}
+	pendingPrompts.entries[p] = struct{}{}
+}
+
+func unregisterPendingPrompt(p *promptRegistration) {
+	pendingPrompts.Lock()
+	defer pendingPrompts.Unlock()
+	delete(pendingPrompts.entries, p)
+}
+
+// trySubmitPassphraseToPending tries password against every currently-pending
+// keyboard prompt and returns the names of devices that unlocked. UnsealVolume
+// is dispatched in parallel — argon2 KDF runs concurrently across devices
+// rather than serially, so a single submission against N volumes finishes in
+// ~one KDF window instead of N. Without this, the keyboard prompt for a
+// not-yet-attempted device briefly displays while SSH works through the rest
+// of the queue.
+//
+// The passphrase is appended to passphraseCache when at least one device
+// matches, so subsequent volumes with the same key (e.g. btrfs RAID1 members)
+// unlock without further prompts.
+func trySubmitPassphraseToPending(password []byte) []string {
+	pendingPrompts.Lock()
+	snapshot := make([]*promptRegistration, 0, len(pendingPrompts.entries))
+	for p := range pendingPrompts.entries {
+		snapshot = append(snapshot, p)
+	}
+	pendingPrompts.Unlock()
+
+	var (
+		mu       sync.Mutex
+		unlocked []string
+		wg       sync.WaitGroup
+	)
+	for _, p := range snapshot {
+		if p.ctx.Err() != nil {
+			continue
+		}
+		wg.Add(1)
+		go func(p *promptRegistration) {
+			defer wg.Done()
+			if tryPassphraseAgainstSlots(p.ctx, p.volumes, p.d, p.checkSlots, password) {
+				mu.Lock()
+				unlocked = append(unlocked, p.mappingName)
+				mu.Unlock()
+			}
+		}(p)
+	}
+	wg.Wait()
+
+	if len(unlocked) > 0 {
+		passphraseCache.Lock()
+		passphraseCache.passwords = append(passphraseCache.passwords, password)
+		passphraseCache.Unlock()
+	}
+	return unlocked
+}
+
 // rd luks options match systemd naming https://www.freedesktop.org/software/systemd/man/crypttab.html
 var rdLuksOptions = map[string]string{
 	"discard":                luks.FlagAllowDiscards,
@@ -769,6 +850,19 @@ func tryCachedPassphrases(ctx context.Context, volumes chan *luks.Volume, d luks
 }
 
 func requestKeyboardPassword(ctx context.Context, volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, maxTries int) {
+	// Register this prompt so out-of-band sources (SSH remote unlock) can
+	// submit against the same device. Done before the plymouth-init wait
+	// so a remote unlock can race ahead of the splash coming up.
+	reg := &promptRegistration{
+		ctx:         ctx,
+		volumes:     volumes,
+		d:           d,
+		checkSlots:  checkSlots,
+		mappingName: mappingName,
+	}
+	registerPendingPrompt(reg)
+	defer unregisterPendingPrompt(reg)
+
 	// Wait for plymouth initialization to complete before attempting to use
 	// it. Without this, udev events can trigger LUKS password prompts while
 	// plymouthd is still starting, causing the graphical prompt to fail.

--- a/init/luks.go
+++ b/init/luks.go
@@ -158,16 +158,14 @@ func trySubmitPassphraseToPending(password []byte) []string {
 		wg       sync.WaitGroup
 	)
 	for _, p := range snapshot {
-		wg.Add(1)
-		go func(p *promptRegistration) {
+		wg.Go(func() {
 			defer p.inflight.Done()
-			defer wg.Done()
 			if tryPassphraseAgainstSlots(p.ctx, p.volumes, p.d, p.checkSlots, password) {
 				mu.Lock()
 				unlocked = append(unlocked, p.mappingName)
 				mu.Unlock()
 			}
-		}(p)
+		})
 	}
 	wg.Wait()
 

--- a/init/luks_test.go
+++ b/init/luks_test.go
@@ -498,6 +498,7 @@ func TestTrySubmitPassphraseToPendingHoldsInflight(t *testing.T) {
 	volumes := make(chan *luks.Volume, 1)
 	reg := &promptRegistration{
 		ctx:         context.Background(),
+		cancel:      func() {},
 		volumes:     volumes,
 		d:           fake,
 		checkSlots:  []int{0},
@@ -547,4 +548,49 @@ func TestTrySubmitPassphraseToPendingHoldsInflight(t *testing.T) {
 
 	<-submitDone
 	require.Len(t, volumes, 1, "volume should have been sent on the channel")
+}
+
+// TestTrySubmitPassphraseCancelsRegistrationOnSuccess pins that a successful
+// SSH submission cancels the unlocked device's ctx synchronously — before
+// trySubmitPassphraseToPending returns. Without this, sshPromptLoop's next
+// pendingDeviceNames() snapshot still lists the just-unlocked device for the
+// window between volume-send and luksOpen's deferred unregister, and the
+// operator sees the already-unlocked mapping name on the reprompt.
+//
+// Property: after a successful submission, pendingDeviceNames() must not
+// include the unlocked entry, because ctx.Err() is non-nil. Removing
+// p.cancel() from trySubmitPassphraseToPending's success branch fails this.
+func TestTrySubmitPassphraseCancelsRegistrationOnSuccess(t *testing.T) {
+	withPendingPrompts(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	fake := &fenceFakeLuksDevice{
+		unseal: func(_ int, _ []byte) (*luks.Volume, error) {
+			return &luks.Volume{}, nil
+		},
+	}
+	// Buffered so the send in tryPassphraseAgainstSlots completes without a
+	// luksOpen-style consumer.
+	volumes := make(chan *luks.Volume, 1)
+	reg := &promptRegistration{
+		ctx:         ctx,
+		cancel:      cancel,
+		volumes:     volumes,
+		d:           fake,
+		checkSlots:  []int{0},
+		mappingName: "cancel-on-success",
+	}
+	registerPendingPrompt(reg)
+
+	unlocked := trySubmitPassphraseToPending([]byte("anything"))
+	require.Equal(t, []string{"cancel-on-success"}, unlocked)
+
+	require.Error(t, reg.ctx.Err(),
+		"ctx must be cancelled by trySubmitPassphraseToPending on success")
+
+	names := pendingDeviceNames()
+	require.NotContains(t, names, "cancel-on-success",
+		"pendingDeviceNames must drop entries whose ctx is cancelled")
 }

--- a/init/luks_test.go
+++ b/init/luks_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -8,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anatol/luks.go"
 	"github.com/google/go-tpm/tpmutil"
 	"github.com/stretchr/testify/require"
 )
@@ -363,4 +365,186 @@ func TestPendingPromptsConcurrent(t *testing.T) {
 		delete(pendingPrompts.entries, r)
 	}
 	pendingPrompts.Unlock()
+}
+
+// TestPendingPromptsInflightFence pins the race fence that prevents
+// luksOpen's watcher from closing the volumes channel while an SSH
+// submission is mid-UnsealVolume.
+//
+// Without this fence the bug is: senderWg.Wait() returns (all in-band
+// senders gave up), watcher calls close(volumes), an SSH goroutine that
+// snapshot-grabbed the entry under pendingPrompts.Lock a moment earlier
+// then completes its UnsealVolume and reaches tryPassphraseAgainstSlots's
+// `case volumes <- v:` — panic "send on closed channel" in pid 1.
+//
+// The fence is two coordinated mutations:
+//   - trySubmitPassphraseToPending Add()s to reg.inflight inside the same
+//     critical section that iterates pendingPrompts.entries.
+//   - The watcher first removes reg from pendingPrompts.entries (blocking
+//     new snapshots from picking us up), then waits on reg.inflight before
+//     closing volumes.
+//
+// This test mirrors both halves directly and asserts the watcher blocks
+// for as long as a snapshotted submitter has not yet completed.
+func TestPendingPromptsInflightFence(t *testing.T) {
+	withPendingPrompts(t)
+
+	reg := &promptRegistration{
+		ctx:         context.Background(),
+		mappingName: "fence-test",
+	}
+	registerPendingPrompt(reg)
+
+	// Submitter snapshot — same critical-section shape as
+	// trySubmitPassphraseToPending. Add to inflight under the lock so the
+	// watcher cannot remove-and-wait while a new submitter is still
+	// transitioning from "saw the entry" to "Add(1)".
+	pendingPrompts.Lock()
+	snapshot := make([]*promptRegistration, 0, len(pendingPrompts.entries))
+	for p := range pendingPrompts.entries {
+		require.NoError(t, p.ctx.Err())
+		p.inflight.Add(1)
+		snapshot = append(snapshot, p)
+	}
+	pendingPrompts.Unlock()
+	require.Len(t, snapshot, 1)
+
+	// Watcher role: delete the entry under the lock, then wait for any
+	// already-snapshotted submitter to drain. Must block — we haven't
+	// called Done yet.
+	watcherDone := make(chan struct{})
+	go func() {
+		pendingPrompts.Lock()
+		delete(pendingPrompts.entries, reg)
+		pendingPrompts.Unlock()
+		reg.inflight.Wait()
+		close(watcherDone)
+	}()
+
+	select {
+	case <-watcherDone:
+		t.Fatal("watcher unblocked before submitter's inflight reference released — fence missing")
+	case <-time.After(100 * time.Millisecond):
+		// expected: watcher must wait
+	}
+
+	// The watcher must have removed the entry before waiting so a later
+	// submitter cannot snapshot a now-doomed registration.
+	pendingPrompts.Lock()
+	_, present := pendingPrompts.entries[reg]
+	pendingPrompts.Unlock()
+	require.False(t, present, "watcher should have removed entry before waiting on inflight")
+
+	// Submitter completes its UnsealVolume + channel send. Watcher must
+	// unblock immediately after.
+	reg.inflight.Done()
+
+	select {
+	case <-watcherDone:
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not unblock after inflight reached zero")
+	}
+}
+
+// fenceFakeLuksDevice satisfies luks.Device for the production-path fence
+// test. Only UnsealVolume is exercised; everything else is a no-op stub.
+type fenceFakeLuksDevice struct {
+	unseal func(keyslot int, passphrase []byte) (*luks.Volume, error)
+}
+
+func (f *fenceFakeLuksDevice) UnsealVolume(keyslot int, passphrase []byte) (*luks.Volume, error) {
+	return f.unseal(keyslot, passphrase)
+}
+func (f *fenceFakeLuksDevice) Close() error                                              { return nil }
+func (f *fenceFakeLuksDevice) Version() int                                              { return 2 }
+func (f *fenceFakeLuksDevice) Path() string                                              { return "/dev/fake" }
+func (f *fenceFakeLuksDevice) UUID() string                                              { return "" }
+func (f *fenceFakeLuksDevice) Slots() []int                                              { return []int{0} }
+func (f *fenceFakeLuksDevice) Tokens() ([]luks.Token, error)                             { return nil, nil }
+func (f *fenceFakeLuksDevice) FlagsGet() []string                                        { return nil }
+func (f *fenceFakeLuksDevice) FlagsAdd(flags ...string) error                            { return nil }
+func (f *fenceFakeLuksDevice) FlagsClear()                                               {}
+func (f *fenceFakeLuksDevice) Unlock(keyslot int, passphrase []byte, dmName string) error {
+	return nil
+}
+func (f *fenceFakeLuksDevice) UnlockAny(passphrase []byte, dmName string) error { return nil }
+
+// TestTrySubmitPassphraseToPendingHoldsInflight pins that the production
+// trySubmitPassphraseToPending bumps reg.inflight before UnsealVolume runs
+// and only releases it after the dispatched goroutine completes. This is
+// the producer half of the race fence (TestPendingPromptsInflightFence
+// covers the synchronization property; this test catches future regressions
+// that drop the Add(1) or move the Done() earlier).
+func TestTrySubmitPassphraseToPendingHoldsInflight(t *testing.T) {
+	withPendingPrompts(t)
+
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	fake := &fenceFakeLuksDevice{
+		unseal: func(_ int, _ []byte) (*luks.Volume, error) {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release
+			return &luks.Volume{}, nil
+		},
+	}
+
+	// Buffered so tryPassphraseAgainstSlots's `case volumes <- v:` sends
+	// without needing a consumer goroutine; we're testing the inflight
+	// lifecycle, not the unlock-orchestration consumer side.
+	volumes := make(chan *luks.Volume, 1)
+	reg := &promptRegistration{
+		ctx:         context.Background(),
+		volumes:     volumes,
+		d:           fake,
+		checkSlots:  []int{0},
+		mappingName: "producer-test",
+	}
+	registerPendingPrompt(reg)
+
+	submitDone := make(chan struct{})
+	go func() {
+		defer close(submitDone)
+		trySubmitPassphraseToPending([]byte("any"))
+	}()
+
+	// Wait for UnsealVolume to enter — by which point trySubmitPassphraseToPending
+	// has already taken the pendingPrompts lock, called Add(1), released the
+	// lock, and dispatched the inner goroutine.
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("UnsealVolume never entered; trySubmitPassphraseToPending stalled")
+	}
+
+	// inflight must be >0 — verify by spawning a Wait()er and asserting it
+	// blocks while UnsealVolume is hung.
+	waitDone := make(chan struct{})
+	go func() {
+		reg.inflight.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+		t.Fatal("reg.inflight at zero while UnsealVolume hung — Add(1) missing or Done() premature")
+	case <-time.After(100 * time.Millisecond):
+		// expected
+	}
+
+	// Let UnsealVolume return. The dispatched goroutine's deferred Done()
+	// drops inflight to zero; our Wait()er unblocks.
+	close(release)
+
+	select {
+	case <-waitDone:
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("inflight did not drop to zero after UnsealVolume returned")
+	}
+
+	<-submitDone
+	require.Len(t, volumes, 1, "volume should have been sent on the channel")
 }

--- a/init/luks_test.go
+++ b/init/luks_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"sync"
 	"testing"
 	"time"
 
@@ -281,4 +282,85 @@ func TestUnreachableMapperName(t *testing.T) {
 			require.Equal(t, tc.wantName, name)
 		})
 	}
+}
+
+// withPendingPrompts isolates the pendingPrompts global across tests so a
+// failure in one case doesn't leave stale registrations visible to another.
+func withPendingPrompts(t *testing.T) {
+	t.Helper()
+	pendingPrompts.Lock()
+	orig := pendingPrompts.entries
+	pendingPrompts.entries = nil
+	pendingPrompts.Unlock()
+	t.Cleanup(func() {
+		pendingPrompts.Lock()
+		pendingPrompts.entries = orig
+		pendingPrompts.Unlock()
+	})
+}
+
+func TestPendingPromptsRegistry(t *testing.T) {
+	withPendingPrompts(t)
+
+	a := &promptRegistration{mappingName: "alpha"}
+	b := &promptRegistration{mappingName: "beta"}
+
+	registerPendingPrompt(a)
+	registerPendingPrompt(b)
+
+	pendingPrompts.Lock()
+	require.Equal(t, 2, len(pendingPrompts.entries))
+	pendingPrompts.Unlock()
+
+	unregisterPendingPrompt(a)
+	pendingPrompts.Lock()
+	_, hasA := pendingPrompts.entries[a]
+	_, hasB := pendingPrompts.entries[b]
+	pendingPrompts.Unlock()
+	require.False(t, hasA, "alpha should have been removed")
+	require.True(t, hasB, "beta should remain")
+
+	// unregistering an unknown entry must be a no-op
+	unregisterPendingPrompt(&promptRegistration{mappingName: "ghost"})
+	pendingPrompts.Lock()
+	require.Equal(t, 1, len(pendingPrompts.entries))
+	pendingPrompts.Unlock()
+}
+
+func TestPendingPromptsConcurrent(t *testing.T) {
+	// Hammer the registry from multiple goroutines so -race can flag any
+	// missing locking. The registry backs the SSH unlock path, where
+	// register/unregister races against trySubmitPassphraseToPending's
+	// snapshot are the primary concern.
+	withPendingPrompts(t)
+
+	const N = 200
+	regs := make([]*promptRegistration, N)
+	for i := range regs {
+		regs[i] = &promptRegistration{mappingName: "dev"}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for _, r := range regs {
+			registerPendingPrompt(r)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for _, r := range regs {
+			unregisterPendingPrompt(r)
+		}
+	}()
+	wg.Wait()
+
+	// Drain whatever's left so we don't leak into other tests; the exact
+	// residue is non-deterministic (races between register/unregister).
+	pendingPrompts.Lock()
+	for r := range pendingPrompts.entries {
+		delete(pendingPrompts.entries, r)
+	}
+	pendingPrompts.Unlock()
 }

--- a/init/main.go
+++ b/init/main.go
@@ -929,6 +929,7 @@ func switchRoot() error {
 func cleanup() {
 	close(udevQuitLoop)
 	udevConn.Close()
+	sshShutdown()
 	shutdownNetwork()
 }
 
@@ -1128,6 +1129,10 @@ func boost() error {
 		if err := os.MkdirAll("/dev/disk/by-"+by, 0o755); err != nil {
 			return err
 		}
+	}
+
+	if config.Network != nil && config.Network.SshAuthorizedKeys != "" {
+		go sshRun(config.Network)
 	}
 
 	go func() { check(scanSysModaliases()) }()

--- a/init/ssh.go
+++ b/init/ssh.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -197,10 +198,11 @@ func sshHandleSession(ch gossh.Channel, reqs <-chan *gossh.Request, remote net.A
 }
 
 // sshPromptLoop reads passphrases from the client and submits them against
-// any LUKS device currently waiting for keyboard input. Successes are
-// reported back; empty submissions reprompt for free; non-matching
-// submissions consume one attempt up to sshMaxPromptAttempts, after which
-// the session is disconnected.
+// every LUKS device currently waiting for unlock. The loop keeps running
+// until pendingPrompts drains (every device unlocked), the client
+// disconnects, or sshMaxPromptAttempts non-empty wrong submissions have
+// been made — so a single SSH session can serve multiple devices with
+// distinct passphrases instead of forcing a reconnect after each unlock.
 func sshPromptLoop(ch gossh.Channel, remote net.Addr) {
 	attempts := 0
 	for {
@@ -208,7 +210,12 @@ func sshPromptLoop(ch gossh.Channel, remote net.Addr) {
 			_, _ = io.WriteString(ch, "Too many attempts, disconnecting.\r\n")
 			return
 		}
-		_, err := io.WriteString(ch, "Enter passphrase: ")
+		names := pendingDeviceNames()
+		if len(names) == 0 {
+			_, _ = io.WriteString(ch, "All devices unlocked.\r\n")
+			return
+		}
+		_, err := io.WriteString(ch, "Enter passphrase for "+strings.Join(names, ", ")+": ")
 		if err != nil {
 			return
 		}
@@ -233,7 +240,7 @@ func sshPromptLoop(ch gossh.Channel, remote net.Addr) {
 				fmt.Fprintf(ch, "Unlocked: %s\r\n", name)
 				statusMessage(name + " unlocked via SSH")
 			}
-			return
+			continue
 		}
 		statusMessage("")
 		_, _ = io.WriteString(ch, "Passphrase did not unlock any device. Try again or disconnect.\r\n")

--- a/init/ssh.go
+++ b/init/ssh.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// sshHandshakeTimeout bounds how long a peer may hold a TCP connection open
+// before completing the SSH handshake. Without it a slow-loris client can
+// tie up goroutines until kernel TCP timeouts fire.
+const sshHandshakeTimeout = 15 * time.Second
+
+// sshMaxPromptAttempts caps wrong-passphrase tries per authenticated session.
+// Bounds online brute-force against LUKS keyslots if the operator's private
+// key has leaked. 10 is enough for human typos and well above what the unit
+// tests submit (1 empty + 1 wrong + 1 correct in the retry case).
+const sshMaxPromptAttempts = 10
+
+var (
+	sshState struct {
+		sync.Mutex
+		listener net.Listener
+		conns    []net.Conn
+		shutdown bool
+	}
+)
+
+// sshRun parses keys, starts the SSH listener, and accepts connections until
+// sshShutdown is called. Intended to be invoked as a goroutine.
+func sshRun(cfg *InitNetworkConfig) {
+	addr := cfg.SshListen
+	if addr == "" {
+		addr = ":22"
+	}
+
+	hostSigner, err := gossh.ParsePrivateKey([]byte(cfg.SshHostKey))
+	if err != nil {
+		warning("ssh: invalid host key: %v", err)
+		return
+	}
+
+	authKeys, err := parseAuthorizedKeys([]byte(cfg.SshAuthorizedKeys))
+	if err != nil {
+		warning("ssh: %v", err)
+		return
+	}
+	if len(authKeys) == 0 {
+		warning("ssh: no valid authorized keys, not starting server")
+		return
+	}
+
+	serverCfg := &gossh.ServerConfig{
+		// Cap auth attempts per connection (matches gossh's default but
+		// pinned explicitly so a future library change can't relax it
+		// silently). Total online brute-force = MaxAuthTries * reconnects.
+		MaxAuthTries: 6,
+		// Don't leak the Go toolchain in the SSH banner — default is
+		// "SSH-2.0-Go" which narrows targeting.
+		ServerVersion: "SSH-2.0-booster",
+		PublicKeyCallback: func(c gossh.ConnMetadata, key gossh.PublicKey) (*gossh.Permissions, error) {
+			for _, k := range authKeys {
+				if bytes.Equal(k.Marshal(), key.Marshal()) {
+					info("ssh: %s authenticated as %q", c.RemoteAddr(), c.User())
+					return nil, nil
+				}
+			}
+			return nil, fmt.Errorf("unknown public key")
+		},
+	}
+	serverCfg.AddHostKey(hostSigner)
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		warning("ssh: listen %s: %v", addr, err)
+		return
+	}
+
+	sshState.Lock()
+	if sshState.shutdown {
+		sshState.Unlock()
+		_ = listener.Close()
+		return
+	}
+	sshState.listener = listener
+	sshState.Unlock()
+
+	info("ssh: listening on %s", addr)
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if !errors.Is(err, net.ErrClosed) {
+				warning("ssh: accept: %v", err)
+			}
+			return
+		}
+		go sshHandleConn(conn, serverCfg)
+	}
+}
+
+// sshShutdown closes the listener and all live connections. Safe to call when
+// the server was never started.
+func sshShutdown() {
+	sshState.Lock()
+	sshState.shutdown = true
+	listener := sshState.listener
+	conns := sshState.conns
+	sshState.listener = nil
+	sshState.conns = nil
+	sshState.Unlock()
+
+	if listener != nil {
+		_ = listener.Close()
+	}
+	for _, c := range conns {
+		_ = c.Close()
+	}
+}
+
+func sshTrackConn(c net.Conn) bool {
+	sshState.Lock()
+	defer sshState.Unlock()
+	if sshState.shutdown {
+		return false
+	}
+	sshState.conns = append(sshState.conns, c)
+	return true
+}
+
+func sshHandleConn(rawConn net.Conn, cfg *gossh.ServerConfig) {
+	if !sshTrackConn(rawConn) {
+		_ = rawConn.Close()
+		return
+	}
+	defer rawConn.Close()
+
+	// Slow-loris guard: drop the connection if the handshake doesn't
+	// complete in sshHandshakeTimeout. Cleared on success so a live
+	// session is bound only by the per-session prompt cap and natural
+	// client disconnects.
+	_ = rawConn.SetDeadline(time.Now().Add(sshHandshakeTimeout))
+	conn, chans, reqs, err := gossh.NewServerConn(rawConn, cfg)
+	if err != nil {
+		debug("ssh: handshake from %s failed: %v", rawConn.RemoteAddr(), err)
+		return
+	}
+	_ = rawConn.SetDeadline(time.Time{})
+	defer conn.Close()
+	go gossh.DiscardRequests(reqs)
+
+	for newCh := range chans {
+		if newCh.ChannelType() != "session" {
+			_ = newCh.Reject(gossh.UnknownChannelType, "only session channels supported")
+			continue
+		}
+		ch, chReqs, err := newCh.Accept()
+		if err != nil {
+			debug("ssh: accept channel: %v", err)
+			continue
+		}
+		go sshHandleSession(ch, chReqs, conn.RemoteAddr())
+	}
+}
+
+// sshHandleSession waits for the client to send a shell, pty-req, or exec
+// request, then drives the passphrase prompt. Any other request type is
+// declined so the session is functionally restricted to the unlock flow.
+func sshHandleSession(ch gossh.Channel, reqs <-chan *gossh.Request, remote net.Addr) {
+	defer ch.Close()
+
+	started := false
+	for req := range reqs {
+		switch req.Type {
+		case "pty-req", "env":
+			_ = req.Reply(true, nil)
+		case "shell", "exec":
+			if started {
+				_ = req.Reply(false, nil)
+				continue
+			}
+			started = true
+			_ = req.Reply(true, nil)
+			sshPromptLoop(ch, remote)
+			// Inform the client we're done, then drain remaining requests.
+			_, _ = ch.SendRequest("exit-status", false, gossh.Marshal(struct{ Status uint32 }{0}))
+			return
+		default:
+			_ = req.Reply(false, nil)
+		}
+	}
+}
+
+// sshPromptLoop reads passphrases from the client and submits them against
+// any LUKS device currently waiting for keyboard input. Successes are
+// reported back; empty submissions reprompt for free; non-matching
+// submissions consume one attempt up to sshMaxPromptAttempts, after which
+// the session is disconnected.
+func sshPromptLoop(ch gossh.Channel, remote net.Addr) {
+	attempts := 0
+	for {
+		if attempts >= sshMaxPromptAttempts {
+			_, _ = io.WriteString(ch, "Too many attempts, disconnecting.\r\n")
+			return
+		}
+		_, err := io.WriteString(ch, "Enter passphrase: ")
+		if err != nil {
+			return
+		}
+		pass, err := sshReadLine(ch)
+		if err != nil {
+			return
+		}
+		if len(pass) == 0 {
+			continue
+		}
+		attempts++
+
+		// Pre-render a status message before the KDF starts so it's visible
+		// for the duration of the unlock attempt — the post-success message
+		// otherwise only renders for ~100ms before clearSplashStatusSync
+		// wipes it at switchRoot.
+		statusMessage("Unlocking via SSH...")
+		unlocked := trySubmitPassphraseToPending(pass)
+		if len(unlocked) > 0 {
+			for _, name := range unlocked {
+				info("ssh: %s unlocked %s", remote, name)
+				fmt.Fprintf(ch, "Unlocked: %s\r\n", name)
+				statusMessage(name + " unlocked via SSH")
+			}
+			return
+		}
+		statusMessage("")
+		_, _ = io.WriteString(ch, "No pending devices matched. Try again or disconnect.\r\n")
+	}
+}
+
+// sshReadLine reads one line of input from the SSH channel without echoing,
+// driving the same inputScanner FSM as the local console prompt
+// (init/console_input.go). Sharing the scanner keeps both unlock paths
+// byte-for-byte consistent: CSI/SS3/OSC/DCS escape sequences and
+// bracketed-paste markers are stripped, multi-byte UTF-8 codepoints are
+// reassembled across reads, and the line-editing keys (BS/DEL, Ctrl+U,
+// Ctrl+W) behave identically to typing at the local console.
+//
+// Two intentional differences from the console reader, both because SSH
+// is a different kind of connection than a local keyboard:
+//   - No echo: the console prints an asterisk per character as you type;
+//     over SSH we show nothing, so Tab (which toggles that masking on the
+//     console) does nothing here.
+//   - Ctrl+C: at the console the kernel turns Ctrl+C into a cancel signal
+//     before our code ever sees the key, so the console reader never has
+//     to handle it. SSH has no such kernel handling, so we watch for the
+//     Ctrl+C byte (0x03) ourselves and abort. The exception is pasted
+//     text: a 0x03 that arrives inside a paste is real content, not a
+//     cancel, so we leave it alone there.
+func sshReadLine(ch gossh.Channel) ([]byte, error) {
+	var buf []byte
+	var scanner inputScanner
+	one := make([]byte, 1)
+	for {
+		n, err := ch.Read(one)
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			continue
+		}
+		b := one[0]
+		if b == 0x03 && !scanner.inPaste { // Ctrl-C outside a paste aborts
+			return nil, errors.New("interrupted")
+		}
+		ev, chars := scanner.Feed(b)
+		switch ev {
+		case keyEnter:
+			_, _ = io.WriteString(ch, "\r\n")
+			return buf, nil
+		case keyEOF: // Ctrl-D: EOF on empty buffer, submit otherwise
+			if len(buf) == 0 {
+				return nil, errors.New("eof")
+			}
+			_, _ = io.WriteString(ch, "\r\n")
+			return buf, nil
+		case keyChar:
+			buf = append(buf, chars...)
+		case keyBackspace:
+			buf = trimLastCodepoint(buf)
+		case keyKillLine:
+			buf = buf[:0]
+		case keyKillWord:
+			buf, _ = killWord(buf)
+		case keyTab, keyNone:
+			// keyTab: mask toggle is a console-only affordance (no SSH echo).
+			// keyNone: byte consumed mid-sequence — nothing to emit.
+		}
+	}
+}
+
+// parseAuthorizedKeys parses an authorized_keys-format buffer into a slice of
+// public keys, skipping blank lines and comments. Invalid lines abort with an
+// error so misconfiguration is loud rather than silently weakening auth.
+func parseAuthorizedKeys(data []byte) ([]gossh.PublicKey, error) {
+	var keys []gossh.PublicKey
+	rest := data
+	for len(bytes.TrimSpace(rest)) > 0 {
+		key, _, _, next, err := gossh.ParseAuthorizedKey(rest)
+		if err != nil {
+			return nil, fmt.Errorf("authorized_keys: %v", err)
+		}
+		keys = append(keys, key)
+		rest = next
+	}
+	return keys, nil
+}

--- a/init/ssh.go
+++ b/init/ssh.go
@@ -236,7 +236,7 @@ func sshPromptLoop(ch gossh.Channel, remote net.Addr) {
 			return
 		}
 		statusMessage("")
-		_, _ = io.WriteString(ch, "No pending devices matched. Try again or disconnect.\r\n")
+		_, _ = io.WriteString(ch, "Passphrase did not unlock any device. Try again or disconnect.\r\n")
 	}
 }
 

--- a/init/ssh_test.go
+++ b/init/ssh_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
 
+	"github.com/anatol/luks.go"
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -127,25 +129,31 @@ func TestParseAuthorizedKeysSkipsGarbageBetweenValidKeys(t *testing.T) {
 // online oracle against LUKS keyslots whenever the operator's private
 // key has leaked.
 //
-// Setup: feed sshMaxPromptAttempts+5 non-empty wrong submissions and
-// assert exactly sshMaxPromptAttempts "Enter passphrase: " prompts are
-// emitted (one per attempt the loop processed) and the final output is
-// the "Too many attempts" disconnect line.
+// Setup: register one fake device whose UnsealVolume always reports
+// "passphrase does not match", feed sshMaxPromptAttempts+5 non-empty
+// wrong submissions, and assert exactly sshMaxPromptAttempts prompts
+// are emitted (one per attempt the loop processed) and the final output
+// is the "Too many attempts" disconnect line.
 func TestSshPromptLoopDisconnectsAfterMaxAttempts(t *testing.T) {
-	// Ensure pendingPrompts is empty so every submission returns
-	// no-unlock — otherwise we'd need a real LUKS device.
-	pendingPrompts.Lock()
-	saved := pendingPrompts.entries
-	pendingPrompts.entries = nil
-	pendingPrompts.Unlock()
-	t.Cleanup(func() {
-		pendingPrompts.Lock()
-		pendingPrompts.entries = saved
-		pendingPrompts.Unlock()
-	})
+	withPendingPrompts(t)
+
+	fake := &fenceFakeLuksDevice{
+		unseal: func(int, []byte) (*luks.Volume, error) {
+			return nil, luks.ErrPassphraseDoesNotMatch
+		},
+	}
+	reg := &promptRegistration{
+		ctx:         context.Background(),
+		cancel:      func() {},
+		volumes:     make(chan *luks.Volume, 1), // never sent on for this test
+		d:           fake,
+		checkSlots:  []int{0},
+		mappingName: "cap-test",
+	}
+	registerPendingPrompt(reg)
 
 	var input bytes.Buffer
-	for i := 0; i < sshMaxPromptAttempts+5; i++ {
+	for range sshMaxPromptAttempts + 5 {
 		input.WriteString("wrong\r")
 	}
 	ch := &fakeChannel{in: &input}
@@ -154,7 +162,7 @@ func TestSshPromptLoopDisconnectsAfterMaxAttempts(t *testing.T) {
 	sshPromptLoop(ch, addr)
 
 	got := ch.out.String()
-	gotPrompts := bytes.Count([]byte(got), []byte("Enter passphrase: "))
+	gotPrompts := bytes.Count([]byte(got), []byte("Enter passphrase for cap-test: "))
 	require.Equal(t, sshMaxPromptAttempts, gotPrompts,
 		"expected exactly sshMaxPromptAttempts prompts, got %d", gotPrompts)
 	require.Contains(t, got, "Too many attempts, disconnecting.",

--- a/init/ssh_test.go
+++ b/init/ssh_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// fakeChannel is a minimal gossh.Channel backed by an in-memory reader for
+// client input and a buffer capturing what the server writes back. Only the
+// methods sshReadLine touches are functional.
+type fakeChannel struct {
+	in  io.Reader
+	out bytes.Buffer
+}
+
+func (c *fakeChannel) Read(p []byte) (int, error)  { return c.in.Read(p) }
+func (c *fakeChannel) Write(p []byte) (int, error) { return c.out.Write(p) }
+func (c *fakeChannel) Close() error                { return nil }
+func (c *fakeChannel) CloseWrite() error           { return nil }
+func (c *fakeChannel) SendRequest(string, bool, []byte) (bool, error) {
+	return false, nil
+}
+func (c *fakeChannel) Stderr() io.ReadWriter { return &bytes.Buffer{} }
+
+// TestSshReadLineSharesScanner pins the payoff of routing SSH bytes through
+// the same inputScanner as the console: pasted escape/control bytes can't
+// corrupt a passphrase, edit keys work, and the two documented divergences
+// (Ctrl-C handling, paste-literal control bytes) behave as commented.
+func TestSshReadLineSharesScanner(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"plain line", "secret\r", "secret", false},
+		{"LF terminator", "secret\n", "secret", false},
+		{"arrow key stripped", "se\x1b[Dcret\r", "secret", false},
+		{"OSC sequence stripped", "se\x1b]0;title\x07cret\r", "secret", false},
+		{"backspace edits buffer", "sx\x7f\x7fecret\r", "ecret", false},
+		// User mistypes, backspaces to fix, finishes the correct passphrase:
+		// the submitted buffer must equal the real passphrase so it unlocks.
+		{"backspace corrects a typo (DEL)", "secX\x7fret\r", "secret", false},
+		{"backspace corrects a typo (BS 0x08)", "secX\x08ret\r", "secret", false},
+		{"backspace on empty buffer is harmless", "\x7f\x7fsecret\r", "secret", false},
+		{"ctrl-u kills line", "junk\x15secret\r", "secret", false},
+		{"utf-8 multibyte preserved", "café\r", "café", false},
+		{"bracketed paste keeps literal ctrl byte", "\x1b[200~pa\x03ss\x1b[201~\r", "pa\x03ss", false},
+		{"pasted passphrase then enter", "\x1b[200~Tr0ub4dor&3\x1b[201~\r", "Tr0ub4dor&3", false},
+		{"ctrl-c outside paste aborts", "abc\x03", "", true},
+		{"ctrl-d on empty aborts", "\x04", "", true},
+		{"ctrl-d with buffer submits", "secret\x04", "secret", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ch := &fakeChannel{in: bytes.NewReader([]byte(tc.input))}
+			got, err := sshReadLine(ch)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(got))
+		})
+	}
+}
+
+var _ gossh.Channel = (*fakeChannel)(nil)
+
+func TestParseAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+
+	// A valid ssh-ed25519 line for use across cases (public key only).
+	const validKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIaELDfV8WnFiKK9XyXkk3RYHpx9Lv2nGtPYGcEC91YE test@example"
+
+	for _, tc := range []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{"empty", "", 0, false},
+		{"whitespace only", "   \n\n  \t\n", 0, false},
+		{"single key with newline", validKey + "\n", 1, false},
+		{"single key no trailing newline", validKey, 1, false},
+		{"CRLF line endings", validKey + "\r\n" + validKey + "\r\n", 2, false},
+		{"two keys with comment between", validKey + "\n# comment\n" + validKey + "\n", 2, false},
+		{"trailing whitespace around key", "  " + validKey + "  \n", 1, false},
+		{"garbage line", "this is not a key\n", 0, true},
+		{"unknown key type", "ssh-unknown AAAAB3NzaC1yc2E= test\n", 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			keys, err := parseAuthorizedKeys([]byte(tc.input))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, len(keys), "expected %d key(s), got %d", tc.want, len(keys))
+		})
+	}
+}
+
+func TestParseAuthorizedKeysSkipsGarbageBetweenValidKeys(t *testing.T) {
+	// gossh.ParseAuthorizedKey follows sshd(8) and silently skips
+	// unparseable lines once at least one valid key has been seen. Pin
+	// that behavior so a stray bad line doesn't lock the user out.
+	t.Parallel()
+
+	const validKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIaELDfV8WnFiKK9XyXkk3RYHpx9Lv2nGtPYGcEC91YE test@example"
+	input := validKey + "\nthis is garbage\n" + validKey + "\n"
+	keys, err := parseAuthorizedKeys([]byte(input))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(keys))
+}
+
+// TestSshPromptLoopDisconnectsAfterMaxAttempts pins the per-session
+// brute-force bound. Without this cap, an authenticated peer can submit
+// arbitrarily many wrong passphrases over a single SSH session — an
+// online oracle against LUKS keyslots whenever the operator's private
+// key has leaked.
+//
+// Setup: feed sshMaxPromptAttempts+5 non-empty wrong submissions and
+// assert exactly sshMaxPromptAttempts "Enter passphrase: " prompts are
+// emitted (one per attempt the loop processed) and the final output is
+// the "Too many attempts" disconnect line.
+func TestSshPromptLoopDisconnectsAfterMaxAttempts(t *testing.T) {
+	// Ensure pendingPrompts is empty so every submission returns
+	// no-unlock — otherwise we'd need a real LUKS device.
+	pendingPrompts.Lock()
+	saved := pendingPrompts.entries
+	pendingPrompts.entries = nil
+	pendingPrompts.Unlock()
+	t.Cleanup(func() {
+		pendingPrompts.Lock()
+		pendingPrompts.entries = saved
+		pendingPrompts.Unlock()
+	})
+
+	var input bytes.Buffer
+	for i := 0; i < sshMaxPromptAttempts+5; i++ {
+		input.WriteString("wrong\r")
+	}
+	ch := &fakeChannel{in: &input}
+
+	addr := &fakeAddr{}
+	sshPromptLoop(ch, addr)
+
+	got := ch.out.String()
+	gotPrompts := bytes.Count([]byte(got), []byte("Enter passphrase: "))
+	require.Equal(t, sshMaxPromptAttempts, gotPrompts,
+		"expected exactly sshMaxPromptAttempts prompts, got %d", gotPrompts)
+	require.Contains(t, got, "Too many attempts, disconnecting.",
+		"loop should print the cap-reached message and return")
+}
+
+// fakeAddr satisfies net.Addr for sshPromptLoop's logging side-effects.
+type fakeAddr struct{}
+
+func (fakeAddr) Network() string { return "tcp" }
+func (fakeAddr) String() string  { return "127.0.0.1:0" }

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -101,6 +101,19 @@ var assetGenerators = map[string]assetGenerator{
 		"FS_UUID=f9bd37eb-607c-4123-ef51-5c79bdf13579",
 		"LUKS_PASSWORD=1234",
 	}},
+	// luks2.btrfs_raid1_distinct.img: like luks2.btrfs_raid1.img but the two
+	// LUKS2 members have DIFFERENT passphrases. Exercises the multi-device
+	// SSH unlock path where each member is unlocked by a separate
+	// submission; the boot sequence's waitForBtrfsDevicesReady ioctl gate
+	// keeps the SSH listener alive across both unlocks until btrfs
+	// assembles.
+	"luks2.btrfs_raid1_distinct.img": {"luks_btrfs_raid1_distinct.sh", []string{
+		"LUKS_UUID1=9b5d8ac8-342b-423d-b253-3d3a5403fee8",
+		"LUKS_UUID2=461f9179-04f9-4def-9731-ac1598824026",
+		"FS_UUID=aef9c3f8-2fbe-476f-b732-99f31226d601",
+		"LUKS_PASSWORD1=1111",
+		"LUKS_PASSWORD2=2222",
+	}},
 	"swap.raw":          {"swap.sh", nil},
 	"zfs.img":           {"zfs.sh", nil},
 	"zfs_encrypted.img": {"zfs.sh", []string{"ZFS_PASSPHRASE=encrypted"}},

--- a/tests/generators/luks_btrfs_raid1_distinct.sh
+++ b/tests/generators/luks_btrfs_raid1_distinct.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Creates a single GPT disk with two LUKS2 partitions, each wrapping one member
+# of a btrfs RAID1 volume.  Each partition has a DIFFERENT passphrase.
+#
+#   Partition 1: LUKS2, UUID=$LUKS_UUID1 (passphrase $LUKS_PASSWORD1) → btrfs RAID1 member
+#   Partition 2: LUKS2, UUID=$LUKS_UUID2 (passphrase $LUKS_PASSWORD2) → btrfs RAID1 member
+#   btrfs filesystem UUID: $FS_UUID
+#
+# Used by TestLuksBtrfsRaid1DistinctPass to verify the issue #283 scenario
+# where the two btrfs members do NOT share a passphrase: the passphrase cache
+# cannot help, so booster must prompt for each member separately (serialized,
+# not interleaved) and btrfs must still assemble once both are unlocked.
+#
+# Required env vars:
+#   OUTPUT         path for the disk image
+#   LUKS_UUID1     UUID of the first  LUKS2 container
+#   LUKS_UUID2     UUID of the second LUKS2 container
+#   FS_UUID        UUID of the btrfs filesystem spanning both containers
+#   LUKS_PASSWORD1 passphrase for the first  LUKS container
+#   LUKS_PASSWORD2 passphrase for the second LUKS container
+
+set -o errexit
+
+lodev=
+dir=
+MAPPER1="luks-btrfs1-${LUKS_UUID1}"
+MAPPER2="luks-btrfs2-${LUKS_UUID2}"
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  [ -n "${dir}" ] && { sudo umount "${dir}" 2>/dev/null; rm -rf "${dir}"; }
+  sudo cryptsetup close "${MAPPER1}" 2>/dev/null || true
+  sudo cryptsetup close "${MAPPER2}" 2>/dev/null || true
+  [ -n "${lodev}" ] && sudo losetup -d "${lodev}"
+}
+
+truncate --size 450M "${OUTPUT}"
+lodev=$(sudo losetup -f -P --show "${OUTPUT}" | grep -m1 '^/dev/')
+
+sudo parted -s "${lodev}" mklabel gpt \
+  mkpart member1 2MiB 224MiB \
+  mkpart member2 224MiB 446MiB
+
+sudo partprobe "${lodev}"
+sleep 0.5
+
+sudo cryptsetup luksFormat --uuid "${LUKS_UUID1}" --type luks2 "${lodev}p1" <<< "${LUKS_PASSWORD1}"
+sudo cryptsetup luksFormat --uuid "${LUKS_UUID2}" --type luks2 "${lodev}p2" <<< "${LUKS_PASSWORD2}"
+
+sudo cryptsetup open "${lodev}p1" "${MAPPER1}" <<< "${LUKS_PASSWORD1}"
+sudo cryptsetup open "${lodev}p2" "${MAPPER2}" <<< "${LUKS_PASSWORD2}"
+
+sudo mkfs.btrfs -f --uuid "${FS_UUID}" -d raid1 -m raid1 \
+  "/dev/mapper/${MAPPER1}" "/dev/mapper/${MAPPER2}"
+
+dir=$(mktemp -d)
+sudo mount "/dev/mapper/${MAPPER1}" "${dir}"
+sudo chown "${USER}" "${dir}"
+mkdir "${dir}/sbin"
+cp assets/init "${dir}/sbin/init"

--- a/tests/ssh_unlock_test.go
+++ b/tests/ssh_unlock_test.go
@@ -1,0 +1,545 @@
+package tests
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/ed25519"
+	"encoding/pem"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/anatol/vmtest"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// pickFreePort asks the kernel for an unused TCP port. We close the listener
+// immediately and hand the number to QEMU; there's an inherent race but the
+// window is tiny and these tests run serially.
+func pickFreePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+// generateSSHKeyPair returns PEM-encoded private key bytes plus the
+// OpenSSH authorized_keys line for the matching public key. Both halves of
+// the pair are ed25519.
+func generateSSHKeyPair(t *testing.T) (privPEM, authKeyLine []byte, signer gossh.Signer) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	block, err := gossh.MarshalPrivateKey(priv, "")
+	require.NoError(t, err)
+	privPEM = pem.EncodeToMemory(block)
+
+	sshPub, err := gossh.NewPublicKey(pub)
+	require.NoError(t, err)
+	authKeyLine = gossh.MarshalAuthorizedKey(sshPub)
+
+	signer, err = gossh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+	return
+}
+
+// TestSSHRemoteUnlock boots a LUKS2 root with SSH remote unlock enabled,
+// connects from the host through a QEMU port forward, sends the passphrase,
+// and verifies both the "Unlocked:" handshake and a normal boot completion.
+func TestSSHRemoteUnlock(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.img"))
+
+	tmp := t.TempDir()
+
+	// Server-side host key + client public key (written as authorized_keys).
+	hostPriv, _, _ := generateSSHKeyPair(t)
+	_, clientAuthLine, clientSigner := generateSSHKeyPair(t)
+
+	hostKeyPath := filepath.Join(tmp, "host_ed25519")
+	require.NoError(t, os.WriteFile(hostKeyPath, hostPriv, 0o600))
+	authKeysPath := filepath.Join(tmp, "authorized_keys")
+	require.NoError(t, os.WriteFile(authKeysPath, clientAuthLine, 0o600))
+
+	hostPort := pickFreePort(t)
+	const guestPort = 2222
+
+	vm, err := buildVmInstance(t, Opts{
+		disk: "assets/luks2.img",
+		// e1000 gives us a NIC inside early userspace; the booster init
+		// only includes network modules when they're explicitly requested
+		// or auto-detected, and we don't want to depend on host hardware.
+		modules:       "e1000",
+		enableNetwork: true,
+		useDhcp:       true,
+		params: []string{
+			"-nic", "user,id=n1,hostfwd=tcp::" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+		},
+		sshHostKeyPath:        hostKeyPath,
+		sshAuthorizedKeysPath: authKeysPath,
+		sshListen:             ":" + strconv.Itoa(guestPort),
+		kernelArgs: []string{
+			"rd.luks.name=639b8fdd-36ba-443e-be3e-e5b335935502=cryptroot",
+			"root=/dev/mapper/cryptroot",
+		},
+		// Network bring-up + DHCP can take noticeably longer than the
+		// 40s default before the SSH server is reachable.
+		vmTimeout: 90 * time.Second,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	// Wait for the LUKS prompt to appear on the console: that's our signal
+	// that the device is registered as "pending" and the SSH server has
+	// almost certainly bound its listener too.
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+
+	clientCfg := &gossh.ClientConfig{
+		User:            "root",
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(clientSigner)},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+
+	// Retry until QEMU's hostfwd is wired up and the guest is listening.
+	addr := "127.0.0.1:" + strconv.Itoa(hostPort)
+	var conn *gossh.Client
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		conn, err = gossh.Dial("tcp", addr, clientCfg)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "ssh.Dial never succeeded")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	defer conn.Close()
+
+	sess, err := conn.NewSession()
+	require.NoError(t, err)
+	defer sess.Close()
+
+	stdin, err := sess.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := sess.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, sess.Shell())
+
+	// The server writes "Enter passphrase: " then reads a CR/LF terminated
+	// line. Read until we see the prompt, send the passphrase, then look
+	// for "Unlocked: cryptroot" on the same channel.
+	br := bufio.NewReader(stdout)
+	require.NoError(t, readUntil(br, "Enter passphrase:", 15*time.Second))
+	_, err = io.WriteString(stdin, "1234\n")
+	require.NoError(t, err)
+	require.NoError(t, readUntil(br, "Unlocked: cryptroot", 15*time.Second))
+
+	// The session ends as soon as the server reports success, so we don't
+	// need to explicitly close stdin. The boot then proceeds to switch_root.
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestSSHRemoteUnlockMultiDeviceSharedPassphrase boots two LUKS volumes
+// with the same passphrase and verifies that a single SSH submission
+// unlocks both.
+func TestSSHRemoteUnlockMultiDeviceSharedPassphrase(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks1.img"))
+	require.NoError(t, checkAsset("assets/luks2.img"))
+
+	tmp := t.TempDir()
+
+	hostPriv, _, _ := generateSSHKeyPair(t)
+	_, clientAuthLine, clientSigner := generateSSHKeyPair(t)
+
+	hostKeyPath := filepath.Join(tmp, "host_ed25519")
+	require.NoError(t, os.WriteFile(hostKeyPath, hostPriv, 0o600))
+	authKeysPath := filepath.Join(tmp, "authorized_keys")
+	require.NoError(t, os.WriteFile(authKeysPath, clientAuthLine, 0o600))
+
+	hostPort := pickFreePort(t)
+	const guestPort = 2222
+
+	vm, err := buildVmInstance(t, Opts{
+		disks: []vmtest.QemuDisk{
+			{Path: "assets/luks2.img", Format: "raw"},
+			{Path: "assets/luks1.img", Format: "raw"},
+		},
+		modules:       "e1000",
+		enableNetwork: true,
+		useDhcp:       true,
+		params: []string{
+			"-nic", "user,id=n1,hostfwd=tcp::" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+		},
+		sshHostKeyPath:        hostKeyPath,
+		sshAuthorizedKeysPath: authKeysPath,
+		sshListen:             ":" + strconv.Itoa(guestPort),
+		kernelArgs: []string{
+			"rd.luks.name=639b8fdd-36ba-443e-be3e-e5b335935502=cryptroot",
+			"rd.luks.name=f0c89fd5-7e1e-4ecc-b310-8cd650bd5415=cryptdata",
+			"root=/dev/mapper/cryptroot",
+		},
+		vmTimeout: 90 * time.Second,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	// Wait until at least one device is prompting. Both should register
+	// in pendingPrompts before SSH submits, but we only need to observe
+	// one prompt to know the unlock path is live.
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for"))
+
+	clientCfg := &gossh.ClientConfig{
+		User:            "root",
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(clientSigner)},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+
+	addr := "127.0.0.1:" + strconv.Itoa(hostPort)
+	var conn *gossh.Client
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		conn, err = gossh.Dial("tcp", addr, clientCfg)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "ssh.Dial never succeeded")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	defer conn.Close()
+
+	sess, err := conn.NewSession()
+	require.NoError(t, err)
+	defer sess.Close()
+
+	stdin, err := sess.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := sess.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, sess.Shell())
+
+	br := bufio.NewReader(stdout)
+	require.NoError(t, readUntil(br, "Enter passphrase:", 15*time.Second))
+	_, err = io.WriteString(stdin, "1234\n")
+	require.NoError(t, err)
+
+	// One submission should produce two "Unlocked:" lines, one per
+	// registered device. Order is non-deterministic (map iteration).
+	require.NoError(t, readUntil(br, "Unlocked: ", 15*time.Second))
+	require.NoError(t, readUntil(br, "Unlocked: ", 15*time.Second))
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestSSHRemoteUnlockRejectsWrongClientKey verifies that a client whose
+// public key isn't in authorized_keys cannot complete SSH auth — pubkey-only
+// gate has to actually reject unknown keys, not just prefer authorized ones.
+func TestSSHRemoteUnlockRejectsWrongClientKey(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.img"))
+
+	tmp := t.TempDir()
+	hostPriv, _, _ := generateSSHKeyPair(t)
+	// Only the *first* client's public key is written into authorized_keys.
+	_, authorizedAuthLine, _ := generateSSHKeyPair(t)
+	// The *second* client (signer) is unauthorized; this is the one we dial.
+	_, _, unauthorizedSigner := generateSSHKeyPair(t)
+
+	hostKeyPath := filepath.Join(tmp, "host_ed25519")
+	require.NoError(t, os.WriteFile(hostKeyPath, hostPriv, 0o600))
+	authKeysPath := filepath.Join(tmp, "authorized_keys")
+	require.NoError(t, os.WriteFile(authKeysPath, authorizedAuthLine, 0o600))
+
+	hostPort := pickFreePort(t)
+	const guestPort = 2222
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:          "assets/luks2.img",
+		modules:       "e1000",
+		enableNetwork: true,
+		useDhcp:       true,
+		params: []string{
+			"-nic", "user,id=n1,hostfwd=tcp::" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+		},
+		sshHostKeyPath:        hostKeyPath,
+		sshAuthorizedKeysPath: authKeysPath,
+		sshListen:             ":" + strconv.Itoa(guestPort),
+		kernelArgs: []string{
+			"rd.luks.name=639b8fdd-36ba-443e-be3e-e5b335935502=cryptroot",
+			"root=/dev/mapper/cryptroot",
+		},
+		vmTimeout: 60 * time.Second,
+	})
+	require.NoError(t, err)
+	defer vm.Kill()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+
+	clientCfg := &gossh.ClientConfig{
+		User:            "root",
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(unauthorizedSigner)},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+
+	addr := "127.0.0.1:" + strconv.Itoa(hostPort)
+	deadline := time.Now().Add(45 * time.Second)
+	var dialErr error
+	for {
+		_, dialErr = gossh.Dial("tcp", addr, clientCfg)
+		// We expect failure; once we see a "permission denied" / "no auth
+		// methods" error we know the guest server rejected us properly.
+		if dialErr != nil && (bytes.Contains([]byte(dialErr.Error()), []byte("unable to authenticate")) ||
+			bytes.Contains([]byte(dialErr.Error()), []byte("no supported methods")) ||
+			bytes.Contains([]byte(dialErr.Error()), []byte("handshake failed"))) {
+			return
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.Error(t, dialErr, "ssh.Dial unexpectedly succeeded with an unauthorized client key")
+	require.Failf(t, "auth rejection check exhausted", "last error: %v", dialErr)
+}
+
+// TestSSHRemoteUnlockRetryThenUnlock walks the prompt-loop retry paths:
+// empty submission reprompts, wrong passphrase is reported, then the
+// correct passphrase unlocks. All in a single SSH session.
+func TestSSHRemoteUnlockRetryThenUnlock(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.img"))
+
+	tmp := t.TempDir()
+	hostPriv, _, _ := generateSSHKeyPair(t)
+	_, clientAuthLine, clientSigner := generateSSHKeyPair(t)
+
+	hostKeyPath := filepath.Join(tmp, "host_ed25519")
+	require.NoError(t, os.WriteFile(hostKeyPath, hostPriv, 0o600))
+	authKeysPath := filepath.Join(tmp, "authorized_keys")
+	require.NoError(t, os.WriteFile(authKeysPath, clientAuthLine, 0o600))
+
+	hostPort := pickFreePort(t)
+	const guestPort = 2222
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:          "assets/luks2.img",
+		modules:       "e1000",
+		enableNetwork: true,
+		useDhcp:       true,
+		params: []string{
+			"-nic", "user,id=n1,hostfwd=tcp::" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+		},
+		sshHostKeyPath:        hostKeyPath,
+		sshAuthorizedKeysPath: authKeysPath,
+		sshListen:             ":" + strconv.Itoa(guestPort),
+		kernelArgs: []string{
+			"rd.luks.name=639b8fdd-36ba-443e-be3e-e5b335935502=cryptroot",
+			"root=/dev/mapper/cryptroot",
+		},
+		vmTimeout: 90 * time.Second,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for cryptroot:"))
+
+	clientCfg := &gossh.ClientConfig{
+		User:            "root",
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(clientSigner)},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+
+	addr := "127.0.0.1:" + strconv.Itoa(hostPort)
+	var conn *gossh.Client
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		conn, err = gossh.Dial("tcp", addr, clientCfg)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "ssh.Dial never succeeded")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	defer conn.Close()
+
+	sess, err := conn.NewSession()
+	require.NoError(t, err)
+	defer sess.Close()
+
+	stdin, err := sess.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := sess.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, sess.Shell())
+
+	br := bufio.NewReader(stdout)
+	require.NoError(t, readUntil(br, "Enter passphrase:", 15*time.Second))
+
+	// Empty submission — server's prompt-loop should treat zero-length input
+	// as a no-op and reprompt without trying to unlock anything.
+	_, err = io.WriteString(stdin, "\n")
+	require.NoError(t, err)
+	require.NoError(t, readUntil(br, "Enter passphrase:", 10*time.Second))
+
+	// Wrong passphrase — KDF runs but no slot matches; expect the "no
+	// pending devices matched" line plus another prompt.
+	_, err = io.WriteString(stdin, "wrongpass\n")
+	require.NoError(t, err)
+	require.NoError(t, readUntil(br, "No pending devices matched", 30*time.Second))
+	require.NoError(t, readUntil(br, "Enter passphrase:", 10*time.Second))
+
+	// Correct passphrase unlocks.
+	_, err = io.WriteString(stdin, "1234\n")
+	require.NoError(t, err)
+	require.NoError(t, readUntil(br, "Unlocked: cryptroot", 30*time.Second))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestSSHRemoteUnlockFido2Pending boots a LUKS volume whose only keyslot
+// carries both a passphrase and a fake systemd-fido2 token. The init starts
+// the FIDO2 attempt (which can't progress — no hidraw device matches the
+// random credential) while the SSH server listens. The host SSHes in mid-
+// FIDO2-wait and submits the passphrase; the concurrent passphrase path
+// (init/luks.go: registerPendingPrompt runs at luksOpen entry, not gated
+// behind tokenWg.Wait()) unlocks the slot and ctx-cancels the in-flight
+// FIDO2 goroutine. Hardware-independent: same fixture as TestCrypttabFido2NoDevice.
+func TestSSHRemoteUnlockFido2Pending(t *testing.T) {
+	if !fileExists(binariesDir + "/fido2plugin.so") {
+		t.Skip("fido2plugin.so not built (libfido2 may not be installed)")
+	}
+	require.NoError(t, checkAsset("assets/systemd-fido2-nodev.img"))
+
+	tmp := t.TempDir()
+
+	hostPriv, _, _ := generateSSHKeyPair(t)
+	_, clientAuthLine, clientSigner := generateSSHKeyPair(t)
+
+	hostKeyPath := filepath.Join(tmp, "host_ed25519")
+	require.NoError(t, os.WriteFile(hostKeyPath, hostPriv, 0o600))
+	authKeysPath := filepath.Join(tmp, "authorized_keys")
+	require.NoError(t, os.WriteFile(authKeysPath, clientAuthLine, 0o600))
+
+	// crypttab fido2-device=auto triggers the generator to auto-bundle
+	// fido2plugin.so and the init to attempt FIDO2 token unlock against the
+	// device. With no real key plugged in, recoverSystemdFido2Password blocks
+	// waiting for hidraw devices — that's the "pending" state we need.
+	crypttabPath := filepath.Join(tmp, "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"cryptroot UUID=a6cdb03e-ad77-440a-8a93-28ad97de3b00 none fido2-device=auto,x-initrd.attach\n",
+	), 0o644))
+
+	hostPort := pickFreePort(t)
+	const guestPort = 2222
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:          "assets/systemd-fido2-nodev.img",
+		modules:       "e1000",
+		enableNetwork: true,
+		useDhcp:       true,
+		params: []string{
+			"-nic", "user,id=n1,hostfwd=tcp::" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+		},
+		sshHostKeyPath:        hostKeyPath,
+		sshAuthorizedKeysPath: authKeysPath,
+		sshListen:             ":" + strconv.Itoa(guestPort),
+		crypttabFile:          crypttabPath,
+		kernelArgs:            []string{"root=UUID=0cb4665f-65a0-4acc-9710-05163af16f19"},
+		// token-timeout default is 30s; SSH must beat that to exercise the
+		// concurrent-with-token path. Allow generous headroom for DHCP +
+		// FIDO2-attempt warm-up before we dial.
+		vmTimeout: 120 * time.Second,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	// "Waiting for FIDO2 security key for cryptroot" is emitted from
+	// recoverSystemdFido2Password (init/luks.go) only after the device is
+	// registered in pendingPrompts and the FIDO2 token goroutine is running.
+	// Matching this confirms we're submitting during the token attempt, not
+	// after fallback to keyboard.
+	require.NoError(t, vm.ConsoleExpect("Waiting for FIDO2 security key for cryptroot"))
+
+	clientCfg := &gossh.ClientConfig{
+		User:            "root",
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(clientSigner)},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+
+	addr := "127.0.0.1:" + strconv.Itoa(hostPort)
+	var conn *gossh.Client
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		conn, err = gossh.Dial("tcp", addr, clientCfg)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "ssh.Dial never succeeded")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	defer conn.Close()
+
+	sess, err := conn.NewSession()
+	require.NoError(t, err)
+	defer sess.Close()
+
+	stdin, err := sess.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := sess.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, sess.Shell())
+
+	br := bufio.NewReader(stdout)
+	require.NoError(t, readUntil(br, "Enter passphrase:", 15*time.Second))
+	// systemd-fido2-nodev.img's keyslot 0 was formatted with passphrase 567.
+	_, err = io.WriteString(stdin, "567\n")
+	require.NoError(t, err)
+	require.NoError(t, readUntil(br, "Unlocked: cryptroot", 15*time.Second))
+
+	// Boot proceeds to switch_root. If the FIDO2 goroutine's ctx-cancel
+	// hadn't fired we'd hang here until token-timeout — passing "Hello,
+	// booster!" inside the vmTimeout confirms the cancellation path works.
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// readUntil drains the reader byte-by-byte until the needle appears as a
+// substring, or until the timeout fires. The SSH channel may pack the
+// prompt and response into the same read, so we can't rely on
+// ReadString('\n'). The read blocks if the server stalls — we guard
+// against that with a watchdog goroutine that closes the underlying
+// session via the passed-in cancel.
+func readUntil(br *bufio.Reader, needle string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	needleBytes := []byte(needle)
+	var seen []byte
+
+	for {
+		if time.Now().After(deadline) {
+			return io.EOF
+		}
+		b, err := br.ReadByte()
+		if err != nil {
+			return err
+		}
+		seen = append(seen, b)
+		if bytes.Contains(seen, needleBytes) {
+			return nil
+		}
+	}
+}

--- a/tests/ssh_unlock_test.go
+++ b/tests/ssh_unlock_test.go
@@ -135,11 +135,11 @@ func TestSSHRemoteUnlock(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sess.Shell())
 
-	// The server writes "Enter passphrase: " then reads a CR/LF terminated
-	// line. Read until we see the prompt, send the passphrase, then look
-	// for "Unlocked: cryptroot" on the same channel.
+	// The server writes "Enter passphrase for <device>: " then reads a
+	// CR/LF-terminated line. Read until we see the prompt, send the
+	// passphrase, then look for "Unlocked: cryptroot" on the same channel.
 	br := bufio.NewReader(stdout)
-	require.NoError(t, readUntil(br, "Enter passphrase:", 15*time.Second))
+	require.NoError(t, readUntil(br, "Enter passphrase for ", 15*time.Second))
 	_, err = io.WriteString(stdin, "1234\n")
 	require.NoError(t, err)
 	require.NoError(t, readUntil(br, "Unlocked: cryptroot", 15*time.Second))
@@ -231,7 +231,7 @@ func TestSSHRemoteUnlockMultiDeviceSharedPassphrase(t *testing.T) {
 	require.NoError(t, sess.Shell())
 
 	br := bufio.NewReader(stdout)
-	require.NoError(t, readUntil(br, "Enter passphrase:", 15*time.Second))
+	require.NoError(t, readUntil(br, "Enter passphrase for ", 15*time.Second))
 	_, err = io.WriteString(stdin, "1234\n")
 	require.NoError(t, err)
 
@@ -239,6 +239,227 @@ func TestSSHRemoteUnlockMultiDeviceSharedPassphrase(t *testing.T) {
 	// registered device. Order is non-deterministic (map iteration).
 	require.NoError(t, readUntil(br, "Unlocked: ", 15*time.Second))
 	require.NoError(t, readUntil(br, "Unlocked: ", 15*time.Second))
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestSSHRemoteUnlockBtrfsRaid1SharedPassphrase boots a btrfs RAID1 root
+// whose two members are each wrapped in LUKS2 with the same passphrase.
+// A single SSH submission unlocks both members via the broadcast path; the
+// boot sequence must then poll BTRFS_IOC_DEVICES_READY (init/main.go's
+// waitForBtrfsDevicesReady) until both mapper devices are present and the
+// kernel reports the array assembled, before mountRootFs proceeds. The SSH
+// listener must stay alive across that wait; if cleanup()/sshShutdown()
+// fired early the second member's mapper-creation event would race against
+// process replacement.
+//
+// Verifies the btrfs-multi-device wait gate: switch_root does NOT fire
+// when *root* is unlocked, only when *root mount succeeds*, which for
+// multi-device btrfs requires every member assembled.
+func TestSSHRemoteUnlockBtrfsRaid1SharedPassphrase(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.btrfs_raid1.img"))
+
+	tmp := t.TempDir()
+
+	hostPriv, _, _ := generateSSHKeyPair(t)
+	_, clientAuthLine, clientSigner := generateSSHKeyPair(t)
+
+	hostKeyPath := filepath.Join(tmp, "host_ed25519")
+	require.NoError(t, os.WriteFile(hostKeyPath, hostPriv, 0o600))
+	authKeysPath := filepath.Join(tmp, "authorized_keys")
+	require.NoError(t, os.WriteFile(authKeysPath, clientAuthLine, 0o600))
+
+	// Mark both members x-initrd.attach so the generator includes them in
+	// the image's /etc/crypttab. The SSH unlock then targets both via the
+	// pendingPrompts broadcast.
+	crypttabPath := filepath.Join(tmp, "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"luks-btrfs1 UUID=d7fb15c9-4e6a-4901-cd3f-3a579bdf1357 none x-initrd.attach\n"+
+			"luks-btrfs2 UUID=e8ac26da-5f7b-4012-de40-4b68ace02468 none x-initrd.attach\n",
+	), 0o644))
+
+	hostPort := pickFreePort(t)
+	const guestPort = 2222
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:          "assets/luks2.btrfs_raid1.img",
+		modules:       "e1000",
+		enableNetwork: true,
+		useDhcp:       true,
+		crypttabFile:  crypttabPath,
+		params: []string{
+			"-nic", "user,id=n1,hostfwd=tcp:127.0.0.1:" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+		},
+		sshHostKeyPath:        hostKeyPath,
+		sshAuthorizedKeysPath: authKeysPath,
+		sshListen:             ":" + strconv.Itoa(guestPort),
+		kernelArgs:            []string{"root=UUID=f9bd37eb-607c-4123-ef51-5c79bdf13579"},
+		vmTimeout:             120 * time.Second,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for"))
+
+	clientCfg := &gossh.ClientConfig{
+		User:            "root",
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(clientSigner)},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+
+	addr := "127.0.0.1:" + strconv.Itoa(hostPort)
+	var conn *gossh.Client
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		conn, err = gossh.Dial("tcp", addr, clientCfg)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "ssh.Dial never succeeded")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	defer conn.Close()
+
+	sess, err := conn.NewSession()
+	require.NoError(t, err)
+	defer sess.Close()
+
+	stdin, err := sess.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := sess.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, sess.Shell())
+
+	br := bufio.NewReader(stdout)
+	require.NoError(t, readUntil(br, "Enter passphrase for ", 15*time.Second))
+	_, err = io.WriteString(stdin, "1234\n")
+	require.NoError(t, err)
+
+	// One submission unlocks both members via broadcast — two "Unlocked:"
+	// lines, order non-deterministic. After both unlock, the SSH server's
+	// next iteration finds pendingPrompts empty and emits the drain line.
+	// The boot then blocks in waitForBtrfsDevicesReady until btrfs sees
+	// both members; SSH stays alive throughout.
+	require.NoError(t, readUntil(br, "Unlocked: ", 15*time.Second))
+	require.NoError(t, readUntil(br, "Unlocked: ", 15*time.Second))
+	require.NoError(t, readUntil(br, "All devices unlocked.", 15*time.Second))
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
+// TestSSHRemoteUnlockBtrfsRaid1DistinctPassphrase boots a btrfs RAID1 root
+// whose two LUKS members carry DIFFERENT passphrases. Sequential SSH
+// unlocks must both complete before btrfs assembles: the broadcast path
+// only unlocks one member per submission (the passphrase cache cannot
+// help cross-member here — distinct keys), so the SSH session must stay
+// alive across two prompts. waitForBtrfsDevicesReady (init/main.go:606)
+// is what keeps the boot sequence parked between the first and second
+// unlock — without it, switch_root would fire as soon as the first LUKS
+// member's mapper appeared (it never would in practice with btrfs, but
+// the gate is what makes the multi-device case work cleanly).
+//
+// This is the legitimate-multi-device-in-initramfs case the boot
+// sequence handles correctly. Non-root LUKS volumes on a non-multi-
+// device root (e.g. ext4 root + extra ext4-shaped LUKS partition) are
+// abandoned at switch_root and should be configured via post-boot
+// userspace crypttab instead — outside the scope of this test.
+func TestSSHRemoteUnlockBtrfsRaid1DistinctPassphrase(t *testing.T) {
+	require.NoError(t, checkAsset("assets/luks2.btrfs_raid1_distinct.img"))
+
+	tmp := t.TempDir()
+
+	hostPriv, _, _ := generateSSHKeyPair(t)
+	_, clientAuthLine, clientSigner := generateSSHKeyPair(t)
+
+	hostKeyPath := filepath.Join(tmp, "host_ed25519")
+	require.NoError(t, os.WriteFile(hostKeyPath, hostPriv, 0o600))
+	authKeysPath := filepath.Join(tmp, "authorized_keys")
+	require.NoError(t, os.WriteFile(authKeysPath, clientAuthLine, 0o600))
+
+	crypttabPath := filepath.Join(tmp, "crypttab")
+	require.NoError(t, os.WriteFile(crypttabPath, []byte(
+		"luks-btrfs1 UUID=9b5d8ac8-342b-423d-b253-3d3a5403fee8 none x-initrd.attach\n"+
+			"luks-btrfs2 UUID=461f9179-04f9-4def-9731-ac1598824026 none x-initrd.attach\n",
+	), 0o644))
+
+	hostPort := pickFreePort(t)
+	const guestPort = 2222
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:          "assets/luks2.btrfs_raid1_distinct.img",
+		modules:       "e1000",
+		enableNetwork: true,
+		useDhcp:       true,
+		crypttabFile:  crypttabPath,
+		params: []string{
+			"-nic", "user,id=n1,hostfwd=tcp:127.0.0.1:" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+		},
+		sshHostKeyPath:        hostKeyPath,
+		sshAuthorizedKeysPath: authKeysPath,
+		sshListen:             ":" + strconv.Itoa(guestPort),
+		kernelArgs:            []string{"root=UUID=aef9c3f8-2fbe-476f-b732-99f31226d601"},
+		vmTimeout:             180 * time.Second,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Enter passphrase for"))
+
+	clientCfg := &gossh.ClientConfig{
+		User:            "root",
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(clientSigner)},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+
+	addr := "127.0.0.1:" + strconv.Itoa(hostPort)
+	var conn *gossh.Client
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		conn, err = gossh.Dial("tcp", addr, clientCfg)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "ssh.Dial never succeeded")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	defer conn.Close()
+
+	sess, err := conn.NewSession()
+	require.NoError(t, err)
+	defer sess.Close()
+
+	stdin, err := sess.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := sess.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, sess.Shell())
+
+	br := bufio.NewReader(stdout)
+
+	// First prompt should name both members (order: alphabetical via
+	// pendingDeviceNames' sort). luks-btrfs1 < luks-btrfs2.
+	require.NoError(t, readUntil(br, "Enter passphrase for luks-btrfs1, luks-btrfs2:", 15*time.Second))
+
+	// Submit passphrase for member 1 ("1111"). Broadcast tries against
+	// both; only member 1's slot matches. SSH session continues
+	// (cb07ce3 + cancel-on-success), reprompts with just member 2.
+	_, err = io.WriteString(stdin, "1111\n")
+	require.NoError(t, err)
+	require.NoError(t, readUntil(br, "Unlocked: luks-btrfs1", 30*time.Second))
+	require.NoError(t, readUntil(br, "Enter passphrase for luks-btrfs2:", 15*time.Second))
+
+	// Submit member 2's passphrase ("2222"). Both members now unlocked;
+	// btrfs's BTRFS_IOC_DEVICES_READY ioctl transitions to ready; root
+	// mounts; switch_root fires.
+	_, err = io.WriteString(stdin, "2222\n")
+	require.NoError(t, err)
+	require.NoError(t, readUntil(br, "Unlocked: luks-btrfs2", 30*time.Second))
 
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
 }
@@ -387,20 +608,20 @@ func TestSSHRemoteUnlockRetryThenUnlock(t *testing.T) {
 	require.NoError(t, sess.Shell())
 
 	br := bufio.NewReader(stdout)
-	require.NoError(t, readUntil(br, "Enter passphrase:", 15*time.Second))
+	require.NoError(t, readUntil(br, "Enter passphrase for ", 15*time.Second))
 
 	// Empty submission — server's prompt-loop should treat zero-length input
 	// as a no-op and reprompt without trying to unlock anything.
 	_, err = io.WriteString(stdin, "\n")
 	require.NoError(t, err)
-	require.NoError(t, readUntil(br, "Enter passphrase:", 10*time.Second))
+	require.NoError(t, readUntil(br, "Enter passphrase for ", 10*time.Second))
 
 	// Wrong passphrase — KDF runs but no slot matches; expect the "no
 	// pending devices matched" line plus another prompt.
 	_, err = io.WriteString(stdin, "wrongpass\n")
 	require.NoError(t, err)
 	require.NoError(t, readUntil(br, "Passphrase did not unlock any device", 30*time.Second))
-	require.NoError(t, readUntil(br, "Enter passphrase:", 10*time.Second))
+	require.NoError(t, readUntil(br, "Enter passphrase for ", 10*time.Second))
 
 	// Correct passphrase unlocks.
 	_, err = io.WriteString(stdin, "1234\n")
@@ -506,7 +727,7 @@ func TestSSHRemoteUnlockFido2Pending(t *testing.T) {
 	require.NoError(t, sess.Shell())
 
 	br := bufio.NewReader(stdout)
-	require.NoError(t, readUntil(br, "Enter passphrase:", 15*time.Second))
+	require.NoError(t, readUntil(br, "Enter passphrase for ", 15*time.Second))
 	// systemd-fido2-nodev.img's keyslot 0 was formatted with passphrase 567.
 	_, err = io.WriteString(stdin, "567\n")
 	require.NoError(t, err)

--- a/tests/ssh_unlock_test.go
+++ b/tests/ssh_unlock_test.go
@@ -81,7 +81,7 @@ func TestSSHRemoteUnlock(t *testing.T) {
 		enableNetwork: true,
 		useDhcp:       true,
 		params: []string{
-			"-nic", "user,id=n1,hostfwd=tcp::" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+			"-nic", "user,id=n1,hostfwd=tcp:127.0.0.1:" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
 		},
 		sshHostKeyPath:        hostKeyPath,
 		sshAuthorizedKeysPath: authKeysPath,
@@ -178,7 +178,7 @@ func TestSSHRemoteUnlockMultiDeviceSharedPassphrase(t *testing.T) {
 		enableNetwork: true,
 		useDhcp:       true,
 		params: []string{
-			"-nic", "user,id=n1,hostfwd=tcp::" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+			"-nic", "user,id=n1,hostfwd=tcp:127.0.0.1:" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
 		},
 		sshHostKeyPath:        hostKeyPath,
 		sshAuthorizedKeysPath: authKeysPath,
@@ -270,7 +270,7 @@ func TestSSHRemoteUnlockRejectsWrongClientKey(t *testing.T) {
 		enableNetwork: true,
 		useDhcp:       true,
 		params: []string{
-			"-nic", "user,id=n1,hostfwd=tcp::" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+			"-nic", "user,id=n1,hostfwd=tcp:127.0.0.1:" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
 		},
 		sshHostKeyPath:        hostKeyPath,
 		sshAuthorizedKeysPath: authKeysPath,
@@ -338,7 +338,7 @@ func TestSSHRemoteUnlockRetryThenUnlock(t *testing.T) {
 		enableNetwork: true,
 		useDhcp:       true,
 		params: []string{
-			"-nic", "user,id=n1,hostfwd=tcp::" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+			"-nic", "user,id=n1,hostfwd=tcp:127.0.0.1:" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
 		},
 		sshHostKeyPath:        hostKeyPath,
 		sshAuthorizedKeysPath: authKeysPath,
@@ -451,7 +451,7 @@ func TestSSHRemoteUnlockFido2Pending(t *testing.T) {
 		enableNetwork: true,
 		useDhcp:       true,
 		params: []string{
-			"-nic", "user,id=n1,hostfwd=tcp::" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
+			"-nic", "user,id=n1,hostfwd=tcp:127.0.0.1:" + strconv.Itoa(hostPort) + "-:" + strconv.Itoa(guestPort),
 		},
 		sshHostKeyPath:        hostKeyPath,
 		sshAuthorizedKeysPath: authKeysPath,

--- a/tests/ssh_unlock_test.go
+++ b/tests/ssh_unlock_test.go
@@ -399,7 +399,7 @@ func TestSSHRemoteUnlockRetryThenUnlock(t *testing.T) {
 	// pending devices matched" line plus another prompt.
 	_, err = io.WriteString(stdin, "wrongpass\n")
 	require.NoError(t, err)
-	require.NoError(t, readUntil(br, "No pending devices matched", 30*time.Second))
+	require.NoError(t, readUntil(br, "Passphrase did not unlock any device", 30*time.Second))
 	require.NoError(t, readUntil(br, "Enter passphrase:", 10*time.Second))
 
 	// Correct passphrase unlocks.

--- a/tests/util.go
+++ b/tests/util.go
@@ -253,6 +253,12 @@ type NetworkConfig struct {
 	IP         string `yaml:",omitempty"` // e.g. 10.0.2.15/24
 	Gateway    string `yaml:",omitempty"` // e.g. 10.0.2.255
 	DNSServers string `yaml:"dns_servers,omitempty"`
+
+	// SSH remote-unlock fields. The generator reads these as paths to files
+	// on the host whose contents are embedded into the initramfs config.
+	SshHostKey        string `yaml:"ssh_host_key,omitempty"`
+	SshAuthorizedKeys string `yaml:"ssh_authorized_keys,omitempty"`
+	SshListen         string `yaml:"ssh_listen,omitempty"`
 }
 
 type GeneratorConfig struct {
@@ -289,6 +295,13 @@ func generateBoosterConfig(output string, opts Opts) error {
 		}
 
 		net.Interfaces = opts.activeNetIfaces
+
+		// SSH remote-unlock wiring. Test code writes the keypair + authorized_keys
+		// to temp files and passes their paths through Opts; the generator
+		// embeds the file contents into the initramfs.
+		net.SshHostKey = opts.sshHostKeyPath
+		net.SshAuthorizedKeys = opts.sshAuthorizedKeysPath
+		net.SshListen = opts.sshListen
 	}
 	conf.Universal = true
 	conf.Compression = opts.compression
@@ -348,6 +361,12 @@ type Opts struct {
 	zfsCachePath         string // TODO: do we need any of these parameters?
 	crypttabFile         string // path to host crypttab to bundle; overrides /etc/crypttab
 	enableFido2          bool
+
+	// SSH remote-unlock options. Paths are passed through to the generator,
+	// which embeds the file contents into the initramfs config.
+	sshHostKeyPath        string
+	sshAuthorizedKeysPath string
+	sshListen             string
 }
 
 func buildVmInstance(t *testing.T, opts Opts) (*vmtest.Qemu, error) {


### PR DESCRIPTION
Closes #320.

Picks up @kenshaw's original SSH-unlock proposal after his clearance to take it
over. Reworks against current master so the submission integrates with the
existing prompt machinery rather than walking devices itself.

## Approach

- stdlib `golang.org/x/crypto/ssh` only. No dropbear, no external daemon.
- Pubkey-only auth. `ssh_host_key` + `ssh_authorized_keys` are paths in
  `booster.yaml`, read at build time and embedded into the initramfs.
- SSH submissions land in a `pendingPrompts` registry in `init/luks.go`. The
  handler broadcasts the passphrase against every LUKS device currently
  waiting and seeds the in-boot passphrase cache so sibling volumes (e.g.
  btrfs RAID1) unlock without further prompts.
- Runs concurrently with token attempts (TPM2 PIN, FIDO2, clevis) and the
  local keyboard prompt — not gated behind `tokenWg.Wait()`. A successful
  out-of-band unlock cancels `ctx`, dismissing the in-flight
  token/keyboard prompt.

## Hardening

Pubkey-only auth, explicit `MaxAuthTries=6`, 15s handshake deadline
(slow-loris guard), 10 wrong-passphrase attempts per session before
disconnect. No PAM, no shell, no PTY, no exec, no port forwarding. Threat
model and operator guidance (host key extractability from `/boot`,
brute-force economics, dual-stack `:22` caveat) live in REMOTE UNLOCK >
Security notes in `docs/manpage.md`.

## Scope

LUKS volumes only. ZFS-native encryption (#191) uses a different unlock path
and is not covered here.

## Test plan

- `init` + `generator` unit suites pass under `-race`. New tests:
  - `TestPendingPromptsInflightFence` + `TestTrySubmitPassphraseToPendingHoldsInflight`
    — race fence preventing panic when an SSH submission races `luksOpen`'s
    watcher closing `volumes` (both demonstrably fail without the fix).
  - `TestSshPromptLoopDisconnectsAfterMaxAttempts` — per-session
    brute-force cap (demonstrably fails without the cap).
  - `TestSshReadLineSharesScanner` — pasted-input safety via shared
    console inputScanner.
  - `TestParseAuthorizedKeys*`,
    `TestReadConfigRejectsEmpty/GarbageAuthorizedKeys`,
    `TestReadConfigAcceptsLooseHostKeyPerms` — build- and parse-time
    validation.
- `tests/ssh_unlock_test.go` — 5 QEMU integration cases: single root,
  multi-device shared passphrase, unauthorized key rejection,
  wrong-then-correct retry, FIDO2-pending concurrent unlock.
- Manual QEMU: TPM2-both + Plymouth + SSH — PIN prompt dismissed cleanly,
  no redraw artifact. Paste from clipboard through real SSH client clean,
  no line-mangling.
- FIDO2/Yubikey real-hardware test deferred (fake-FIDO2 path covered; real
  Yubikey will follow on the interactive harness).

## Co-author credit

- `init/ssh: SSH server for remote LUKS unlock` preserves @kenshaw's
  co-authorship — much of the structural scaffold is from #320.
- `tests: pin SSH hostfwd to IPv4 loopback` credits @anatol — pattern
  taken from `tests-improvements` (f5e33f7).