### PR TITLE
init/luks: broadcast hidraw events + touch-anytime FIDO2 retry

### DIFF
--- a/init/fido2_reseed_test.go
+++ b/init/fido2_reseed_test.go
@@ -1,0 +1,154 @@
+package main
+
+// Tests for reseedTouchlessFido2 — the gate-and-send helper that implements
+// touch-anytime FIDO2 retry (project plan item N).
+//
+// When a touchless FIDO2 device returns a non-fatal error, the goroutine
+// re-seeds the device back into its own listener channel so the recover
+// loop tries again. The user can then touch the token at any point during
+// boot — including while a passphrase prompt is showing — and the unlock
+// succeeds without further intervention.
+//
+// Three gates protect against misuse:
+//   1. !pinRequired   — PIN tokens have engaged the user via prompt; silent
+//                        re-seed would be confusing.
+//   2. elapsed > 1s   — bounds hot-loops on fast-fail libfido2 errors.
+//   3. ctx not done   — sibling-token win cancels parent ctx; don't keep
+//                        re-seeding into a doomed channel.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReseedHappyPath(t *testing.T) {
+	// Touchless device, slow assertion (>1s elapsed), live ctx → re-seeds:
+	// listener receives devName and seen[devName] is cleared.
+	ctx := context.Background()
+	listener := make(chan string, 1)
+	seen := set{"hidraw0": true}
+
+	err := reseedTouchlessFido2(ctx, listener, "hidraw0", seen, false, 2*time.Second)
+	require.NoError(t, err)
+
+	select {
+	case got := <-listener:
+		require.Equal(t, "hidraw0", got)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("re-seed should have delivered to listener")
+	}
+	require.False(t, seen["hidraw0"], "re-seed must clear seen[devName] so the outer loop accepts the redelivery")
+}
+
+func TestReseedSkippedForPinRequired(t *testing.T) {
+	// PIN tokens drive their own user interaction via prompts; silent re-seed
+	// behind their back would confuse the prompt state machine. Gate skips.
+	ctx := context.Background()
+	listener := make(chan string, 1)
+	seen := set{"hidraw0": true}
+
+	err := reseedTouchlessFido2(ctx, listener, "hidraw0", seen, true, 5*time.Second)
+	require.NoError(t, err)
+
+	select {
+	case got := <-listener:
+		t.Fatalf("PIN-required tokens must not re-seed; got %q", got)
+	case <-time.After(50 * time.Millisecond):
+		// expected — gate skipped
+	}
+	require.True(t, seen["hidraw0"], "seen must NOT be cleared when re-seed is skipped")
+}
+
+func TestReseedSkippedOnFastFail(t *testing.T) {
+	// Fast-fail errors (immediate libfido2 rejections) return in microseconds.
+	// Without the elapsed-time gate, re-seed would hot-loop the device back
+	// into the listener channel and burn CPU.
+	ctx := context.Background()
+	listener := make(chan string, 1)
+	seen := set{"hidraw0": true}
+
+	err := reseedTouchlessFido2(ctx, listener, "hidraw0", seen, false, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	select {
+	case got := <-listener:
+		t.Fatalf("fast-fail must not re-seed; got %q", got)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+	require.True(t, seen["hidraw0"], "seen must NOT be cleared on fast-fail skip")
+}
+
+func TestReseedSkippedAtGateBoundary(t *testing.T) {
+	// Boundary: elapsed == 1s exactly is treated as fast-fail (gate uses
+	// strict >, not >=). Pinned to keep the gate semantics explicit.
+	ctx := context.Background()
+	listener := make(chan string, 1)
+	seen := set{"hidraw0": true}
+
+	err := reseedTouchlessFido2(ctx, listener, "hidraw0", seen, false, time.Second)
+	require.NoError(t, err)
+
+	select {
+	case got := <-listener:
+		t.Fatalf("elapsed==1s must not re-seed (gate is strict >); got %q", got)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestReseedReturnsCtxErrWhenCancelledBeforeCall(t *testing.T) {
+	// Sibling token wins → ctx cancelled. Helper observes and returns ctx.Err
+	// without sending. Caller (recoverSystemdFido2Password) propagates by
+	// returning early.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	listener := make(chan string, 1)
+	seen := set{"hidraw0": true}
+
+	err := reseedTouchlessFido2(ctx, listener, "hidraw0", seen, false, 2*time.Second)
+	require.ErrorIs(t, err, context.Canceled)
+
+	select {
+	case got := <-listener:
+		t.Fatalf("cancelled ctx must not send; got %q", got)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+	require.True(t, seen["hidraw0"], "seen must NOT be cleared when ctx already cancelled")
+}
+
+func TestReseedReturnsCtxErrWhenCancelledDuringSend(t *testing.T) {
+	// Listener buffer is full; send blocks. ctx cancellation must unblock
+	// the helper and return ctx.Err. Without the select, the goroutine
+	// would deadlock holding fido2Mu.
+	ctx, cancel := context.WithCancel(context.Background())
+	listener := make(chan string, 1)
+	listener <- "filler" // saturate the buffer
+	seen := set{"hidraw0": true}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- reseedTouchlessFido2(ctx, listener, "hidraw0", seen, false, 2*time.Second)
+	}()
+
+	// Briefly let the helper enter the select{}, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("helper did not return after ctx cancel — likely deadlocked")
+	}
+
+	// Note: seen[devName] WAS cleared (the gate passed before ctx cancel),
+	// but the device wasn't re-seeded into the channel. This is benign —
+	// the goroutine returns ctx.Err immediately after, so the cleared map
+	// is discarded.
+	require.False(t, seen["hidraw0"], "seen is cleared before the send attempt — caller exits via ctx.Err so the asymmetry is benign")
+}

--- a/init/hidraw_broadcast_test.go
+++ b/init/hidraw_broadcast_test.go
@@ -122,3 +122,64 @@ func TestHidrawBroadcastEmptyRegistryIsNoop(t *testing.T) {
 		t.Fatal("broadcast to empty registry blocked")
 	}
 }
+
+// Tests below document N's re-seed design: when recoverSystemdFido2Password's
+// inner assertion fails on a touchless device, the goroutine sends the device
+// name back into ITS OWN listener channel (not via broadcastHidrawDevice).
+// Sibling FIDO2 goroutines have already tracked the device in their own
+// seenHidrawDevices, so a broadcast would be a no-op on them at best (and at
+// worst would re-seed devices they've already exhausted). Re-seed must be
+// private to the goroutine that owns the listener.
+//
+// The full re-seed path (gate on assertion elapsed > 1s, gate on !pinRequired,
+// select with ctx.Done()) lives inline inside recoverSystemdFido2Password and
+// is not directly unit-testable without mocking libfido2; behavioural coverage
+// is intended via the integration test path.
+
+func TestListenerSelfSendReachesSelfNotSiblings(t *testing.T) {
+	// N re-seeds via `listener <- devName` (a self-channel-send), not via
+	// broadcastHidrawDevice. Verify that pattern's semantics: the originating
+	// goroutine sees its own re-seed; siblings do not.
+	mine, dropMine := registerHidrawListener()
+	defer dropMine()
+	sibling, dropSibling := registerHidrawListener()
+	defer dropSibling()
+
+	// Self-send: same mechanic the inline re-seed uses.
+	mine <- "hidraw0"
+
+	select {
+	case got := <-mine:
+		require.Equal(t, "hidraw0", got, "self-send must reach own listener")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("self-send never reached own listener")
+	}
+
+	select {
+	case got := <-sibling:
+		t.Fatalf("self-send must not reach siblings; got %q", got)
+	case <-time.After(50 * time.Millisecond):
+		// expected — siblings observe nothing
+	}
+}
+
+func TestListenerSelfSendDoesNotInteractWithBroadcastQueue(t *testing.T) {
+	// Self-send must not displace events that arrive concurrently via
+	// broadcastHidrawDevice. The owning goroutine's listener should observe
+	// both: the broadcast (from a real udev 'add') and the self-send (from
+	// N's re-seed) in queue order.
+	mine, dropMine := registerHidrawListener()
+	defer dropMine()
+
+	broadcastHidrawDevice("hidraw_from_udev")
+	mine <- "hidraw_from_reseed"
+
+	for _, want := range []string{"hidraw_from_udev", "hidraw_from_reseed"} {
+		select {
+		case got := <-mine:
+			require.Equal(t, want, got)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("listener never received %q", want)
+		}
+	}
+}

--- a/init/hidraw_broadcast_test.go
+++ b/init/hidraw_broadcast_test.go
@@ -1,0 +1,124 @@
+package main
+
+// Tests for the hidraw listener broadcast registry in init/luks.go.
+//
+// hidrawDevices used to be a single global channel shared across every FIDO2
+// goroutine. A udev `add hidraw` event was a single push — the first goroutine
+// to read won the device and siblings starved. This caused the "touchless
+// FIDO2 never blinks unless first found" bug: with one PIN-required FIDO2 and
+// one touchless FIDO2 against the same physical device, only one of the two
+// recoverSystemdFido2Password goroutines ever saw the device.
+//
+// The fix replaces the global channel with a registry of per-goroutine
+// listeners; udev events are broadcast to every registered listener so each
+// FIDO2 token's recover loop sees every device-add independently.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The TestHidrawBroadcast* tests share the global hidrawListeners registry,
+// so they cannot run in parallel — listeners registered by one test would
+// receive broadcasts from another.
+
+func TestHidrawBroadcastDeliversToAllListeners(t *testing.T) {
+	a, dropA := registerHidrawListener()
+	defer dropA()
+	b, dropB := registerHidrawListener()
+	defer dropB()
+
+	broadcastHidrawDevice("hidraw0")
+
+	select {
+	case got := <-a:
+		require.Equal(t, "hidraw0", got)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("listener A never received the broadcast")
+	}
+	select {
+	case got := <-b:
+		require.Equal(t, "hidraw0", got)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("listener B never received the broadcast")
+	}
+}
+
+func TestHidrawBroadcastDoesNotBlockOnSlowListener(t *testing.T) {
+	// A listener whose buffer fills up must not stall broadcasts to siblings.
+	a, dropA := registerHidrawListener()
+	defer dropA()
+	for range cap(a) {
+		a <- "filler"
+	}
+	b, dropB := registerHidrawListener()
+	defer dropB()
+
+	done := make(chan struct{})
+	go func() {
+		broadcastHidrawDevice("hidraw1")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("broadcast blocked on a full listener buffer")
+	}
+
+	select {
+	case got := <-b:
+		require.Equal(t, "hidraw1", got)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("sibling listener never received the broadcast despite A being full")
+	}
+}
+
+func TestHidrawBroadcastIgnoresDroppedListener(t *testing.T) {
+	a, dropA := registerHidrawListener()
+	dropA() // drop immediately
+
+	broadcastHidrawDevice("hidraw2")
+	select {
+	case got := <-a:
+		t.Fatalf("dropped listener should not receive broadcasts; got %q", got)
+	case <-time.After(100 * time.Millisecond):
+		// expected — no delivery
+	}
+}
+
+func TestHidrawBroadcastDeliversMultipleEvents(t *testing.T) {
+	// A listener receives every broadcast in order, not just the first one.
+	a, dropA := registerHidrawListener()
+	defer dropA()
+
+	for _, name := range []string{"hidraw0", "hidraw1", "hidraw2"} {
+		broadcastHidrawDevice(name)
+	}
+
+	for _, want := range []string{"hidraw0", "hidraw1", "hidraw2"} {
+		select {
+		case got := <-a:
+			require.Equal(t, want, got)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("listener never received %q", want)
+		}
+	}
+}
+
+func TestHidrawBroadcastEmptyRegistryIsNoop(t *testing.T) {
+	// Broadcast with zero registered listeners must not panic or block.
+	// Realistic for the brief window after init starts and before any FIDO2
+	// goroutine has registered.
+	done := make(chan struct{})
+	go func() {
+		broadcastHidrawDevice("hidraw3")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("broadcast to empty registry blocked")
+	}
+}

--- a/init/luks.go
+++ b/init/luks.go
@@ -466,6 +466,32 @@ func broadcastHidrawDevice(name string) {
 // messages. Channel-as-semaphore so acquire is ctx-cancellable.
 var fido2Sem = make(chan struct{}, 1)
 
+// Push a touchless FIDO2 device back into the goroutine's own listener channel
+// so the loop retries — the user can then touch the token at any point during
+// boot, including while a passphrase prompt is showing, and the unlock succeeds.
+//
+// Gates (silently no-op if any fail):
+//   - pinRequired: PIN tokens have already engaged the user via prompt;
+//     re-seeding them silently would be confusing.
+//   - elapsed > 1s: bounds hot-loops on fast-fail errors (immediate libfido2
+//     rejections that return in microseconds would otherwise spin).
+//   - ctx not done: don't re-seed if a sibling token has already won.
+func reseedTouchlessFido2(ctx context.Context, listener chan string, devName string, seen set, pinRequired bool, elapsed time.Duration) error {
+	if pinRequired || elapsed <= time.Second {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	seen[devName] = false
+	select {
+	case listener <- devName:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 var errFido2Skipped = errors.New("FIDO2 skipped by user")
 var errFido2PinInvalid = errors.New("FIDO2 PIN invalid")
 var errFido2WrongDevice = errors.New("FIDO2 device does not have our credential")
@@ -554,6 +580,7 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 		pinExhausted := false
 		promptPrefix := ""
 		attempt := 0
+		assertStart := time.Now() // for reseedTouchlessFido2's elapsed gate
 		for attempt < maxAttempts {
 			password, err = recoverFido2Password(ctx, devName, node.Credential, node.Salt, node.RelyingParty, pinRequired, node.UserPresenceRequired, node.UserVerificationRequired, mappingName, promptPrefix)
 			if err == nil {
@@ -605,6 +632,12 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 				continue
 			}
 			info("%v", err)
+			// Private re-seed (not broadcast): sibling FIDO2 goroutines already
+			// tracked the device in their own seenHidrawDevices, so broadcasting
+			// would be a no-op for them.
+			if reseedErr := reseedTouchlessFido2(ctx, hidrawDevices, devName, seenHidrawDevices, pinRequired, time.Since(assertStart)); reseedErr != nil {
+				return nil, reseedErr
+			}
 			continue
 		}
 		return password, nil

--- a/init/luks.go
+++ b/init/luks.go
@@ -418,7 +418,46 @@ func recoverFido2Password(ctx context.Context, devName string, credential string
 	return result, err
 }
 
-var hidrawDevices = make(chan string, 10) // channel that receives 'add hidraw' events
+// hidraw udev events are broadcast to every registered listener so multiple
+// FIDO2 tokens (e.g. one PIN-required, one touchless against the same physical
+// device) observe device-add events independently. A single shared channel
+// would let the first reader steal the event from siblings.
+var (
+	hidrawListenersMu sync.Mutex
+	hidrawListeners   []chan string
+)
+
+// Caller must invoke the returned drop function when done so the listener
+// doesn't accumulate in the registry.
+func registerHidrawListener() (chan string, func()) {
+	ch := make(chan string, 16)
+	hidrawListenersMu.Lock()
+	hidrawListeners = append(hidrawListeners, ch)
+	hidrawListenersMu.Unlock()
+	return ch, func() {
+		hidrawListenersMu.Lock()
+		defer hidrawListenersMu.Unlock()
+		for i, c := range hidrawListeners {
+			if c == ch {
+				hidrawListeners = append(hidrawListeners[:i], hidrawListeners[i+1:]...)
+				return
+			}
+		}
+	}
+}
+
+// Non-blocking per listener: a slow consumer with a full buffer drops the
+// event for itself only — siblings still receive it.
+func broadcastHidrawDevice(name string) {
+	hidrawListenersMu.Lock()
+	defer hidrawListenersMu.Unlock()
+	for _, ch := range hidrawListeners {
+		select {
+		case ch <- name:
+		default:
+		}
+	}
+}
 
 // fido2Sem serializes FIDO2 user interactions (PIN prompt + touch + assertion)
 // across all goroutines. The FIDO2 key can only service one assertion at a
@@ -453,6 +492,11 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 	}
 
 	statusMessage("Waiting for FIDO2 security key for " + mappingName + "...")
+
+	// Register BEFORE waiting on usbhidReady so any 'add' events arriving
+	// after the wait but before /sys/class/hidraw/ is read are buffered for us.
+	hidrawDevices, dropListener := registerHidrawListener()
+	defer dropListener()
 
 	if err := waitForUsbhid(ctx); err != nil {
 		info("FIDO2 unlock for %s cancelled before USB HID ready: %v", mappingName, err)

--- a/init/udev.go
+++ b/init/udev.go
@@ -120,7 +120,7 @@ func handleUdevEvent(ev netlink.UEvent) {
 	} else if ev.Env["SUBSYSTEM"] == "net" {
 		go func() { check(handleNetworkUevent(ev)) }()
 	} else if ev.Env["SUBSYSTEM"] == "hidraw" && ev.Action == "add" {
-		go func() { hidrawDevices <- ev.Env["DEVNAME"] }()
+		go broadcastHidrawDevice(ev.Env["DEVNAME"])
 	} else if ev.Env["SUBSYSTEM"] == "tpmrm" && ev.Action == "add" {
 		go handleTpmReadyUevent(ev)
 	}


### PR DESCRIPTION
## Context

Companion to #367 (ctx-aware FIDO2 primitives). Both PRs are independent foundation work for reliable multi-token FIDO2 boots: #367 makes blocking sync primitives observe `ctx.Done()`; this PR fixes event delivery and adds touch-anytime UX.

## Problem

### 1. Shared hidraw channel starves siblings

`hidrawDevices` is a single global channel. The first goroutine to read wins the device-add event; siblings starve.

- **Same disk, primary + backup key** (real-world setup) — N FIDO2 tokens enrolled on the same volume, one per physical key. The goroutine whose credential matches the inserted key never sees the device-add event if a sibling reads it first, and times out even though the right key is physically present.
- **Same key, multiple tokens** (dev/test setup — e.g. one PIN-required + one touchless on the same physical key) — only the first goroutine ever sees the device; the second never blinks. Not a typical user configuration, but useful for exercising the multi-token dispatch path without two physical keys.

### 2. Touch-only retry costs a re-prompt

A touchless FIDO2 device that returns a non-fatal error (typically "user not present" — the user didn't touch in time) gives up immediately and falls through to the next attempt or keyboard fallback. The user has to re-trigger the boot sequence to try again.

## Changes

### Per-listener broadcast (commit 1)

Replace the global channel with a registry of per-call listener channels. Each `recoverSystemdFido2Password` call registers its own buffered channel via `registerHidrawListener()`; `broadcastHidrawDevice()` delivers each udev event to every listener non-blocking (a full listener buffer drops the event for that listener only).

A `done <-chan struct{}` parameter on the device-iteration loop ensures the deferred `dropListener()` actually runs on early exit.

### Touch-anytime re-seed (commit 2)

`reseedTouchlessFido2` re-injects the device into the goroutine's own listener channel on non-fatal errors, so the loop keeps retrying. The user can then touch the token at any point during boot — including while the keyboard passphrase prompt is showing — and the unlock succeeds.

Three gates:
- **!pinRequired**: PIN tokens have already engaged the user via prompt; silent re-seed would confuse the prompt state.
- **elapsed > 1s**: bounds hot-loops on fast-fail libfido2 errors that return in microseconds.
- **ctx not done**: sibling-token win cancels parent ctx; helper returns `ctx.Err()` rather than re-seeding into a doomed channel. The select on `ctx.Done()` during send avoids deadlock if the listener buffer is full when the context cancels.

Wrong-credential errors are filtered earlier by the existing skip path, so re-seed only runs on genuine "user not present" outcomes.

## Verification

`init/hidraw_broadcast_test.go` (7 tests):
- Broadcast delivers to all listeners; doesn't block on slow listener; ignores dropped listener; multi-event ordering; empty-registry no-op.
- Listener self-send (used by re-seed) reaches only the sending goroutine, not siblings; self-send and broadcast queue independently.

`init/fido2_reseed_test.go` (6 tests):
- Happy path re-seeds; PIN gate skips silently; fast-fail gate skips silently; gate boundary (elapsed==1s) is no-op (strict `>`).
- Pre-cancelled ctx returns `ctx.Err()` without sending or mutating `seen`.
- Full-buffer listener + mid-send cancel: select unblocks via `ctx.Done()` so the goroutine doesn't deadlock holding `fido2Mu`.