### PR TITLE
packaging,docs: recommend kernel-install for UKIs, fix the hook, deprecate regenerate_uki

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -396,14 +396,38 @@ For example if a user manually added `ext4` and kernel build system says `ext` m
 `mbcache` and `jbd2` automatically added to the image.
 
 ## Unified Kernel Image
-A [Unified Kernel Image](https://uapi-group.org/specifications/specs/unified_kernel_image/) (UKI) is a PE binary that bundles various boot components (e.g. kernel, initrd, and an UEFI boot stub) as a single executable.
-This allows for booting directly through the firmware (UEFI) as well as authenticating all of the boot components at once for Secure Boot.
+A [Unified Kernel Image](https://uapi-group.org/specifications/specs/unified_kernel_image/) (UKI) is a PE binary that bundles the boot components (kernel, initrd, kernel command line, and a UEFI boot stub) as a single executable.
+This allows booting directly through the firmware (UEFI) and authenticating all of the boot components at once for Secure Boot.
 
-To generate UKIs in Booster, please install the systemd UKI generator (systemd-ukify) from your distribution's package manager and use `/usr/lib/booster/regenerate_uki`.
-It is a convenience script that performs the same type of image regeneration as if you installed `booster` with your package manager, then passes the result to systemd's UKI generator (ukify) as input.
-The script only passes a subset of boot components, namely the system's microcode(s), initrd, os-release file, boot splash image and kernel. Kernel command-line entries of the UKI are inherited from `/etc/booster.yaml`.
+The recommended, cross-distribution way to build UKIs with Booster is through systemd's [kernel-install(8)](https://man7.org/linux/man-pages/man8/kernel-install.8.html). Booster ships a kernel-install plugin that generates the initrd; systemd's `ukify` plugin then assembles and optionally signs the UKI. Configure `/etc/kernel/install.conf`:
 
-Please note that to boot the UKI by default, it may be necessary to configure your system's boot loader configuration file(s) accordingly.
+    layout=uki
+    initrd_generator=booster
+    uki_generator=ukify
+
+The kernel command line is read from `/etc/kernel/cmdline` and embedded into the UKI:
+
+    # /etc/kernel/cmdline
+    rd.luks.uuid=<luks-uuid> root=UUID=<fs-uuid> rw
+
+Microcode and Secure Boot signing are configured in `/etc/kernel/uki.conf`, which `ukify` consumes (see [ukify(1)](https://man7.org/linux/man-pages/man1/ukify.1.html)):
+
+    [UKI]
+    Microcode=/boot/intel-ucode.img
+    SecureBootPrivateKey=/etc/kernel/secureboot/db.key
+    SecureBootCertificate=/etc/kernel/secureboot/db.crt
+
+Booster does not bundle CPU microcode into its initramfs, so point `Microcode=` at your distribution's early-microcode image (e.g. `/boot/intel-ucode.img` or `/boot/amd-ucode.img`); `ukify` adds it as the UKI's `.ucode` section. Set the kernel command line in `/etc/kernel/cmdline`, not in `uki.conf`.
+
+`ukify` can also sign TPM2 PCR policies (`PCRPrivateKey=`/`PCRBanks=`) for measured-boot binding.
+
+Distributions that already drive kernel installation through `kernel-install` (e.g. Fedora) build the UKI automatically. On Arch-based distributions, which use pacman hooks rather than `kernel-install`, a hook such as the AUR `pacman-hook-kernel-install` runs it on kernel updates; booster's own pacman hook can stay enabled (it then builds an unused plain initrd next to the UKI) or be disabled to avoid the redundant build.
+
+Embedding the command line matters for security. A UKI with no embedded command line accepts one from the boot loader at runtime, which is not part of the signed and measured image: an attacker could append e.g. `init=/bin/sh` and obtain a root shell on the decrypted filesystem after a TPM2 auto-unlock, because the measured boot chain — and therefore the TPM policy — is unchanged. When the command line is embedded it is measured into PCR 11, and under Secure Boot systemd-stub ignores any externally supplied command line.
+
+The legacy Arch-only helper `/usr/lib/booster/regenerate_uki` is deprecated: it does not embed the kernel command line and is therefore vulnerable to the injection described above. Prefer `kernel-install`.
+
+To boot the UKI by default you may also need to adjust your boot loader configuration.
 
 ## DEBUGGING
 If you have a problem with booster boot tool you can enable debug mode to get more
@@ -489,9 +513,9 @@ So /boot/loader/entries/booster.conf should look like this:
 
 Booster has no built-in Btrfs subvolume default. If `subvol=` (or `subvolid=`) is omitted, the kernel mounts the filesystem's configured default subvolume — set with `btrfs subvolume set-default <id> <path>` — falling back to the top-level subvolume (ID 5) when no default has been configured. Distro conventions like `@` (Arch), `root` (some Debian-derived installers), or `@/.snapshots/N/snapshot` (openSUSE) must be set explicitly in your bootloader entry; both `subvol=NAME` and `subvolid=ID` are accepted.
 
-Create a Unified Kernel Image and write the result to /boot/EFI/Linux:
+Build a Unified Kernel Image via kernel-install (with `/etc/kernel/install.conf` configured for the UKI layout as described under UNIFIED KERNEL IMAGE):
 
-    $ /usr/lib/booster/regenerate_uki build /boot/EFI/Linux
+    # kernel-install add "$(uname -r)" /usr/lib/modules/"$(uname -r)"/vmlinuz
 
 ## COPYRIGHT
 Booster is Copyright (C) 2020 Anatol Pomazau <http://github.com/anatol>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -66,7 +66,7 @@ package() {
   install -Dp -m755 init/fido2plugin.so "$pkgdir/usr/lib/booster/fido2plugin.so"
   install -Dp -m755 packaging/arch/regenerate_images "$pkgdir/usr/lib/booster/regenerate_images"
   install -Dp -m755 packaging/arch/regenerate_uki "$pkgdir/usr/lib/booster/regenerate_uki"
-  install -Dp -m755 packaging/common/50-booster.install "$pkgdir/usr/lib/kernel/install.d/50-booster.install"
+  install -Dp -m755 packaging/common/60-booster.install "$pkgdir/usr/lib/kernel/install.d/60-booster.install"
 
   install -Dp -m644 packaging/arch/90-booster-install.hook "$pkgdir/usr/share/libalpm/hooks/90-booster-install.hook"
   install -Dp -m755 packaging/arch/booster-install "$pkgdir/usr/share/libalpm/scripts/booster-install"

--- a/packaging/arch/regenerate_uki
+++ b/packaging/arch/regenerate_uki
@@ -25,6 +25,11 @@ usage() {
 }
 
 main() {
+  echo "regenerate_uki is DEPRECATED (booster#324) and will be removed in a future release." >&2
+  echo "It does not embed the kernel command line, so the resulting UKI is vulnerable to" >&2
+  echo "cmdline injection (e.g. init=/bin/sh) under TPM2 auto-unlock (booster#379)." >&2
+  echo "Use systemd kernel-install instead (layout=uki, initrd_generator=booster); see booster(1)." >&2
+
   local esp
   local package
   esp=$(pwd)

--- a/packaging/centos/booster.spec
+++ b/packaging/centos/booster.spec
@@ -66,7 +66,7 @@ touch $RPM_BUILD_ROOT/etc/booster.yaml
 %{__install} -Dp -m755 packaging/centos/booster-remove "$RPM_BUILD_ROOT/usr/share/yum-plugins/post-actions/scripts/booster-remove"
 %{__install} -Dp -m755 packaging/centos/booster-install-pre.action "$RPM_BUILD_ROOT/etc/yum/pre-actions/booster-pre.action"
 %{__install} -Dp -m755 packaging/centos/booster-install-post.action "$RPM_BUILD_ROOT/etc/yum/post-actions/booster-post.action"
-%{__install} -Dp -m755 packaging/common/50-booster.install "$RPM_BUILD_ROOT/usr/lib/kernel/install.d/50-booster.install"
+%{__install} -Dp -m755 packaging/common/60-booster.install "$RPM_BUILD_ROOT/usr/lib/kernel/install.d/60-booster.install"
 
 %files
 /etc/booster.yaml

--- a/packaging/common/60-booster.install
+++ b/packaging/common/60-booster.install
@@ -1,11 +1,15 @@
 #!/usr/bin/bash -e
 
+# kernel-install initrd_generator plugin. Named 60- so it runs after
+# 50-depmod.install: booster resolves module dependencies from the kernel's
+# modules.dep, which depmod (re)generates earlier in the same kernel-install run.
+
 COMMAND="${1:?}"
 KERNEL_VERSION="${2:?}"
 BOOT_DIR="$3"
 KERNEL_IMAGE="$4"
 
-# If the initrd was provide don the command line, we shouldn't generate our own
+# If the initrd was provided on the command line, we shouldn't generate our own
 # If the supplied image is a UKI, we don't need to create an initrd
 if [[ "$COMMAND" != "add" || "$#" -gt 4  || "$KERNEL_INSTALL_IMAGE_TYPE" = "uki" ]]; then
     exit 0
@@ -16,14 +20,14 @@ if [[ "$KERNEL_INSTALL_INITRD_GENERATOR" != "booster" ]]; then
     exit 0
 fi
 
-existing_image="$KERNEL_IMAGE%/*}/initrd"
+existing_image="${KERNEL_IMAGE%/*}/initrd"
 output_path="$KERNEL_INSTALL_STAGING_AREA/initrd"
 if [[ -f "$existing_image" ]]; then
     # we found an initrd at the same place as the kernel
     # use this and don't generate a new one
-    [[ "$KERNEL_INSTALL_VERBOSE" == 1 ]] && printf "Thres is an initrd image at the same place as the kernel, skipping generating a new one"
+    [[ "$KERNEL_INSTALL_VERBOSE" == 1 ]] && printf "There is an initrd image at the same place as the kernel, skipping generating a new one"
     cp --reflink=auto --no-preserve=ownership "$existing_image" "$output_path"
-    chmod 0600 "$KERNEL_INSTALL_STAGING_AREA/$IMAGE"
+    chmod 0600 "$output_path"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

Make systemd `kernel-install` the recommended, cross-distribution way to build Unified Kernel Images with booster, fix two latent bugs in booster's `kernel-install` initrd plugin, and deprecate the Arch-only `regenerate_uki` helper. Documentation and packaging only — no changes to `init/` or the generator.

## Motivation

Booster's only UKI tooling today is `packaging/arch/regenerate_uki`, an Arch-specific shell script that calls `ukify` **without** `--cmdline`. That has two problems:

- **It's a security gap.** With no embedded command line, the kernel cmdline is supplied by the boot loader at runtime and is not part of the measured image's policy-bound PCR. An attacker can append `init=/bin/sh` and get a root shell *after* a TPM2 auto-unlock, bypassing the protection entirely (#379). When the cmdline is embedded, it is measured into PCR 11 and systemd-stub ignores external overrides under Secure Boot.
- **It's distro-locked and a removal candidate** (#324).

`kernel-install` solves both, on every distro: with `initrd_generator=booster` + `uki_generator=ukify`, systemd's `60-ukify.install` embeds the cmdline from `/etc/kernel/cmdline`, and microcode / Secure Boot keys come from `/etc/kernel/uki.conf`. This keeps UKI assembly and signing in maintained systemd tooling, with booster decoupled as just the `initrd_generator`.

## Changes

**`packaging`: fix and reorder the kernel-install hook (`60-booster.install`)**

- Fix two bugs in the "initrd already beside the kernel" branch: a malformed parameter expansion (`${KERNEL_IMAGE%/*}`) computed the wrong source path, and the `chmod` referenced an unset `$IMAGE` instead of the staged output.
- Rename `50-booster.install` → `60-booster.install` so it runs **after** `50-depmod.install`: booster resolves module dependencies from the kernel's `modules.dep`, which depmod regenerates earlier in the same run (dracut and mkinitcpio order after depmod likewise).
- Update the Arch and CentOS packaging install paths.

**`docs,packaging`: kernel-install for UKIs, deprecate `regenerate_uki`**

- Rewrite the manpage UKI section around `kernel-install` (`/etc/kernel/install.conf` with `layout=uki`, `initrd_generator=booster`, `uki_generator=ukify`), with `/etc/kernel/cmdline` and `/etc/kernel/uki.conf` (microcode + Secure Boot keys) examples, and links to `kernel-install(8)` / `ukify(1)`.
- Note the cmdline must live in `/etc/kernel/cmdline`, not `uki.conf`'s `Cmdline=` (systemd #39373).
- Deprecate `regenerate_uki` with a runtime stderr notice (#324).
- Correct the manpage's inaccurate claim that the UKI command line is inherited from `/etc/booster.yaml`.

## Testing

- The documented `kernel-install → booster → ukify` UKI flow was validated end-to-end on real hardware (Arch-based CachyOS, limine): a UKI built via `kernel-install` with `initrd_generator=booster` + `uki_generator=ukify` booted and unlocked LUKS (FIDO2+PIN → TPM2+PIN → passphrase), with the cmdline embedded from `/etc/kernel/cmdline` and microcode from `uki.conf` (`ukify inspect` confirmed the `.linux`/`.initrd`/`.ucode`/`.cmdline` sections).
- The reworked `60-booster.install` was exercised under a mock `kernel-install` environment covering the skip conditions, the happy path, and the fixed existing-initrd branch.

## Notes

- The kernel-install hook is pre-existing (added in #279); this PR only fixes and reorders it.
- Sibling to forthcoming TPM2 supplantation-hardening work (the PCR15 re-unseal latch, #379); embedding the cmdline here is the precondition that makes the measured-boot side meaningful.
