### PR TITLE
init: console-mode prompt and log output cleanup

### DIFF
--- a/init/console_input.go
+++ b/init/console_input.go
@@ -89,6 +89,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"unicode/utf8"
 
@@ -506,6 +507,20 @@ func consolePrint(msg string) {
 		_, _ = fmt.Fprint(devKmsg, "<", 2, ">booster: ", msg, "\n")
 	} else {
 		fmt.Print(msg)
+	}
+}
+
+// consolePrintWithPromptRedraw writes msg to the console under consoleMu,
+// re-painting any active password prompt below so the user's cursor stays
+// at the bottom. Used by log levels (info, warning, severe) which would
+// otherwise overwrite the prompt line mid-input.
+func consolePrintWithPromptRedraw(msg string) {
+	consoleMu.Lock()
+	defer consoleMu.Unlock()
+	if consolePrompt.active && !promptVolumeUnlocked() {
+		consolePrint(msg + "\n" + consolePrompt.text + strings.Repeat("*", consolePrompt.asterisks))
+	} else {
+		consolePrint(msg + "\n")
 	}
 }
 

--- a/init/console_input.go
+++ b/init/console_input.go
@@ -752,7 +752,9 @@ loop:
 	}
 
 	if postPrompt != "" {
-		console(postPrompt)
+		// Newline before the postPrompt so it renders on its own line below
+		// the typed asterisks, not glued to the right of them.
+		console("\n" + postPrompt)
 	}
 	if !quirk.TestEnabled {
 		console("\n")

--- a/init/logging.go
+++ b/init/logging.go
@@ -43,7 +43,7 @@ func printMessage(format string, requestedLevel, kernelLevel int, v ...any) {
 		}
 	}
 	if printToConsole {
-		fmt.Println(msg)
+		consolePrintWithPromptRedraw(msg)
 	}
 }
 

--- a/init/luks.go
+++ b/init/luks.go
@@ -718,15 +718,14 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 
 		if err != nil {
 			if errors.Is(err, errFido2Skipped) || pinExhausted {
-				statusMessage("FIDO2 skipped, falling back to passphrase")
-				break
+				break // passphrase prompt is self-explanatory
 			}
 			if isFido2PinAuthBlockedError(err) {
-				statusMessage("FIDO2 PIN auth blocked (too many wrong attempts), falling back to passphrase")
+				statusMessageIfPrompt("FIDO2 PIN auth blocked (too many wrong attempts), falling back to passphrase")
 				break
 			}
 			if isFido2PinBlockedError(err) {
-				statusMessage("FIDO2 PIN is blocked (reset required), falling back to passphrase")
+				statusMessageIfPrompt("FIDO2 PIN is blocked (reset required), falling back to passphrase")
 				break
 			}
 			// Safety net only — pre-flight should have prevented us getting
@@ -944,8 +943,7 @@ func recoverSystemdTPM2Password(ctx context.Context, t luks.Token, mappingName s
 				return nil, err
 			}
 			if len(pin) == 0 {
-				statusMessage("TPM2 PIN skipped")
-				return nil, errTPM2Skipped
+				return nil, errTPM2Skipped // passphrase prompt is self-explanatory
 			}
 			authValue = tpm2PINAuthValue(pin, salt)
 		}
@@ -1123,7 +1121,8 @@ func recoverTokenPassword(ctx context.Context, volumes chan *luks.Volume, d luks
 	if !tryPassphraseAgainstSlots(ctx, volumes, d, t.Slots, password) {
 		return false
 	}
-	statusMessage(mappingName + " unlocked via " + tokenFriendlyName(t.Type))
+	// TODO: re-evaluate after plymouth!393 lands (auto-dismisses prompt on client disconnect)
+	statusMessageIfPrompt(mappingName + " unlocked via " + tokenFriendlyName(t.Type))
 	return true
 }
 

--- a/init/luks.go
+++ b/init/luks.go
@@ -374,7 +374,7 @@ func recoverFido2Password(ctx context.Context, devName string, credID []byte, sa
 	defer releaseFido2Lock()
 
 	if plymouthEnabled {
-		plymouthMessage("") // clear "Waiting for FIDO2" now that device is detected and we have the lock
+		plymouthMessage("") // clear "No FIDO2 device found" now that we have one and the lock
 	}
 
 	saltBytes, err := base64.StdEncoding.DecodeString(salt)
@@ -542,8 +542,6 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 	if node.PinRequired {
 		return recoverFido2WithEagerPrompt(ctx, mappingName, credID, node.Salt, node.RelyingParty, node.UserPresenceRequired, node.UserVerificationRequired)
 	}
-
-	statusMessage("Waiting for FIDO2 security key for " + mappingName + "...")
 
 	// Register BEFORE reading /sys/class/hidraw so any 'add' events arriving
 	// during/after the scan are buffered. We deliberately do NOT block on

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -226,6 +226,20 @@ func statusMessage(msg string) {
 	}
 }
 
