### PR TITLE
init/luks: eager FIDO2 PIN prompt + defer pinless "no device" hint

### DIFF
--- a/init/luks.go
+++ b/init/luks.go
@@ -545,15 +545,15 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 
 	statusMessage("Waiting for FIDO2 security key for " + mappingName + "...")
 
-	// Register BEFORE waiting on usbhidReady so any 'add' events arriving
-	// after the wait but before /sys/class/hidraw/ is read are buffered for us.
+	// Register BEFORE reading /sys/class/hidraw so any 'add' events arriving
+	// during/after the scan are buffered. We deliberately do NOT block on
+	// waitForUsbhid here: on usbhid-less configs (QEMU without USB,
+	// embedded systems, laptops with only PS2/i2c HID) usbhidReady never
+	// closes, and blocking would prevent the deferred "No FIDO2 device
+	// found" timer below from ever arming. A late-arriving usbhid bind
+	// surfaces its hidraw through the listener channel.
 	hidrawDevices, dropListener := registerHidrawListener()
 	defer dropListener()
-
-	if err := waitForUsbhid(ctx); err != nil {
-		info("FIDO2 unlock for %s cancelled before USB HID ready: %v", mappingName, err)
-		return nil, err
-	}
 
 	dir, err := os.ReadDir(hidrawSysPath)
 	if err != nil {

--- a/init/luks.go
+++ b/init/luks.go
@@ -576,23 +576,16 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 
 	seenHidrawDevices := make(set)
 
-	// Defer the "No FIDO2 device found" hint so a parallel non-interactive
-	// token (TPM2, clevis) can win silently in the common case. Cap the wait
-	// at 10s so the message surfaces in time to inform the user before a
-	// long tokenTimeout completes. Suppressed on console-quiet (verbosity
-	// < info); Plymouth always shows because it's the only visibility
-	// layer under `quiet splash`.
-	//
-	// PIN-required tokens early-returned into recoverFido2WithEagerPrompt
-	// above and never reach this code — the eager PIN prompt is their
-	// affordance. The timer here serves only the pinless touch-anytime path.
+	// "No FIDO2 device found" hint, delayed tokenTimeout/2 with 10s floor:
+	// a fast non-interactive token (TPM2, clevis) should win silently before
+	// the hint fires. PIN-required tokens use the eager-prompt path above.
 	var noDeviceC <-chan time.Time
 	if len(dir) == 0 && (plymouthEnabled || verbosityLevel >= levelInfo) {
 		delay := 30 * time.Second
 		if config.TokenTimeout > 0 {
 			delay = time.Duration(config.TokenTimeout) * time.Second
 		}
-		if delay /= 2; delay > 10*time.Second {
+		if delay /= 2; delay < 10*time.Second {
 			delay = 10 * time.Second
 		}
 		noDeviceTimer := time.NewTimer(delay)

--- a/init/luks.go
+++ b/init/luks.go
@@ -384,7 +384,7 @@ func recoverFido2Password(ctx context.Context, devName string, credID []byte, sa
 
 	var pin string
 	if pinRequired {
-		prompt := promptPrefix + "Enter FIDO2 PIN for " + mappingName + " (empty to skip to passphrase):"
+		prompt := promptPrefix + "Enter FIDO2 PIN for " + mappingName + " (empty to skip):"
 		pinBytes, err := askPasswordWithFallback(ctx, prompt, "")
 		if err != nil {
 			return nil, err

--- a/init/luks.go
+++ b/init/luks.go
@@ -467,6 +467,12 @@ func broadcastHidrawDevice(name string) {
 // messages. Channel-as-semaphore so acquire is ctx-cancellable.
 var fido2Sem = make(chan struct{}, 1)
 
+// fido2NoDeviceMsgOnce dedups the "No FIDO2 device found" status across
+// goroutines unlocking the same mapping. Multi-FIDO2-token pinless
+// enrollments invoke recoverSystemdFido2Password once per token; each
+// arms the no-device timer, but only the first to fire emits the hint.
+var fido2NoDeviceMsgOnce sync.Map // mappingName → *sync.Once
+
 // Push a touchless FIDO2 device back into the goroutine's own listener channel
 // so the loop retries — the user can then touch the token at any point during
 // boot, including while a passphrase prompt is showing, and the unlock succeeds.
@@ -554,10 +560,6 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 		return nil, err
 	}
 
-	if len(dir) == 0 {
-		statusMessage("No FIDO2 device found for " + mappingName + ", insert security key or wait for passphrase prompt")
-	}
-
 	seedDone := make(chan struct{})
 	stopSeeding := make(chan struct{})
 	defer close(stopSeeding)
@@ -573,6 +575,30 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 	}()
 
 	seenHidrawDevices := make(set)
+
+	// Defer the "No FIDO2 device found" hint so a parallel non-interactive
+	// token (TPM2, clevis) can win silently in the common case. Cap the wait
+	// at 10s so the message surfaces in time to inform the user before a
+	// long tokenTimeout completes. Suppressed on console-quiet (verbosity
+	// < info); Plymouth always shows because it's the only visibility
+	// layer under `quiet splash`.
+	//
+	// PIN-required tokens early-returned into recoverFido2WithEagerPrompt
+	// above and never reach this code — the eager PIN prompt is their
+	// affordance. The timer here serves only the pinless touch-anytime path.
+	var noDeviceC <-chan time.Time
+	if len(dir) == 0 && (plymouthEnabled || verbosityLevel >= levelInfo) {
+		delay := 30 * time.Second
+		if config.TokenTimeout > 0 {
+			delay = time.Duration(config.TokenTimeout) * time.Second
+		}
+		if delay /= 2; delay > 10*time.Second {
+			delay = 10 * time.Second
+		}
+		noDeviceTimer := time.NewTimer(delay)
+		defer noDeviceTimer.Stop()
+		noDeviceC = noDeviceTimer.C
+	}
 
 	var (
 		uniqueDevicesProcessed int // unique hidraws filtered through pre-flight; converges to len(dir) once seed drains
@@ -604,7 +630,23 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 			// serialize-mode per-token timeout (or cancel-on-win) fired
 			// while waiting for a FIDO2 device to appear — stop waiting.
 			return nil, ctx.Err()
+		case <-noDeviceC:
+			// Dedup across goroutines for the same mapping (multi-FIDO2-token
+			// pinless enrollment): each token's recoverSystemdFido2Password
+			// arms its own timer, but only the first to fire emits the hint.
+			v, _ := fido2NoDeviceMsgOnce.LoadOrStore(mappingName, &sync.Once{})
+			v.(*sync.Once).Do(func() {
+				statusMessage("No FIDO2 device found for " + mappingName + ", insert security key or wait for passphrase prompt")
+			})
+			noDeviceC = nil
+			continue
 		case devName = <-hidrawDevices:
+			// A device arrived: suppress the empty-state message. Without
+			// this nil-out, a timer expiry queued while we were processing
+			// an earlier device would fire on a subsequent loop iteration
+			// and tell the user "no FIDO2 device found" while a key is
+			// plugged in.
+			noDeviceC = nil
 		}
 		if seenHidrawDevices[devName] {
 			continue

--- a/init/luks.go
+++ b/init/luks.go
@@ -501,6 +501,11 @@ var errFido2TouchTimeout = errors.New("FIDO2 touch timed out")
 var errFido2FallbackToKeyboard = errors.New("FIDO2 falling back to keyboard")
 var errTPM2Skipped = errors.New("TPM2 skipped by user")
 
+// askFido2Pin is the prompt entry point for FIDO2 PIN entry. Indirected
+// through a package var so tests can substitute a deterministic responder
+// without standing up plymouth or a console TTY.
+var askFido2Pin = askPasswordWithFallback
+
 func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName string) ([]byte, error) {
 	var node struct {
 		Credential               string `json:"fido2-credential"` // base64
@@ -521,6 +526,15 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 	credID, err := base64.StdEncoding.DecodeString(node.Credential)
 	if err != nil {
 		return nil, fmt.Errorf("invalid credential: %v", err)
+	}
+
+	// Eager PIN prompt for PIN-required tokens. Token metadata tells us a PIN
+	// is enrolled; ask now instead of waiting for device discovery. Lets the
+	// user empty-Enter to skip — breaks the serial-dispatcher deadlock where
+	// a missing FIDO2 device parks the loop and the next PIN-bearing token
+	// (e.g. TPM2-PIN) never gets prompted.
+	if node.PinRequired {
+		return recoverFido2WithEagerPrompt(ctx, mappingName, credID, node.Salt, node.RelyingParty, node.UserPresenceRequired, node.UserVerificationRequired)
 	}
 
 	statusMessage("Waiting for FIDO2 security key for " + mappingName + "...")
@@ -702,6 +716,134 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 	}
 
 	return nil, errFido2FallbackToKeyboard
+}
+
+// recoverFido2WithEagerPrompt drives a PIN-required FIDO2 token by asking
+// for the PIN from token metadata BEFORE scanning for a device. On each
+// submission we rescan /sys/class/hidraw and pre-flight every FIDO2-capable
+// entry for the token's credential; if none match we reprompt with a
+// "device not detected" prefix so the user can plug a key in and retype.
+// Empty Enter returns errFido2Skipped, which the serial dispatcher uses to
+// advance to the next PIN-bearing token (TPM2-PIN) without waiting on a
+// device that never arrives.
+//
+// PIN attempts are bounded at 3 — only assertion calls that consumed a PIN
+// attempt count toward the cap. "Device not detected" reprompts and touch
+// timeouts do not.
+func recoverFido2WithEagerPrompt(ctx context.Context, mappingName string, credID []byte, salt, relyingParty string, userPresenceRequired, userVerificationRequired bool) ([]byte, error) {
+	saltBytes, err := base64.StdEncoding.DecodeString(salt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid salt: %v", err)
+	}
+
+	// No waitForUsbhid: findMatchingFido2Device below rescans /sys/class/hidraw
+	// on every PIN submission, so a late-arriving key is picked up next round.
+
+	if err := acquireFido2Lock(ctx); err != nil {
+		info("FIDO2 unlock for %s cancelled waiting for assertion lock: %v", mappingName, err)
+		return nil, err
+	}
+	defer releaseFido2Lock()
+
+	const maxPinAttempts = 3
+	promptPrefix := ""
+	pinAttempts := 0
+
+	for {
+		prompt := promptPrefix + "Enter FIDO2 PIN for " + mappingName + " (empty to skip):"
+		pinBytes, err := askFido2Pin(ctx, prompt, "")
+		if err != nil {
+			return nil, err
+		}
+		if len(pinBytes) == 0 {
+			return nil, errFido2Skipped
+		}
+		pin := string(pinBytes)
+
+		devName, err := findMatchingFido2Device(credID, relyingParty, userVerificationRequired)
+		if err != nil {
+			info("FIDO2 device discovery error: %v", err)
+			promptPrefix = "FIDO2 device discovery error — "
+			continue
+		}
+		if devName == "" {
+			promptPrefix = "FIDO2 device not detected — "
+			continue
+		}
+
+		notifyTouch := func() {
+			statusMessage("Please touch the FIDO2 key for " + mappingName)
+		}
+		result, err := fido2Assertion("/dev/"+devName, credID, saltBytes, relyingParty, pin, true, userPresenceRequired, userVerificationRequired, notifyTouch)
+		if err == nil {
+			statusMessage("")
+			return result, nil
+		}
+
+		if isFido2PinInvalidError(err) {
+			pinAttempts++
+			if pinAttempts >= maxPinAttempts {
+				statusMessage("FIDO2 PIN attempts exhausted, falling back to passphrase")
+				return nil, errFido2FallbackToKeyboard
+			}
+			promptPrefix = "FIDO2 PIN incorrect — "
+			continue
+		}
+		if isFido2TouchTimeoutError(err) {
+			// User typed PIN correctly but didn't touch in time — re-prompt
+			// without consuming a PIN attempt.
+			promptPrefix = "FIDO2 touch timed out — "
+			continue
+		}
+		if isFido2WrongDeviceError(err) {
+			// Pre-flight green-lit this device but assertion rejected the
+			// credential. Could be a hot-plug race; retry by reprompting.
+			debug("FIDO2 device %s rejected credential at assertion (pre-flight skew?)", devName)
+			promptPrefix = "FIDO2 device rejected credential — "
+			continue
+		}
+		if isFido2PinAuthBlockedError(err) {
+			statusMessage("FIDO2 PIN auth blocked (too many wrong attempts), falling back to passphrase")
+			return nil, errFido2FallbackToKeyboard
+		}
+		if isFido2PinBlockedError(err) {
+			statusMessage("FIDO2 PIN is blocked (reset required), falling back to passphrase")
+			return nil, errFido2FallbackToKeyboard
+		}
+		info("FIDO2 assertion failed: %v", err)
+		return nil, errFido2FallbackToKeyboard
+	}
+}
+
+// findMatchingFido2Device scans /sys/class/hidraw, filters by isHidRawFido2,
+// and pre-flights each candidate for credID. Returns the first matching
+// devName (e.g. "hidraw1"); returns "" with nil err when no device matches.
+// Used by the eager-prompt flow to rescan at each PIN submission.
+func findMatchingFido2Device(credID []byte, relyingParty string, userVerificationRequired bool) (string, error) {
+	dir, err := os.ReadDir(hidrawSysPath)
+	if err != nil {
+		return "", err
+	}
+	for _, d := range dir {
+		devName := d.Name()
+		isFido2, ferr := isHidRawFido2(devName)
+		if ferr != nil {
+			info("unable to check whether %s is a FIDO2 device: %v", devName, ferr)
+			continue
+		}
+		if !isFido2 {
+			continue
+		}
+		present, ferr := fido2Preflight("/dev/"+devName, credID, relyingParty, userVerificationRequired)
+		if ferr != nil {
+			info("FIDO2 pre-flight on %s failed: %v", devName, ferr)
+			continue
+		}
+		if present {
+			return devName, nil
+		}
+	}
+	return "", nil
 }
 
 func recoverSystemdTPM2Password(ctx context.Context, t luks.Token, mappingName string) ([]byte, error) {

--- a/init/luks_preflight_test.go
+++ b/init/luks_preflight_test.go
@@ -5,11 +5,18 @@ package main
 // Tests for the FIDO2 pre-flight gate in recoverSystemdFido2Password.
 // The gate keeps tokens whose credential isn't on any connected hidraw
 // from reaching the PIN prompt.
+//
+// Note for eager-prompt tests below: the PIN-required path in
+// recoverSystemdFido2Password routes through recoverFido2WithEagerPrompt,
+// which calls askFido2Pin (a package var) for PIN entry. Tests substitute
+// a scripted responder via withFakeFido2Pin so the flow runs
+// deterministically without a console TTY or plymouthd.
 
 import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -111,6 +118,11 @@ type fakeFidoForPreflight struct {
 	assertionCalls    int
 	preflightCalls    int
 	assertionRequests []string // devPath of each full assertion
+	// assertionFn lets tests script success/failure per assertion call.
+	// nil → return ([]byte("ok"), nil) on every call.
+	assertionFn func(call int, devPath, pin string) ([]byte, error)
+	// pinInvalidFn classifies errors returned by assertionFn as PIN-invalid.
+	pinInvalidFn func(error) bool
 }
 
 func (f *fakeFidoForPreflight) Fido2Preflight(devPath string, credID []byte, rp string, uv bool) (bool, error) {
@@ -119,17 +131,62 @@ func (f *fakeFidoForPreflight) Fido2Preflight(devPath string, credID []byte, rp 
 }
 
 func (f *fakeFidoForPreflight) Fido2Assertion(devPath string, credID, salt []byte, rp, pin string, pinRequired, up, uv bool, notifyTouch func()) ([]byte, error) {
+	call := f.assertionCalls
 	f.assertionCalls++
 	f.assertionRequests = append(f.assertionRequests, devPath)
+	if f.assertionFn != nil {
+		return f.assertionFn(call, devPath, pin)
+	}
 	return []byte("ok"), nil
 }
 
-func (f *fakeFidoForPreflight) IsFido2PinInvalid(error) bool     { return false }
+// Per-error-class predicate hooks let tests script assertion outcomes.
+func (f *fakeFidoForPreflight) IsFido2PinInvalid(err error) bool {
+	if f.pinInvalidFn != nil {
+		return f.pinInvalidFn(err)
+	}
+	return false
+}
 func (f *fakeFidoForPreflight) IsFido2PinAuthBlocked(error) bool { return false }
 func (f *fakeFidoForPreflight) IsFido2PinBlocked(error) bool     { return false }
 func (f *fakeFidoForPreflight) IsFido2WrongDevice(error) bool    { return false }
 func (f *fakeFidoForPreflight) IsFido2PinRequired(error) bool    { return false }
 func (f *fakeFidoForPreflight) IsFido2TouchTimeout(error) bool   { return false }
+
+// withFakeFido2Pin substitutes askFido2Pin with a scripted responder that
+// returns the given replies in order. After the last reply, further calls
+// return ctx.Err() so a misbehaving test can't hang. Restores on cleanup.
+func withFakeFido2Pin(t *testing.T, replies []string) *fakePinResponder {
+	t.Helper()
+	r := &fakePinResponder{replies: replies}
+	prev := askFido2Pin
+	askFido2Pin = r.respond
+	t.Cleanup(func() { askFido2Pin = prev })
+	return r
+}
+
+type fakePinResponder struct {
+	replies []string
+	prompts []string
+	calls   int
+	// beforeReply, if set, fires after each call is recorded but before the
+	// reply is returned. The call argument is 1-indexed and identifies which
+	// reply is about to be issued — letting a test mutate side state (plug
+	// in a device, flip a fake-plugin map) between prompts.
+	beforeReply func(call int)
+}
+
+func (r *fakePinResponder) respond(ctx context.Context, prompt, postPrompt string) ([]byte, error) {
+	r.prompts = append(r.prompts, prompt)
+	r.calls++
+	if r.beforeReply != nil {
+		r.beforeReply(r.calls)
+	}
+	if r.calls > len(r.replies) {
+		return nil, context.Canceled
+	}
+	return []byte(r.replies[r.calls-1]), nil
+}
 
 // makeFido2TokenPayload builds the systemd-fido2 LUKS token JSON payload
 // that recoverSystemdFido2Password unmarshals.
@@ -359,4 +416,167 @@ func TestEmptyHidrawAtEntryHotPlugNonMatchingKeepsWaiting(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		require.Fail(t, "recoverSystemdFido2Password did not return within deadline overrun budget")
 	}
+}
+
+// TestEagerPromptEmptyEnterReturnsFido2Skipped: when a PIN-required token's
+// PIN prompt is answered with empty Enter, the function returns
+// errFido2Skipped so the serial dispatcher can advance to the next
+// PIN-bearing token (TPM2-PIN, etc.) without waiting for a device. This is
+// the deadlock break: an empty hidraw at boot no longer parks the serial
+// loop for the full token-timeout.
+func TestEagerPromptEmptyEnterReturnsFido2Skipped(t *testing.T) {
+	credID := []byte("our-credential")
+	fake := &fakeFidoForPreflight{presentCreds: map[string]bool{}}
+	installFakeFido2Plugin(t, fake)
+	resp := withFakeFido2Pin(t, []string{""}) // empty Enter
+
+	withFakeHidrawDevices(t, []string{}, func() {
+		token := luks.Token{
+			Type:    "systemd-fido2",
+			ID:      0,
+			Slots:   []int{2},
+			Payload: makeFido2TokenPayload(t, credID, []byte("salt"), "io.systemd.cryptsetup", true, true, false),
+		}
+		_, err := recoverSystemdFido2Password(context.Background(), token, "cryptroot")
+		require.ErrorIs(t, err, errFido2Skipped, "expected errFido2Skipped on empty PIN")
+		require.Zero(t, fake.assertionCalls, "expected zero assertion calls when user skips")
+		require.Equal(t, 1, resp.calls, "expected exactly one PIN prompt")
+	})
+}
+
+// TestEagerPromptRepromptsWhenDeviceMissing: PIN prompt fires, user types PIN,
+// no FIDO2 device is plugged in → reprompt with "device not detected" prefix.
+// User plugs in the key (test injects it before second submission), types PIN
+// again → assertion fires against the now-present device.
+func TestEagerPromptRepromptsWhenDeviceMissing(t *testing.T) {
+	credID := []byte("our-credential")
+	fake := &fakeFidoForPreflight{presentCreds: map[string]bool{}}
+	installFakeFido2Plugin(t, fake)
+	resp := withFakeFido2Pin(t, []string{"1234", "1234"})
+
+	// Start with empty hidraw; the beforeReply hook plugs hidraw1 in and
+	// flips presentCreds between the first and second PIN prompts.
+	tmp := t.TempDir()
+	prev := hidrawSysPath
+	hidrawSysPath = tmp + "/"
+	t.Cleanup(func() { hidrawSysPath = prev })
+
+	resp.beforeReply = func(call int) {
+		if call != 2 {
+			return
+		}
+		devDir := filepath.Join(tmp, "hidraw1", "device")
+		require.NoError(t, os.MkdirAll(devDir, 0o755), "mkdir")
+		require.NoError(t, os.WriteFile(filepath.Join(devDir, "report_descriptor"), fidoHIDDescriptor, 0o644), "write desc")
+		fake.presentCreds["/dev/hidraw1:"+string(credID)] = true
+	}
+
+	token := luks.Token{
+		Type:    "systemd-fido2",
+		ID:      0,
+		Slots:   []int{2},
+		Payload: makeFido2TokenPayload(t, credID, []byte("salt"), "io.systemd.cryptsetup", true, true, false),
+	}
+	_, err := recoverSystemdFido2Password(context.Background(), token, "cryptroot")
+	require.NoError(t, err, "expected unlock to succeed after device arrived")
+	require.Equal(t, 1, fake.assertionCalls, "expected exactly one assertion call")
+	require.Equal(t, 2, resp.calls, "expected exactly 2 PIN prompts (initial + after device arrives)")
+	require.Contains(t, resp.prompts[1], "not detected", "expected second prompt to include 'not detected'")
+}
+
+// TestEagerPromptInvalidPinExhaustsAt3Attempts: assertion returns PIN-invalid
+// three times in a row. The function reprompts after attempts 1 and 2 with a
+// "PIN incorrect" prefix, and bails to keyboard fallback after the 3rd. Only
+// assertion calls that actually attempted with a PIN count toward the cap.
+func TestEagerPromptInvalidPinExhaustsAt3Attempts(t *testing.T) {
+	credID := []byte("our-credential")
+	pinErr := errors.New("pin invalid sentinel")
+	fake := &fakeFidoForPreflight{
+		presentCreds: map[string]bool{"/dev/hidraw0:" + string(credID): true},
+		assertionFn: func(call int, devPath, pin string) ([]byte, error) {
+			return nil, pinErr // always wrong
+		},
+		pinInvalidFn: func(err error) bool { return errors.Is(err, pinErr) },
+	}
+	installFakeFido2Plugin(t, fake)
+	resp := withFakeFido2Pin(t, []string{"1111", "2222", "3333"})
+
+	withFakeHidrawDevices(t, []string{"hidraw0"}, func() {
+		token := luks.Token{
+			Type:    "systemd-fido2",
+			ID:      0,
+			Slots:   []int{2},
+			Payload: makeFido2TokenPayload(t, credID, []byte("salt"), "io.systemd.cryptsetup", true, true, false),
+		}
+		_, err := recoverSystemdFido2Password(context.Background(), token, "cryptroot")
+		require.ErrorIs(t, err, errFido2FallbackToKeyboard, "expected errFido2FallbackToKeyboard after PIN attempts exhausted")
+		require.Equal(t, 3, fake.assertionCalls, "expected exactly 3 assertion calls (PIN cap)")
+		require.Equal(t, 3, resp.calls, "expected exactly 3 PIN prompts")
+		require.Contains(t, resp.prompts[1], "PIN incorrect", "expected second prompt to include 'PIN incorrect'")
+	})
+}
+
+// TestEagerPromptFiresPromptBeforeUsbhidReady: the whole point of the
+// eager-prompt path is to surface a PIN prompt BEFORE any hardware bind, so
+// the user can type while the kernel is still loading usbhid. Regression
+// guard: previous revisions called waitForUsbhid up-front, which in QEMU
+// (no USB HID device → no usbhid uevent → usbhidReady never closes) blocked
+// the goroutine until tokenTimeout, defeating the entire feature.
+func TestEagerPromptFiresPromptBeforeUsbhidReady(t *testing.T) {
+	// Force a fresh, never-closed usbhidReady for this test (other tests in
+	// the package close it as a side effect, so we cannot rely on initial
+	// state).
+	prevUsbhid := usbhidReady
+	usbhidReady = make(chan struct{})
+	t.Cleanup(func() { usbhidReady = prevUsbhid })
+
+	credID := []byte("our-credential")
+	fake := &fakeFidoForPreflight{presentCreds: map[string]bool{}}
+	installFakeFido2Plugin(t, fake)
+	resp := withFakeFido2Pin(t, []string{""}) // empty Enter → errFido2Skipped
+
+	withFakeHidrawDevices(t, []string{}, func() {
+		token := luks.Token{
+			Type:    "systemd-fido2",
+			ID:      0,
+			Slots:   []int{2},
+			Payload: makeFido2TokenPayload(t, credID, []byte("salt"), "io.systemd.cryptsetup", true, true, false),
+		}
+		done := make(chan error, 1)
+		go func() {
+			_, err := recoverSystemdFido2Password(context.Background(), token, "cryptroot")
+			done <- err
+		}()
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, errFido2Skipped, "expected errFido2Skipped on empty PIN")
+		case <-time.After(time.Second):
+			require.Fail(t, "eager-prompt blocked waiting for usbhid — PIN prompt never fired")
+		}
+		require.Equal(t, 1, resp.calls, "expected exactly one PIN prompt")
+	})
+}
+
+// TestEagerPromptHappyPath: device present at function entry, PIN correct on
+// first try → single prompt, single assertion, success.
+func TestEagerPromptHappyPath(t *testing.T) {
+	credID := []byte("our-credential")
+	fake := &fakeFidoForPreflight{
+		presentCreds: map[string]bool{"/dev/hidraw0:" + string(credID): true},
+	}
+	installFakeFido2Plugin(t, fake)
+	resp := withFakeFido2Pin(t, []string{"1234"})
+
+	withFakeHidrawDevices(t, []string{"hidraw0"}, func() {
+		token := luks.Token{
+			Type:    "systemd-fido2",
+			ID:      0,
+			Slots:   []int{2},
+			Payload: makeFido2TokenPayload(t, credID, []byte("salt"), "io.systemd.cryptsetup", true, true, false),
+		}
+		_, err := recoverSystemdFido2Password(context.Background(), token, "cryptroot")
+		require.NoError(t, err, "expected unlock to succeed")
+		require.Equal(t, 1, resp.calls, "expected exactly 1 PIN prompt")
+		require.Equal(t, 1, fake.assertionCalls, "expected exactly 1 assertion call")
+	})
 }


### PR DESCRIPTION
## Background

Previously we waited for a FIDO2 device to be present before prompting for PIN entry. That meant a PIN-required token with no device could hang the FIDO2 goroutine until `tokenTimeout`, blocking a pinned TPM (or any subsequent token) from ever reaching its own prompt. The status messages "Waiting for FIDO2 security key for X..." and "No FIDO2 device found..." informed the user but didn't unblock the dispatcher.

The LUKS token JSON already tells us whether a PIN is required (`fido2-clientPin-required`), so we don't need a device in hand to know we'll need a PIN. Better to prompt eagerly from header metadata, then check for a device on submission and return a skip-sentinel if it's missing — the dispatcher advances to the next token instead of parking.

For pinless tokens there's no eager prompt to fire, but we don't want the "No FIDO2 device found" hint flickering on every boot where a faster non-interactive token (TPM2, clevis) was about to win. Defer it behind `tokenTimeout/2` (capped at 10s) — slow tokens get time to unlock first, and the hint only surfaces when it's actually useful.

Relatively free fix; should just work.

## Commits

1. `init/luks: eager FIDO2 PIN prompt for PIN-required tokens` — new `recoverFido2WithEagerPrompt` driving the prompt-first flow + `errFido2Skipped` sentinel for empty-Enter advance. 5 unit tests cover empty-Enter, reprompt-on-missing-device, PIN-attempt cap, happy path, and a regression guard for the next commit's behavior.
2. `init/luks: defer pinless "No FIDO2 device found" behind tokenTimeout/2 timer` — replaces the upstream's immediate-fire status message with a per-mapping timer (dedup via `sync.Once`).
3. `init/luks: trim 'to passphrase' from FIDO2 PIN prompt` — wording fix; empty-Enter actually advances to the next token (TPM2-PIN, more FIDO2, etc.), only reaching passphrase if all tokens exhaust.
4. `init/luks: drop waitForUsbhid block from pinless FIDO2 path` — both pinless and eager paths previously blocked on `waitForUsbhid` before the timer/rescan could fire. On usbhid-less configs (QEMU without USB, headless servers, PS2/i2c-only HID) `usbhidReady` never closes; `registerHidrawListener` already catches late `add` events independently, so the wait was only delaying the user.

## Testing

- `go build` and `go vet ./...` clean
- Each commit individually builds cleanly
- 5 new unit tests pass — testify throughout
- Plymouth-graphical QEMU verification on `fido2-nodev-pin`: Flow A (empty-Enter → fallback at t≈4s vs t≈32s before), Flow B (typed-PIN, no device → "FIDO2 device not detected — Enter FIDO2 PIN…" reprompt → empty-Enter → fallback → unlock)
- Smoke matrix on the rebased branch: `passphrase`, `tpm2`, `tpm2-pin`, `fido2-nodev`, `fido2-nodev-pin`, `clevis-tang` — no regressions