### PR TITLE
generator: Automatically enable LVM if unspecified and we detect it above the rootfs

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -84,6 +84,7 @@ Booster advantages:
     The following config properties are taken into account: `KEYMAP`, `KEYMAP_TOGGLE`, `FONT`, `FONT_MAP`, `FONT_UNIMAP`. See also [man vconsole.conf](https://man.archlinux.org/man/vconsole.conf.5.en).
 
  * `enable_lvm` is a flag that enables LVM volume assembly at the boot time. This flag also makes sure all the required modules/binaries are added to the image.
+   If not specified, it will be automatically enabled at build time if needed. Set to `false` to forcibly disable.
 
  * `enable_mdraid` is a flag that enables MdRaid assembly at the boot time. This flag also makes sure all the required modules/binaries are added to the image.
 

--- a/generator/config.go
+++ b/generator/config.go
@@ -65,7 +65,7 @@ type UserConfig struct {
 	EmergencyShellPassword string `yaml:"emergency_shell_password,omitempty"` // argon2id PHC; gates the emergency shell
 	StripBinaries          bool   `yaml:"strip,omitempty"`                    // if strip symbols from the binaries, shared libraries and kernel modules
 	EnableVirtualConsole   bool   `yaml:"vconsole,omitempty"`                 // configure virtual console at boot time using config from https://www.freedesktop.org/software/systemd/man/vconsole.conf.html
-	EnableLVM              bool   `yaml:"enable_lvm"`
+	EnableLVM              *bool  `yaml:"enable_lvm"`
 	EnableMdraid           bool   `yaml:"enable_mdraid"`
 	MdraidConfigPath       string `yaml:"mdraid_config_path"`
 	EnableZfs              bool   `yaml:"enable_zfs"`
@@ -256,7 +256,8 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 	conf.readModprobeOptions = readModprobeOptions
 	conf.appendAllModAliases = u.AppendAllModAliases
 	conf.stripBinaries = u.StripBinaries || opts.BuildCommand.Strip
-	conf.enableLVM = u.EnableLVM
+	conf.enableLVM = u.EnableLVM != nil && *u.EnableLVM
+	conf.autoEnableLVM = u.EnableLVM == nil
 	conf.emergencyShellPassword = u.EmergencyShellPassword
 	conf.enableMdraid = u.EnableMdraid
 	conf.mdraidConfigPath = u.MdraidConfigPath

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -39,6 +39,7 @@ type generatorConfig struct {
 	readModprobeOptions     func() (map[string]string, error)
 	stripBinaries           bool
 	enableLVM               bool
+	autoEnableLVM		bool
 	enableMdraid            bool
 	mdraidConfigPath        string
 	enableZfs               bool
@@ -200,6 +201,21 @@ func generateInitRamfs(conf *generatorConfig) error {
 	if conf.networkConfigType != netOff {
 		if err := kmod.activateModules(true, false, "kernel/drivers/net/ethernet/"); err != nil {
 			return err
+		}
+	}
+
+	// Detect if LVM is needed
+	if conf.autoEnableLVM {
+		if rootMount, err  := GetRootMountInfo(); err != nil {
+			warning("Failed to automatically determine LVM requirement: %v", err)
+		} else {
+			for _, dev := range rootMount.parentDevices {
+				if dev.devtype == "lvm" {
+					debug("Automatically enabling LVM as root device %s requires it", rootMount.rootMountInfo.Source)
+					conf.enableLVM = true
+					break
+				}
+			}
 		}
 	}
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -39,7 +39,7 @@ type generatorConfig struct {
 	readModprobeOptions     func() (map[string]string, error)
 	stripBinaries           bool
 	enableLVM               bool
-	autoEnableLVM		bool
+	autoEnableLVM           bool
 	enableMdraid            bool
 	mdraidConfigPath        string
 	enableZfs               bool
@@ -206,7 +206,7 @@ func generateInitRamfs(conf *generatorConfig) error {
 
 	// Detect if LVM is needed
 	if conf.autoEnableLVM {
-		if rootMount, err  := GetRootMountInfo(); err != nil {
+		if rootMount, err := GetRootMountInfo(); err != nil {
 			warning("Failed to automatically determine LVM requirement: %v", err)
 		} else {
 			for _, dev := range rootMount.parentDevices {

--- a/generator/quirk/notesting.go
+++ b/generator/quirk/notesting.go
@@ -1,0 +1,6 @@
+//go:build !test
+
+package quirk
+
+// TestEnabled reports if the test flag is enabled.
+const TestEnabled = false

--- a/generator/quirk/testing.go
+++ b/generator/quirk/testing.go
@@ -1,0 +1,6 @@
+//go:build test
+
+package quirk
+
+// TestEnabled reports if the test flag is enabled.
+const TestEnabled = true

--- a/generator/rootmountinfo.go
+++ b/generator/rootmountinfo.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/anatol/booster/generator/quirk"
 	"github.com/moby/sys/mountinfo"
 )
 
@@ -31,7 +32,14 @@ func (o *RootMountInfo) GetSysfsPath(majmin string) string {
 }
 
 func (o *RootMountInfo) GetRootDevice() error {
-	mnts, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter("/"))
+	mntPoint := "/"
+	if quirk.TestEnabled {
+		if tmpMnt := os.Getenv("BOOSTER_TEST_ROOT_MOUNTPOINT"); tmpMnt != "" {
+			mntPoint = tmpMnt
+		}
+	}
+
+	mnts, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter(mntPoint))
 	if err != nil {
 		return err
 	} else if len(mnts) == 0 {

--- a/generator/rootmountinfo.go
+++ b/generator/rootmountinfo.go
@@ -44,13 +44,13 @@ func (o *RootMountInfo) GetRootDevice() (error) {
 }
 
 func (o *RootMountInfo) GetBlockDeviceInfo(devPath string) (*BlockDeviceInfo, error) {
-	fpDevNum, err := os.Open(devPath + "/dev")
+	devNum, err := os.ReadFile(devPath + "/dev")
 	if err != nil {
 		return nil, err
 	}
 
 	var devMajor, devMinor uint32
-	num, err := fmt.Fscanf(fpDevNum, "%d:%d", &devMajor, &devMinor)
+	num, err := fmt.Sscanf(string(devNum), "%d:%d", &devMajor, &devMinor)
 	if err != nil {
 		return nil, err
 	}

--- a/generator/rootmountinfo.go
+++ b/generator/rootmountinfo.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"strconv"
+
+	"github.com/moby/sys/mountinfo"
+)
+
+type RootMountInfo struct {
+	seenDevices []string // Track the ones we've seen to avoid infinite recursion
+
+	rootMountInfo *mountinfo.Info
+	parentDevices []*BlockDeviceInfo
+}
+
+type BlockDeviceInfo struct {
+	name string
+	major uint32
+	minor uint32
+	devtype string
+}
+
+func (o *RootMountInfo) GetSysfsPath(majmin string) (string) {
+	return "/sys/dev/block/" + majmin
+}
+
+func (o *RootMountInfo) GetRootDevice() (error) {
+	mnts, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter("/"))
+	if err != nil {
+		return err
+	} else if len(mnts) == 0 {
+		return fmt.Errorf("GetMounts returned no results")
+	}
+
+	o.rootMountInfo = mnts[0]
+
+	return err
+}
+
+func (o *RootMountInfo) GetBlockDeviceInfo(devPath string) (*BlockDeviceInfo, error) {
+	fpDevNum, err := os.Open(devPath + "/dev")
+	if err != nil {
+		return nil, err
+	}
+
+	var devMajor, devMinor uint32
+	num, err := fmt.Fscanf(fpDevNum, "%d:%d", &devMajor, &devMinor)
+	if err != nil {
+		return nil, err
+	}
+	if num != 2 {
+		return nil, fmt.Errorf("GetBlockDeviceInfo: Failed parsing %s/dev", devPath)
+	}
+
+	devInfo := &BlockDeviceInfo{}
+	devInfo.name = filepath.Base(devPath)
+	devInfo.major = devMajor
+	devInfo.minor = devMinor
+	devInfo.devtype = devInfo.GetDeviceType(devPath)
+
+	debug("GetBlockDeviceInfo: name=%s, dev=%d:%d, devtype=%s", devInfo.name, devInfo.major, devInfo.minor, devInfo.devtype)
+
+	return devInfo, nil
+}
+
+func (o *RootMountInfo) GetDeviceParents(devPath string) ([]*BlockDeviceInfo, error) {
+	var devs []*BlockDeviceInfo
+	var files []os.DirEntry
+
+	devPath = o.realpath(devPath)
+
+	if slices.Contains(o.seenDevices, filepath.Base(devPath)) {
+		return devs, nil
+	}
+
+	devInfo, err := o.GetBlockDeviceInfo(devPath)
+	if err != nil {
+		return nil, err
+	}
+	o.seenDevices = append(o.seenDevices, devInfo.name)
+
+	devs = append(devs, devInfo)
+
+	slavesPath := devPath + "/slaves"
+	if files, err = os.ReadDir(slavesPath); err != nil {
+		return devs, nil
+	}
+
+	for _, file := range files {
+		parents, err := o.GetDeviceParents(slavesPath + "/" + file.Name())
+		if err != nil {
+			debug("GetDeviceParents: ignoring inner error: %v", err)
+			continue
+		}
+		devs = append(devs, parents...)
+	}
+
+	return devs, nil
+}
+
+func (o *RootMountInfo) realpath(path string) (string) {
+	if resolvedPath, err := filepath.EvalSymlinks(path); err == nil {
+		if absPath, err := filepath.Abs(resolvedPath); err == nil {
+			return absPath
+		}
+	}
+	return path
+}
+
+func (o *BlockDeviceInfo) GetDeviceType(devPath string) (string) {
+	var devType []byte
+	var err error
+
+	// If this is a device-mapper device
+	// just return the lowercased UUID prefix
+	// The ones we're interested in will be "CRYPT-" or "LVM-"
+	devType, err = os.ReadFile(devPath + "/dm/uuid")
+	if err == nil {
+		if prefix, _, ok := bytes.Cut(devType, []byte("-")); ok {
+			return strings.ToLower(string(prefix))
+		}
+	}
+
+	// Is it a partition?
+	// Partitions will be at /sys/.../sda/sda1 or /sys/.../mmcblk0/mmcblk0p1
+	parentName := filepath.Base(filepath.Dir(devPath))
+	devName := filepath.Base(devPath)
+
+	// Strip parentName from devName
+	// parentName: sda
+	// devName: sda2 -> 2
+	if suffix, ok := strings.CutPrefix(devName, parentName); ok {
+		// If devName was mmcblk0p1, we need to also strip the leading p
+		suffix = strings.TrimPrefix(suffix, "p")
+		debug("GetDeviceType: parent=%s, dev=%s", parentName, devName)
+
+		if _, err := strconv.Atoi(suffix); err == nil {
+			return "part"
+		}
+	}
+
+	return "disk"
+}
+
+func GetRootMountInfo() (*RootMountInfo, error) {
+	root := &RootMountInfo{}
+	if err := root.GetRootDevice(); err != nil {
+		return nil, err
+	}
+
+	majminRoot := fmt.Sprintf("%d:%d", root.rootMountInfo.Major, root.rootMountInfo.Minor)
+	rootPath := root.GetSysfsPath(majminRoot)
+
+	devs, err := root.GetDeviceParents(rootPath)
+	if err != nil {
+		return nil, err
+	}
+	root.parentDevices = devs
+
+	return root, nil
+}

--- a/generator/rootmountinfo.go
+++ b/generator/rootmountinfo.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/moby/sys/mountinfo"
 )
@@ -20,17 +20,17 @@ type RootMountInfo struct {
 }
 
 type BlockDeviceInfo struct {
-	name string
-	major uint32
-	minor uint32
+	name    string
+	major   uint32
+	minor   uint32
 	devtype string
 }
 
-func (o *RootMountInfo) GetSysfsPath(majmin string) (string) {
+func (o *RootMountInfo) GetSysfsPath(majmin string) string {
 	return "/sys/dev/block/" + majmin
 }
 
-func (o *RootMountInfo) GetRootDevice() (error) {
+func (o *RootMountInfo) GetRootDevice() error {
 	mnts, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter("/"))
 	if err != nil {
 		return err
@@ -104,7 +104,7 @@ func (o *RootMountInfo) GetDeviceParents(devPath string) ([]*BlockDeviceInfo, er
 	return devs, nil
 }
 
-func (o *RootMountInfo) realpath(path string) (string) {
+func (o *RootMountInfo) realpath(path string) string {
 	if resolvedPath, err := filepath.EvalSymlinks(path); err == nil {
 		if absPath, err := filepath.Abs(resolvedPath); err == nil {
 			return absPath
@@ -113,7 +113,7 @@ func (o *RootMountInfo) realpath(path string) (string) {
 	return path
 }
 
-func (o *BlockDeviceInfo) GetDeviceType(devPath string) (string) {
+func (o *BlockDeviceInfo) GetDeviceType(devPath string) string {
 	var devType []byte
 	var err error
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/keys-pub/go-libfido2 v1.5.3
 	github.com/klauspost/compress v1.18.6
+	github.com/moby/sys/mountinfo v0.7.2
 	github.com/stretchr/testify v1.11.1
 	github.com/ulikunitz/xz v0.5.15
 	github.com/vishvananda/netlink v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/lestrrat-go/jwx/v3 v3.1.1 h1:yd9AdPmZ4INnQ7k42IrzXYpnEG803+SrQ6hdMvzH
 github.com/lestrrat-go/jwx/v3 v3.1.1/go.mod h1:uw/MN2M/Xiu4FhwcIwH11Zsh9JWx9SWzgALl7/uIEkU=
 github.com/lestrrat-go/option/v2 v2.0.0 h1:XxrcaJESE1fokHy3FpaQ/cXW8ZsIdWcdFzzLOcID3Ss=
 github.com/lestrrat-go/option/v2 v2.0.0/go.mod h1:oSySsmzMoR0iRzCDCaUfsCzxQHUEuhOViQObyy7S6Vg=
+github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
+github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -60,6 +60,7 @@ var assetGenerators = map[string]assetGenerator{
 	"gpt.img":             {"gpt.sh", []string{"FS_UUID=e5404205-ac6a-4e94-bb3b-14433d0af7d1", "FS_LABEL=newpart"}},
 	"gpt_4ksector.img":    {"gpt_4ksector.sh", nil},
 	"lvm.img":             {"lvm.sh", []string{"FS_UUID=74c9e30c-506f-4106-9f61-a608466ef29c", "FS_LABEL=lvmr00t"}},
+	"autolvm.img":         {"autolvm.sh", []string{"FS_UUID=bd540d27-b1fc-4232-8bf2-a18514e5c4b1", "FS_LABEL=lvmr00t"}},
 	"mdraid_raid1.img":    {"mdraid_raid1.sh", []string{"FS_UUID=98b1a905-3c72-42f0-957a-6c23b303b1fd", "FS_LABEL=boosmdraid"}},
 	"mdraid_raid5.img":    {"mdraid_raid5.sh", []string{"FS_UUID=e62c7dc0-5728-4571-b475-7745de2eef1e", "FS_LABEL=boosmdraid"}},
 	"btrfs_raid0.img":     {"btrfs_raid0.sh", []string{"FS_UUID=5eaa0c1c-e1dc-4be7-9b03-9f1ed5a87289"}},

--- a/tests/autolvm_test.go
+++ b/tests/autolvm_test.go
@@ -1,0 +1,77 @@
+package tests
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type AutoLVMInitConfig struct {
+	EnableLVM bool `yaml:",omitempty"`
+}
+
+func AutoLVMScript(script string, env ...string) error {
+	if testing.Verbose() {
+		fmt.Printf("Running script %s\n", script)
+	}
+	err := shell(script, env...)
+	return err
+}
+
+func TestAutoLVM(t *testing.T) {
+	tmp := t.TempDir()
+	mntPoint := filepath.Join(tmp, "mount")
+
+	require.NoError(t, checkAsset("assets/autolvm.img"))
+
+	if err := AutoLVMScript("scripts/autolvm_pre.sh", "OUTPUT=assets/lvm.img", "MNTPOINT="+mntPoint); err != nil {
+		t.Skip("Setup script failed")
+	}
+	defer AutoLVMScript("scripts/autolvm_post.sh", "OUTPUT=assets/lvm.img", "MNTPOINT="+mntPoint)
+
+	outputFile, err := generateInitRamfs(tmp, Opts{
+		enableAutoLVM:    true,
+		generatorEnvvars: []string{"BOOSTER_TEST_ROOT_MOUNTPOINT=" + mntPoint},
+	})
+	require.NoError(t, err)
+
+	// Extract generated config
+	configString, err := exec.Command(binariesDir+"/generator", "cat", outputFile, "etc/booster.init.yaml").Output()
+	require.NoError(t, err)
+
+	var config AutoLVMInitConfig
+	yaml.Unmarshal(configString, &config)
+	require.True(t, config.EnableLVM)
+
+}
+
+func TestAutoLVMDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	mntPoint := filepath.Join(tmp, "mount")
+
+	require.NoError(t, checkAsset("assets/lvm.img"))
+
+	if err := AutoLVMScript("scripts/autolvm_pre.sh", "OUTPUT=assets/lvm.img", "MNTPOINT="+mntPoint); err != nil {
+		t.Skip("Setup script failed")
+	}
+	defer AutoLVMScript("scripts/autolvm_post.sh", "OUTPUT=assets/lvm.img", "MNTPOINT="+mntPoint)
+
+	outputFile, err := generateInitRamfs(tmp, Opts{
+		enableLVM:        false,
+		generatorEnvvars: []string{"BOOSTER_TEST_ROOT_MOUNTPOINT=" + mntPoint},
+	})
+	require.NoError(t, err)
+
+	// Extract generated config
+	configString, err := exec.Command(binariesDir+"/generator", "cat", outputFile, "etc/booster.init.yaml").Output()
+	require.NoError(t, err)
+
+	var config AutoLVMInitConfig
+	yaml.Unmarshal(configString, &config)
+	require.False(t, config.EnableLVM)
+
+}

--- a/tests/generators/autolvm.sh
+++ b/tests/generators/autolvm.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+trap 'quit' EXIT ERR
+
+quit() {
+  set +o errexit
+  sudo umount "${dir}"
+  rm -r "${dir}"
+  sudo vgchange -an booster_test_vg
+  sudo losetup -d "${lodev}"
+}
+
+truncate --size 100M "${OUTPUT}"
+lodev=$(sudo losetup -f -P --show "${OUTPUT}")
+# create 4 partitions of size 10, 15, 11, 63 megabytes
+sudo fdisk "${lodev}" <<< "g
+n
+
+
++10M
+n
+
+
++15M
+n
+
+
++11M
+n
+
+
+
+w
+"
+
+sudo pvcreate "${lodev}p1" "${lodev}p2" "${lodev}p4"
+sudo vgcreate booster_test_vg "${lodev}p2" "${lodev}p4" "${lodev}p1"
+sudo lvcreate -L 60M -n booster_test_lv booster_test_vg
+
+sudo mkfs.ext4 -U "${FS_UUID}" -L "${FS_LABEL}" /dev/booster_test_vg/booster_test_lv
+dir=$(mktemp -d)
+sudo mount /dev/booster_test_vg/booster_test_lv "${dir}"
+
+sudo chown "${USER}" "${dir}"
+mkdir "${dir}/sbin"
+cp assets/init "${dir}/sbin/init"

--- a/tests/scripts/autolvm_post.sh
+++ b/tests/scripts/autolvm_post.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set +o errexit
+
+sudo umount "${MNTPOINT}"
+sudo rm -r "${MNTPOINT}"
+sudo vgchange -an booster_test_vg
+lodev=$(sudo losetup -n -O name -j "${OUTPUT}")
+if [ -z "${lodev}" ]; then
+	echo "Couldn't find loop dev for ${OUTPUT}" >&2
+	exit 1
+fi
+sudo losetup -d "${lodev}"

--- a/tests/scripts/autolvm_pre.sh
+++ b/tests/scripts/autolvm_pre.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+trap 'err' ERR
+
+err() {
+  set +o errexit
+  sudo umount "${MNTPOINT}"
+  rm -r "${MNTPOINT}"
+  sudo vgchange -an booster_test_vg
+  sudo losetup -d "${lodev}"
+}
+
+lodev=$(sudo losetup -f -P --show "${OUTPUT}")
+sudo vgchange -ay booster_test_vg
+mkdir -p "${MNTPOINT}"
+sudo mount /dev/booster_test_vg/booster_test_lv "${MNTPOINT}"

--- a/tests/util.go
+++ b/tests/util.go
@@ -209,6 +209,7 @@ func generateInitRamfs(workDir string, opts Opts) (string, error) {
 	generatorArgs = append(generatorArgs, "--crypttab", crypttabArg)
 	generatorArgs = append(generatorArgs, output)
 	cmd := exec.Command(binariesDir+"/generator", generatorArgs...)
+	cmd.Env = append(os.Environ(), opts.generatorEnvvars...)
 	if testing.Verbose() {
 		log.Print("Create booster.img with " + cmd.String())
 		cmd.Stdout = os.Stdout
@@ -272,7 +273,7 @@ type GeneratorConfig struct {
 	ExtraFiles           string         `yaml:"extra_files,omitempty"`
 	StripBinaries        bool           `yaml:"strip,omitempty"` // strip symbols from the binaries, shared libraries and kernel modules
 	EnableVirtualConsole bool           `yaml:"vconsole,omitempty"`
-	EnableLVM            bool           `yaml:"enable_lvm"`
+	EnableLVM            *bool          `yaml:"enable_lvm"`
 	EnableMdraid         bool           `yaml:"enable_mdraid"`
 	MdraidConfigPath     string         `yaml:"mdraid_config_path"`
 	EnableZfs            bool           `yaml:"enable_zfs"`
@@ -310,7 +311,9 @@ func generateBoosterConfig(output string, opts Opts) error {
 	conf.ExtraFiles = opts.extraFiles
 	conf.StripBinaries = opts.stripBinaries
 	conf.EnableVirtualConsole = opts.enableVirtualConsole
-	conf.EnableLVM = opts.enableLVM
+	if !opts.enableAutoLVM {
+		conf.EnableLVM = &opts.enableLVM
+	}
 	conf.EnableMdraid = opts.enableMdraid
 	conf.MdraidConfigPath = opts.mdraidConf
 	conf.EnableZfs = opts.enableZfs
@@ -347,6 +350,7 @@ type Opts struct {
 	containsESP          bool // specifies whether the disks contain ESP with bootloader/kernel/initramfs
 	asIso                bool // generate ISO file instead of *.raw
 	scriptEnvvars        []string
+	generatorEnvvars     []string
 	mountTimeout         int           // in seconds
 	vmTimeout            time.Duration // QEMU VM timeout; 0 = use default (40s)
 	appendAllModAliases  bool
@@ -361,6 +365,7 @@ type Opts struct {
 	zfsCachePath         string // TODO: do we need any of these parameters?
 	crypttabFile         string // path to host crypttab to bundle; overrides /etc/crypttab
 	enableFido2          bool
+	enableAutoLVM        bool // separate flag so that we don't change the behaviour of other tests
 
 	// SSH remote-unlock options. Paths are passed through to the generator,
 	// which embeds the file contents into the initramfs config.


### PR DESCRIPTION
This will look through /sys to determine the types of the parent block devices and then enable LVM if we're a child of LVM and enable_lvm hasn't explicitly been disabled (similar to what dracut does)

I've managed to do this with only adding one tiny library requirement to avoid having to parse /proc/self/mountinfo myself. I do still need to add it to the end-to-end tests, but I'm posting it now for feedback.

This can probably also easily be extended to do the same for enable_mdraid