+// Plymouth always shows; console shows only when a password prompt is visible.
+func statusMessageIfPrompt(msg string) {
+	if plymouthEnabled {
+		statusMessage(msg)
+		return
+	}
+	consoleMu.Lock()
+	visible := consolePrompt.active && !promptVolumeUnlocked()
+	consoleMu.Unlock()
+	if visible {
+		statusMessage(msg)
+	}
+}
+
 // promptVolumeUnlocked reports whether the active prompt's volume has been
 // unlocked already (its done channel has closed). Caller must hold consoleMu.
 func promptVolumeUnlocked() bool {


### PR DESCRIPTION
This PR descends from a review-thread inventory in #365 where I
classified every `statusMessage` I had added across the FIDO2 / TPM2 /
clevis paths and proposed how to treat each: gate prompt-dismissal
context on an active prompt, defer "Waiting for FIDO2" behind a short
timer, keep "Unlocking via SSH..." (remote-only audience), keep "No
FIDO2 device found" gated by `quiet`.

Implementation drifted from that plan in two ways worth flagging:

1. **"Waiting for FIDO2"** ended up dropped entirely (not deferred).
   The eager-prompt path in #372 takes over for PIN-required tokens —
   the PIN prompt itself signals "we're waiting" — and the deferred-
   timer idea got applied to "No FIDO2 device found" instead. Same
   "only fire if something is actually wrong" goal, better placed.

2. **"FIDO2 skipped" and "TPM2 PIN skipped"** were classified as
   actionable in the inventory but ended up dropped. With the eager-
   prompt path landed, empty-Enter advances the dispatcher immediately
   and the next prompt (TPM2-PIN or passphrase) appears within
   milliseconds — that prompt IS the notification. A separate
   "X skipped" line just adds noise to the same UI event.

Scope also grew to include two console-output discipline fixes
(commits 3 and 4) that surfaced during the QEMU console-mode
verification matrix for #372 — log lines clobbering active prompts,
and "Unlocking..." rendering on the same line as typed asterisks.
Same "don't trample a visible prompt" theme so they ride along here.

"X unlocked via Y" was planned for gating; the gate is in place but I
had hoped [plymouth!393](https://gitlab.freedesktop.org/plymouth/plymouth/-/merge_requests/393)
would land before v.13 to obsolete the message entirely (Plymouth
auto-dismisses prompts when the client disconnects). !393 hasn't
gotten any review attention upstream, so the gate stays for now.

## Commits

1. **drop premature "Waiting for FIDO2" status** — fired unconditionally
   as the first action of `recoverSystemdFido2Password`, even when the
   key was already plugged in. "No FIDO2 device found" and "Please
   touch the FIDO2 key" already cover the real UI states.

2. **prompt-gate fallback messages, drop redundant ones** — new
   `statusMessageIfPrompt` helper (shows under Plymouth or when a
   console prompt is active). Applied to the legacy FIDO2 path +
   `recoverSystemdTPM2Password`: drop "FIDO2 skipped" / "TPM2 PIN
   skipped" entirely (next prompt is the notification); gate "PIN auth
   blocked" / "PIN is blocked" to active-prompt only; gate "X unlocked
   via Y" with the TODO above.

3. **route console log prints through prompt-redraw helper** —
   `info`/`warning`/`severe` previously printed via `fmt.Println`
   without taking `consoleMu` or re-painting the prompt. New
   `consolePrintWithPromptRedraw` acquires the mutex, writes the
   message, re-paints the active prompt + typed asterisks below so the
   cursor stays at the bottom.

4. **render password postPrompt on its own line** — the "Unlocking..."
   text rendered on the same line as the typed asterisks
   (`Enter passphrase: ********   Unlocking...`). Prepend a newline so
   it sits below the prompt.

## Testing

- `go build` and `go vet ./...` clean; each commit builds cleanly
- FIDO2 / preflight / eager-prompt / console suite passes
- QEMU-verified in a 16-scenario matrix (Plymouth graphical + console
  graphical) earlier this week
