### PR TITLE
init: PCR 15 re-unseal latch for systemd-tpm2 unlock (#379)

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -151,7 +151,7 @@ Some parts of booster boot functionality can be modified with kernel boot parame
     * **Initramfs file** — an absolute path (e.g. `/etc/luks/root.hdr`) to a header file bundled into the initramfs at build time via `extra_files`.
     * **Raw block device** — a device path (e.g. `/dev/sdb`) where the LUKS header begins at byte offset 0. Booster waits for the device to appear and passes it directly to cryptsetup without mounting.
     * **File on a separate device** — `$path:$deviceref` where `$deviceref` is `UUID=...`, `LABEL=...`, `PARTUUID=...`, or `PARTLABEL=...`. Booster mounts the device read-only, reads the header file, then unmounts before unlocking.
- * `rd.luks.options=opt1,opt2` a comma-separated list of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`. `token-timeout=<duration>` sets how long to wait for hardware tokens (FIDO2, TPM2) before also prompting for a keyboard passphrase. Accepts a decimal number followed by a unit (`s`, `m`, `h`), or a bare integer treated as seconds. Default is 30 s.
+ * `rd.luks.options=opt1,opt2` a comma-separated list of LUKS flags. Supported options are `discard`, `same-cpu-crypt`, `submit-from-crypt-cpus`, `no-read-workqueue`, `no-write-workqueue`. `token-timeout=<duration>` sets how long to wait for hardware tokens (FIDO2, TPM2) before also prompting for a keyboard passphrase. Accepts a decimal number followed by a unit (`s`, `m`, `h`), or a bare integer treated as seconds. Default is 30 s. `tpm2-measure-pcr=yes` or `tpm2-measure-pcr=no` forces or suppresses the PCR 15 re-unseal latch for the device (see **TPM2 unlock and the PCR 15 latch**); the command-line value takes precedence over crypttab.
     Note that booster also supports LUKS v2 persistent flags stored with the partition metadata. Any command-line options are added on top of the persistent flags.
  * `rd.modules_force_load` a comma-separated list of extra kernel modules which should be force loaded.
  * `resume=$deviceref` device reference to suspend-to-disk device.
@@ -255,6 +255,7 @@ Booster-specific behaviour for selected options:
  * **`header=`** — if the path is a plain absolute path the generator bundles the file into the initramfs automatically. The `/path:deviceref` form mounts the device at boot; `/dev/...` uses the raw block device directly.
  * **`fido2-device=`** — when this option appears in a crypttab entry, the generator automatically bundles `fido2plugin.so`; no `enable_fido2: true` in the config file is required. Both `fido2-device=` and `tpm2-device=` are otherwise accepted for compatibility; booster discovers enrolled tokens from the LUKS2 header, not from the crypttab option value.
  * **`keyfile-timeout=`** / **`token-timeout=`** — accept a bare integer (seconds) or any duration string accepted by Go's `time.ParseDuration` (e.g. `30s`, `2m`).
+ * **`tpm2-measure-pcr=`** — `yes` or `no`. Overrides the PCR 15 re-unseal latch (see **TPM2 unlock and the PCR 15 latch**). When unset, booster extends PCR 15 automatically if the device's `systemd-tpm2` token is bound to PCR 15; `yes` forces the extend, `no` suppresses it. The same option on the kernel command line (`rd.luks.options=`) takes precedence.
 
 ## REMOTE UNLOCK
 
@@ -423,11 +424,26 @@ Booster does not bundle CPU microcode into its initramfs, so point `Microcode=` 
 
 Distributions that already drive kernel installation through `kernel-install` (e.g. Fedora) build the UKI automatically. On Arch-based distributions, which use pacman hooks rather than `kernel-install`, a hook such as the AUR `pacman-hook-kernel-install` runs it on kernel updates; booster's own pacman hook can stay enabled (it then builds an unused plain initrd next to the UKI) or be disabled to avoid the redundant build.
 
-Embedding the command line matters for security. A UKI with no embedded command line accepts one from the boot loader at runtime, which is not part of the signed and measured image: an attacker could append e.g. `init=/bin/sh` and obtain a root shell on the decrypted filesystem after a TPM2 auto-unlock, because the measured boot chain — and therefore the TPM policy — is unchanged. When the command line is embedded it is measured into PCR 11, and under Secure Boot systemd-stub ignores any externally supplied command line.
+Embedding the command line matters for security. A UKI with no embedded command line accepts one from the boot loader at runtime, which is not part of the signed and measured image: an attacker could append e.g. `init=/bin/sh` and obtain a root shell on the decrypted filesystem after a TPM2 auto-unlock, because the measured boot chain — and therefore the TPM policy — is unchanged. When the command line is embedded it is measured into PCR 11, and under Secure Boot systemd-stub ignores any externally supplied command line. PCR 11 is also the measurement a TPM2 key can be bound to so a supplanted kernel or initrd is rejected — see **TPM2 unlock and the PCR 15 latch** for binding and its fragility under kernel updates.
 
 The legacy Arch-only helper `/usr/lib/booster/regenerate_uki` is deprecated: it does not embed the kernel command line and is therefore vulnerable to the injection described above. Prefer `kernel-install`.
 
 To boot the UKI by default you may also need to adjust your boot loader configuration.
+
+## TPM2 unlock and the PCR 15 latch
+When booster unseals a volume key from a `systemd-tpm2` token it extends PCR 15 — the "system-identity" PCR — with the same measurement systemd-cryptsetup writes for `tpm2-measure-pcr=yes`: `HMAC(volume_key, "cryptsetup:" + name + ":" + uuid)`, in every active PCR bank, before handing off to the real root. A TPM attests the boot *path*, not the data it releases, so a key sealed to an uninitialized PCR 15 can otherwise be unsealed again within the same boot; extending PCR 15 makes the unseal single-use.
+
+The latch engages automatically when the token's policy is bound to PCR 15 — the enrollment is the signal, so no configuration is needed. `tpm2-measure-pcr=yes` (in crypttab or `rd.luks.options=`) forces the extend even when the token is not bound to PCR 15; `tpm2-measure-pcr=no` suppresses it. A measurement failure aborts the unlock (fail closed); `tpm2-measure-pcr=no` is the escape hatch for a deliberately TPM-less or non-latched device.
+
+**The latch is not a supplantation defense on its own.** PCR 15 resets to zero on every power cycle, so an attacker who reboots into a malicious initrd that dumps the key sees a fresh PCR 15 and can unseal again — unless the key is *also* bound to a PCR that covers the kernel and initrd. That is PCR 11, the UKI measurement (see **Unified Kernel Image**): a substituted kernel or initrd yields a different PCR 11 and the TPM refuses to release the key. Enroll the token against PCR 7 (Secure Boot state), 11 (the UKI), and 15, for example:
+
+    # systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7+11+15 /dev/sda2
+
+See [systemd-cryptenroll(1)](https://man7.org/linux/man-pages/man1/systemd-cryptenroll.1.html). PCR 7 records the Secure Boot policy, so the binding also refuses the key if Secure Boot is disabled or its keys change — it is only meaningful with Secure Boot enabled. PCR 11 is only populated with the kernel and initrd measurement when the kernel boots as a UKI; without one the co-binding is hollow. Bind PCR 15 while it is still uninitialized (its state on a normal boot before any volume's latch has run); the value the latch later writes is derived from the volume key and cannot be predicted in advance.
+
+**Fragility — re-enrollment on kernel updates.** Booster unseals with a literal PCR policy, not a signed (authorized) one so binding to PCR 11 pins the key to one exact kernel+initrd: every kernel or initrd change alters PCR 11 and the token must be re-enrolled (see **TPM recovery**). ukify's PCR-policy signing (`PCRPrivateKey=`) does not remove this step, because booster does not evaluate signed PCR policies, yet.
+
+**TPM recovery.** Until you re-enroll — and on any other PCR mismatch — a passphrase keyslot is the fallback: it unlocks regardless of PCR state. On an interactive system it is typed at the console; on a headless or remote machine it can be submitted over the network via booster's **Remote Unlock** (SSH). Where someone is present at unlock, a TPM2-PIN (`systemd-cryptenroll --tpm2-with-pin=yes`) is recommended.
 
 ## DEBUGGING
 If you have a problem with booster boot tool you can enable debug mode to get more
@@ -517,8 +533,30 @@ Build a Unified Kernel Image via kernel-install (with `/etc/kernel/install.conf`
 
     # kernel-install add "$(uname -r)" /usr/lib/modules/"$(uname -r)"/vmlinuz
 
+Headless server: pinless TPM2 auto-unlock with SSH recovery (see **TPM2 unlock and the PCR 15 latch** for the rationale and caveats). The box unseals from the TPM unattended; if the TPM withholds the key for any reason — a kernel or firmware change, a hardware swap, or tampering — the volume waits for the passphrase, which is supplied over SSH. Enroll the TPM pinless, co-bound to the Secure Boot state, the UKI, and the system-identity PCR; keep the existing passphrase keyslot as the recovery credential:
+
+    # systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7+11+15 /dev/sda2
+
+The crypttab entry needs no extra option — the token is read from the LUKS header and the latch engages because it is bound to PCR 15:
+
+    cryptroot  UUID=<luks-uuid>  none  x-initrd.attach
+
+Enable remote unlock in `/etc/booster.yaml` with a dedicated initramfs host key and the operator's public key (see **Remote Unlock**):
+
+    network:
+      dhcp: on
+      ssh_host_key: /etc/booster/ssh_host_ed25519_key
+      ssh_authorized_keys: /etc/booster/authorized_keys
+
+Build the kernel as a UKI so PCR 11 is populated (see **Unified Kernel Image**). Booster binds a literal PCR policy and does not consume systemd's signed-policy auto-resign, so a change to a bound PCR (a kernel update moves PCR 11) needs re-enrollment — done over SSH:
+
+    $ ssh root@host        # submit the LUKS passphrase to finish boot
+    # systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs=7+11+15 /dev/sda2
+
 ## COPYRIGHT
 Booster is Copyright (C) 2020 Anatol Pomazau <http://github.com/anatol>
 
 ## SEE ALSO
 Project homepage <https://github.com/anatol/booster>
+
+[crypttab(5)](https://man7.org/linux/man-pages/man5/crypttab.5.html), [systemd-cryptenroll(1)](https://man7.org/linux/man-pages/man1/systemd-cryptenroll.1.html), [kernel-install(8)](https://man7.org/linux/man-pages/man8/kernel-install.8.html), [ukify(1)](https://man7.org/linux/man-pages/man1/ukify.1.html)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/anatol/clevis.go v0.0.0-20260526031059-8cd07c1db068
 	github.com/anatol/devmapper.go v0.0.0-20260315162726-c47dfb6cf674
 	github.com/anatol/go-udev v0.0.0-20220806124306-5f28d899f64f
-	github.com/anatol/luks.go v0.0.0-20260315175739-98c0a50095cb
+	github.com/anatol/luks.go v0.0.0-20260615185044-2658459c8ca5
 	github.com/anatol/smart.go v0.0.0-20260427185427-04c4679efd4e
 	github.com/anatol/tang.go v0.0.0-20260314012254-926d9c91008f
 	github.com/anatol/vmtest v0.0.0-20260509163454-0d3e5bd9399c

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/anatol/devmapper.go v0.0.0-20260315162726-c47dfb6cf674 h1:hf8WYEOEPib
 github.com/anatol/devmapper.go v0.0.0-20260315162726-c47dfb6cf674/go.mod h1:IdTkstjXP4hR8GyVyk0+i5uHpGMPidNq78ghwCyF4zg=
 github.com/anatol/go-udev v0.0.0-20220806124306-5f28d899f64f h1:Dxki5W8sSFVyPkoYut11RXlIzouHVM5dX99qUL8xsGA=
 github.com/anatol/go-udev v0.0.0-20220806124306-5f28d899f64f/go.mod h1:xM57GU8ntwu+q88yo/exYza/WG1fKGxhJUtvtebxdXg=
-github.com/anatol/luks.go v0.0.0-20260315175739-98c0a50095cb h1:QY6+xwGNree0q4CiQXbxQ/uY63eGO97pGxJn2wcolNI=
-github.com/anatol/luks.go v0.0.0-20260315175739-98c0a50095cb/go.mod h1:lFWvMshFyjkl9gCaM8wfvBk06H7isWw4AuaHdFH0+QQ=
+github.com/anatol/luks.go v0.0.0-20260615185044-2658459c8ca5 h1:Qj6Lfxnswng3KCP3OsSyVwbbYh4UY3bQZaP1m6fCAGU=
+github.com/anatol/luks.go v0.0.0-20260615185044-2658459c8ca5/go.mod h1:lFWvMshFyjkl9gCaM8wfvBk06H7isWw4AuaHdFH0+QQ=
 github.com/anatol/smart.go v0.0.0-20260427185427-04c4679efd4e h1:bpQpdTe8DkhjYimnPoH+T1XkjXtLwyNtENPjoh9oNcI=
 github.com/anatol/smart.go v0.0.0-20260427185427-04c4679efd4e/go.mod h1:PrHdljtLe/VXVRH+zAJOcPjHkOHjF8/T2Arblruu/ac=
 github.com/anatol/tang.go v0.0.0-20260314012254-926d9c91008f h1:MxryJtS/foSbnan9IrdaOK9MtK4lOXr5eOq0Ztn552o=

--- a/init/cmdline.go
+++ b/init/cmdline.go
@@ -175,6 +175,7 @@ func parseParams(params string) error {
 	var luksOptions []string
 	var tokenTimeout time.Duration
 	var tokenTimeoutExplicit bool
+	measurePCR := measurePCRAuto
 
 	var key, value string
 	i := 0
@@ -252,6 +253,14 @@ func parseParams(params string) error {
 					}
 					tokenTimeout = d
 					tokenTimeoutExplicit = true
+					continue
+				}
+				if after, ok := strings.CutPrefix(o, "tpm2-measure-pcr="); ok {
+					s, valid := parseMeasurePCR(after)
+					if !valid {
+						return fmt.Errorf("invalid tpm2-measure-pcr in rd.luks.options: %q", after)
+					}
+					measurePCR = s
 					continue
 				}
 				// Accept fido2-device= and tpm2-device= for compatibility with
@@ -360,6 +369,9 @@ func parseParams(params string) error {
 		if tokenTimeoutExplicit {
 			luksMappings[i].tokenTimeout = tokenTimeout
 			luksMappings[i].tokenTimeoutExplicit = true
+		}
+		if measurePCR != measurePCRAuto {
+			luksMappings[i].measurePCR = measurePCR
 		}
 	}
 

--- a/init/cmdline_test.go
+++ b/init/cmdline_test.go
@@ -43,6 +43,28 @@ func TestParseParams(t *testing.T) {
 	require.Equal(t, "7f28c723-fd6b-4640-bc94-9366edd8880d", cache.ref.data.(UUID).toString())
 }
 
+func TestParseParamsMeasurePCR(t *testing.T) {
+	const base = "rd.luks.name=ab6d7d78-b816-4495-928d-766d6607035e=root root=UUID=e8e81fc3-8f81-4a3a-ac3d-aab36aa0c45f"
+
+	luksMappings = nil
+	require.NoError(t, parseParams(base+" rd.luks.options=tpm2-measure-pcr=yes"))
+	require.Len(t, luksMappings, 1)
+	require.Equal(t, measurePCRForce, luksMappings[0].measurePCR)
+
+	luksMappings = nil
+	require.NoError(t, parseParams(base+" rd.luks.options=tpm2-measure-pcr=no"))
+	require.Equal(t, measurePCRDisabled, luksMappings[0].measurePCR)
+
+	// Unset on the cmdline leaves the auto default (crypttab/token-binding decides).
+	luksMappings = nil
+	require.NoError(t, parseParams(base))
+	require.Equal(t, measurePCRAuto, luksMappings[0].measurePCR)
+
+	// Invalid value is rejected (not silently dropped).
+	luksMappings = nil
+	require.Error(t, parseParams(base+" rd.luks.options=tpm2-measure-pcr=bogus"))
+}
+
 func TestGetNextParam(t *testing.T) {
 	type test struct {
 		input    string

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -137,6 +137,15 @@ func parseCrypttabReader(r io.Reader) ([]*luksMapping, error) {
 					// accepted for compatibility; token detection uses LUKS2 header
 				case strings.HasPrefix(opt, "tpm2-device="):
 					// accepted for compatibility; token detection uses LUKS2 header
+				case strings.HasPrefix(opt, "tpm2-measure-pcr="):
+					// yes forces the volume-key measurement, no suppresses it;
+					// unset = auto (extend iff a token binds PCR15).
+					val := opt[len("tpm2-measure-pcr="):]
+					s, valid := parseMeasurePCR(val)
+					if !valid {
+						return nil, fmt.Errorf("crypttab: entry %q: invalid tpm2-measure-pcr= value %q", name, val)
+					}
+					m.measurePCR = s
 				case strings.HasPrefix(opt, "token-timeout="):
 					d, err := parseTokenTimeout(opt[14:])
 					if err != nil {
@@ -217,6 +226,9 @@ func mergeCrypttabOptions(dst, src *luksMapping) {
 	if dst.header == "" && src.header != "" {
 		dst.header = src.header
 		dst.headerDeviceRef = src.headerDeviceRef
+	}
+	if dst.measurePCR == measurePCRAuto && src.measurePCR != measurePCRAuto {
+		dst.measurePCR = src.measurePCR
 	}
 	dst.options = append(dst.options, src.options...)
 }

--- a/init/crypttab_test.go
+++ b/init/crypttab_test.go
@@ -116,6 +116,31 @@ func TestParseCrypttabKeySlotInvalid(t *testing.T) {
 	require.Contains(t, err.Error(), "key-slot=")
 }
 
+func TestParseCrypttabMeasurePCR(t *testing.T) {
+	const uuid = "UUID=ab6d7d78-b816-4495-928d-766d6607035e"
+	cases := []struct {
+		opt  string
+		want measurePCRSetting
+	}{
+		{"", measurePCRAuto},
+		{" tpm2-measure-pcr=yes", measurePCRForce},
+		{" tpm2-measure-pcr=no", measurePCRDisabled},
+	}
+	for _, c := range cases {
+		mappings, err := parseCrypttabReader(strings.NewReader("cryptroot " + uuid + " none" + c.opt + "\n"))
+		require.NoError(t, err, c.opt)
+		require.Len(t, mappings, 1)
+		require.Equal(t, c.want, mappings[0].measurePCR, c.opt)
+	}
+}
+
+func TestParseCrypttabMeasurePCRInvalid(t *testing.T) {
+	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none tpm2-measure-pcr=maybe\n"
+	_, err := parseCrypttabReader(strings.NewReader(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tpm2-measure-pcr=")
+}
+
 func TestParseCrypttabNofail(t *testing.T) {
 	input := "cryptroot UUID=ab6d7d78-b816-4495-928d-766d6607035e none nofail\n"
 	mappings, err := parseCrypttabReader(strings.NewReader(input))

--- a/init/luks.go
+++ b/init/luks.go
@@ -48,6 +48,10 @@ type luksMapping struct {
 	noFail        bool  // non-fatal unlock failure — boot continues on error
 	keyfileOffset int64 // bytes to skip at start of keyfile
 	keyfileSize   int64 // max bytes to read from keyfile (0 = all)
+
+	// measurePCR is the tpm2-measure-pcr= setting for the PCR15 latch.
+	// Zero value = measurePCRAuto (extend iff a token binds PCR15).
+	measurePCR measurePCRSetting
 }
 
 // tryPassphraseAgainstSlots tries password against each slot, sending the opened
@@ -881,6 +885,82 @@ func findMatchingFido2Device(credID []byte, relyingParty string, userVerificatio
 	return "", nil
 }
 
+// measurePCRSetting is the tpm2-measure-pcr= setting controlling the PCR15 latch.
+type measurePCRSetting int
+
+const (
+	measurePCRAuto     measurePCRSetting = iota // unset: extend iff a token binds PCR15
+	measurePCRForce                             // tpm2-measure-pcr=yes
+	measurePCRDisabled                          // tpm2-measure-pcr=no
+)
+
+func (s measurePCRSetting) String() string {
+	switch s {
+	case measurePCRForce:
+		return "yes"
+	case measurePCRDisabled:
+		return "no"
+	default:
+		return "auto"
+	}
+}
+
+// parseMeasurePCR maps a tpm2-measure-pcr= value to its setting; ok is false for
+// unrecognized values.
+func parseMeasurePCR(val string) (setting measurePCRSetting, ok bool) {
+	switch val {
+	case "yes":
+		return measurePCRForce, true
+	case "no":
+		return measurePCRDisabled, true
+	}
+	return measurePCRAuto, false
+}
+
+// tokenBindsPCR reports whether a systemd-tpm2 token's policy binds the given PCR.
+func tokenBindsPCR(t luks.Token, pcr int) bool {
+	if t.Type != "systemd-tpm2" {
+		return false
+	}
+	var node struct {
+		PCRs []int `json:"tpm2-pcrs"`
+	}
+	if err := json.Unmarshal(t.Payload, &node); err != nil {
+		return false
+	}
+	for _, p := range node.PCRs {
+		if p == pcr {
+			return true
+		}
+	}
+	return false
+}
+
+// tokenBindsPCR15 reports whether a systemd-tpm2 token binds PCR15 — the signal
+// that the user enrolled the uninitialized-PCR15 latch.
+func tokenBindsPCR15(t luks.Token) bool {
+	return tokenBindsPCR(t, pcrSystemIdentity)
+}
+
+// shouldMeasureVolumeKey decides whether to extend PCR15: tpm2-measure-pcr=
+// overrides; otherwise extend iff a systemd-tpm2 token binds PCR15 (the
+// zero-config default).
+func shouldMeasureVolumeKey(tokens []luks.Token, setting measurePCRSetting) bool {
+	switch setting {
+	case measurePCRForce:
+		return true
+	case measurePCRDisabled:
+		return false
+	default:
+		for _, t := range tokens {
+			if tokenBindsPCR15(t) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 func recoverSystemdTPM2Password(ctx context.Context, t luks.Token, mappingName string) ([]byte, error) {
 	var node struct {
 		Blob       string `json:"tpm2-blob"` // base64
@@ -1600,6 +1680,21 @@ func luksOpen(dev string, mapping *luksMapping) error {
 	}
 
 	module.Wait()
+
+	// PCR15 latch: once the volume key is recovered, extend PCR15 with the
+	// systemd-compatible volume-key measurement so a key sealed to an
+	// uninitialized PCR15 can't be re-unsealed for the rest of the boot. Done
+	// before SetupMapper/pivot. Fail closed: if a key bound to PCR15 can't be
+	// latched, abort rather than boot with the oracle left open.
+	if shouldMeasureVolumeKey(tokens, mapping.measurePCR) {
+		if err := measureVolumeKeyToPCR15(v, mapping.name, v.UUID); err != nil {
+			return fmt.Errorf("measuring volume key to PCR%d for %s: %v", pcrSystemIdentity, mapping.name, err)
+		}
+		debug("PCR%d re-unseal latch engaged for %s", pcrSystemIdentity, mapping.name)
+	} else {
+		debug("PCR%d latch not engaged for %s (tpm2-measure-pcr=%s; no token binds PCR%d)", pcrSystemIdentity, mapping.name, mapping.measurePCR, pcrSystemIdentity)
+	}
+
 	return v.SetupMapper(mapping.name)
 }
 

--- a/init/measure_gating_test.go
+++ b/init/measure_gating_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	luks "github.com/anatol/luks.go"
+	"github.com/stretchr/testify/require"
+)
+
+// Gating decision for the PCR15 latch: default = extend iff a systemd-tpm2
+// token binds PCR15; crypttab tpm2-measure-pcr= overrides (=yes force,
+// =no suppress).
+
+func TestTokenBindsPCR15(t *testing.T) {
+	cases := []struct {
+		name string
+		tok  luks.Token
+		want bool
+	}{
+		{"tpm2 binds 7+15", luks.Token{Type: "systemd-tpm2", Payload: []byte(`{"tpm2-pcrs":[7,15]}`)}, true},
+		{"tpm2 binds 7 only", luks.Token{Type: "systemd-tpm2", Payload: []byte(`{"tpm2-pcrs":[7]}`)}, false},
+		{"tpm2 binds nothing", luks.Token{Type: "systemd-tpm2", Payload: []byte(`{"tpm2-pcrs":[]}`)}, false},
+		{"tpm2 no pcrs field", luks.Token{Type: "systemd-tpm2", Payload: []byte(`{}`)}, false},
+		{"tpm2 malformed", luks.Token{Type: "systemd-tpm2", Payload: []byte(`{not json`)}, false},
+		{"clevis token", luks.Token{Type: "clevis", Payload: []byte(`{"tpm2-pcrs":[15]}`)}, false},
+		{"empty type", luks.Token{Type: "", Payload: []byte(`{"tpm2-pcrs":[15]}`)}, false},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, tokenBindsPCR15(c.tok), c.name)
+	}
+}
+
+func TestShouldMeasureVolumeKey(t *testing.T) {
+	binds15 := luks.Token{Type: "systemd-tpm2", Payload: []byte(`{"tpm2-pcrs":[7,15]}`)}
+	binds7 := luks.Token{Type: "systemd-tpm2", Payload: []byte(`{"tpm2-pcrs":[7]}`)}
+
+	cases := []struct {
+		name    string
+		tokens  []luks.Token
+		setting measurePCRSetting
+		want    bool
+	}{
+		{"force, no tokens", nil, measurePCRForce, true},
+		{"force, even if not bound", []luks.Token{binds7}, measurePCRForce, true},
+		{"disabled, even if bound to 15", []luks.Token{binds15}, measurePCRDisabled, false},
+		{"auto, token binds 15", []luks.Token{binds15}, measurePCRAuto, true},
+		{"auto, token binds 7 only", []luks.Token{binds7}, measurePCRAuto, false},
+		{"auto, no tokens", nil, measurePCRAuto, false},
+		{"auto, one of several binds 15", []luks.Token{binds7, binds15}, measurePCRAuto, true},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, shouldMeasureVolumeKey(c.tokens, c.setting), c.name)
+	}
+}

--- a/init/tpm.go
+++ b/init/tpm.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/google/go-tpm/legacy/tpm2"
@@ -160,6 +162,114 @@ func parsePCRBank(bank string) tpm2.Algorithm {
 		return tpm2.AlgSHA256
 	}
 	return tpm2.AlgSHA256
+}
+
+// pcrSystemIdentity is the PCR systemd reserves as "system-identity": it is
+// populated (not consumed) by FDE so later objects can be bound to the unlocked
+// volume. Booster extends it after unseal to close the TPM re-unseal oracle.
+const pcrSystemIdentity = 15
+
+// xescapeColon mirrors systemd's xescape(s, ":") (src/basic/escape.c): it
+// escapes ':' (the delimiter), '\\', control bytes (<0x20) and high/DEL bytes
+// (>=0x7f) as lowercase \xNN, copying everything else verbatim. Used to build
+// the volume-key measurement message byte-compatibly with systemd-cryptsetup.
+func xescapeColon(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c >= 0x7f || c == '\\' || c == ':' {
+			fmt.Fprintf(&b, "\\x%02x", c)
+		} else {
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}
+
+// cryptoHashForPCRBank maps a TPM PCR bank algorithm to its crypto.Hash.
+// ok is false for algorithms booster cannot handle, letting the caller fail
+// closed rather than silently leave that bank's PCR un-extended.
+func cryptoHashForPCRBank(alg tpm2.Algorithm) (h crypto.Hash, ok bool) {
+	switch alg {
+	case tpm2.AlgSHA1:
+		return crypto.SHA1, true
+	case tpm2.AlgSHA256:
+		return crypto.SHA256, true
+	case tpm2.AlgSHA384:
+		return crypto.SHA384, true
+	case tpm2.AlgSHA512:
+		return crypto.SHA512, true
+	}
+	return 0, false
+}
+
+// activePCRBanks returns the hash algorithms of the TPM's allocated PCR banks.
+func activePCRBanks(dev io.ReadWriter) ([]tpm2.Algorithm, error) {
+	caps, _, err := tpm2.GetCapability(dev, tpm2.CapabilityPCRs, 64, 0)
+	if err != nil {
+		return nil, err
+	}
+	var banks []tpm2.Algorithm
+	for _, c := range caps {
+		sel, ok := c.(tpm2.PCRSelection)
+		if !ok || len(sel.PCRs) == 0 {
+			continue
+		}
+		banks = append(banks, sel.Hash)
+	}
+	return banks, nil
+}
+
+// volumeKeyHMACer computes HMAC(volume_key, message) with a caller-named hash
+// algorithm, without exposing the master key. luks.Volume implements it, so the
+// volume key never leaves the LUKS library — only the resulting digest (the
+// value measured into the PCR, which is not secret) crosses into booster. The
+// hash is a crypto.Hash identifier, not a constructor, so the caller cannot
+// supply an implementation that observes the key. This is stricter than
+// libcryptsetup's crypt_volume_key_get, which hands the raw key to the caller.
+type volumeKeyHMACer interface {
+	HMAC(h crypto.Hash, message []byte) ([]byte, error)
+}
+
+// measureVolumeKeyToPCR15 extends PCR15 with the systemd-compatible volume-key
+// measurement after a volume is unsealed, so a key sealed to an uninitialized
+// PCR15 cannot be re-unsealed for the rest of the boot. It matches
+// systemd-cryptsetup's tpm2-measure-pcr=yes: for every active PCR bank it
+// extends HMAC-<bank>(volume_key, "cryptsetup:" + name + ":" + uuid) using that
+// bank's own hash algorithm. Extending ALL active banks is required — a policy
+// satisfiable via an un-extended bank would otherwise be bypassable.
+func measureVolumeKeyToPCR15(k volumeKeyHMACer, volumeName, luksUUID string) error {
+	dev, err := openTPM()
+	if err != nil {
+		return err
+	}
+	defer dev.Close()
+
+	banks, err := activePCRBanks(dev)
+	if err != nil {
+		return fmt.Errorf("reading active PCR banks: %v", err)
+	}
+	if len(banks) == 0 {
+		return fmt.Errorf("no active PCR banks to extend")
+	}
+
+	msg := []byte("cryptsetup:" + xescapeColon(volumeName) + ":" + luksUUID)
+
+	for _, bank := range banks {
+		h, ok := cryptoHashForPCRBank(bank)
+		if !ok {
+			return fmt.Errorf("unsupported active PCR bank %v; refusing to leave PCR%d un-extended", bank, pcrSystemIdentity)
+		}
+		digest, err := k.HMAC(h, msg)
+		if err != nil {
+			return fmt.Errorf("computing PCR%d measurement for bank %v: %v", pcrSystemIdentity, bank, err)
+		}
+		if err := tpm2.PCRExtend(dev, tpmutil.Handle(pcrSystemIdentity), bank, digest, ""); err != nil {
+			return fmt.Errorf("extending PCR%d in bank %v: %v", pcrSystemIdentity, bank, err)
+		}
+	}
+	debug("PCR%d: extended across %d active bank(s) %v for %s", pcrSystemIdentity, len(banks), banks, volumeName)
+	return nil
 }
 
 // Returns session handle and policy digest.

--- a/init/tpm_measure_test.go
+++ b/init/tpm_measure_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"net"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/google/go-tpm/legacy/tpm2"
+	"github.com/stretchr/testify/require"
+)
+
+// startSwtpmTCPForTest starts swtpm in TCP server mode so booster's
+// enableSwEmulator path (which dials :2321) talks to it. Skips when swtpm is
+// unavailable; the process is killed on test cleanup.
+func startSwtpmTCPForTest(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("swtpm"); err != nil {
+		t.Skip("swtpm not installed")
+	}
+	dir := t.TempDir()
+	cmd := exec.Command("swtpm", "socket", "--tpm2",
+		"--server", "type=tcp,port=2321",
+		"--ctrl", "type=tcp,port=2322",
+		"--tpmstate", "dir="+dir,
+		"--flags", "not-need-init,startup-clear")
+	require.NoError(t, cmd.Start())
+	// Kill AND reap so the fixed :2321 port is released before the next
+	// swtpm-binding test starts (booster's emulator path hardcodes :2321, so
+	// these tests can't use random ports and must serialize cleanly).
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		c, err := net.DialTimeout("tcp", "127.0.0.1:2321", 200*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			return
+		}
+		require.False(t, time.Now().After(deadline), "swtpm TCP port never opened")
+	}
+}
+
+func readPCR15(t *testing.T, bank tpm2.Algorithm) []byte {
+	t.Helper()
+	dev, err := openTPM()
+	require.NoError(t, err)
+	defer dev.Close()
+	pcrs, err := tpm2.ReadPCRs(dev, tpm2.PCRSelection{Hash: bank, PCRs: []int{15}})
+	require.NoError(t, err)
+	return pcrs[15]
+}
+
+// rawKeyHMACer is a test volumeKeyHMACer backed by a raw key, mirroring what
+// luks.Volume.HMAC does in production (HMAC keyed by the master key).
+type rawKeyHMACer []byte
+
+func (k rawKeyHMACer) HMAC(h crypto.Hash, message []byte) ([]byte, error) {
+	m := hmac.New(h.New, k)
+	m.Write(message)
+	return m.Sum(nil), nil
+}
+
+// TestMeasureVolumeKeyToPCR15ExtendsSHA256 checks the PCR15 latch: after booster
+// unseals a volume it extends PCR15 with the systemd-compatible volume-key HMAC,
+// so the key cannot be re-unsealed for the rest of the boot (closing the
+// re-unseal oracle). The expected value is pinned to systemd's exact formula so
+// a wrong-formula implementation fails:
+//
+//	extend value = HMAC-SHA256(volumeKey, "cryptsetup:" + name + ":" + uuid)
+//	PCR15_new    = SHA256( PCR15_old(32 zero bytes) || extend value )
+func TestMeasureVolumeKeyToPCR15ExtendsSHA256(t *testing.T) {
+	startSwtpmTCPForTest(t)
+	enableSwEmulator = true
+	t.Cleanup(func() { enableSwEmulator = false })
+
+	const name = "cryptroot"
+	const uuid = "5cbc48ce-0e78-4c6b-ac90-a8a540514b90"
+	volumeKey := []byte("0123456789abcdef0123456789abcdef")
+
+	before := readPCR15(t, tpm2.AlgSHA256)
+	require.Equal(t, make([]byte, 32), before, "PCR15 must start uninitialized (all zeros)")
+
+	require.NoError(t, measureVolumeKeyToPCR15(rawKeyHMACer(volumeKey), name, uuid))
+
+	mac := hmac.New(sha256.New, volumeKey)
+	mac.Write([]byte("cryptsetup:" + name + ":" + uuid))
+	digest := mac.Sum(nil)
+	h := sha256.New()
+	h.Write(make([]byte, 32)) // PCR15 started at all-zeros
+	h.Write(digest)
+	want := h.Sum(nil)
+
+	after := readPCR15(t, tpm2.AlgSHA256)
+	require.Equal(t, want, after,
+		"PCR15 must equal the systemd-compatible HMAC(volume_key, \"cryptsetup:\"+name+\":\"+uuid) extend")
+}
+
+// TestHashForPCRBankUnsupported pins the fail-safe primitive: a PCR bank
+// booster cannot compute must report unsupported, so measureVolumeKeyToPCR15
+// aborts rather than silently leaving that bank's PCR15 un-extended (which would
+// leave a satisfiable-via-that-bank policy bypassable).
+func TestHashForPCRBankUnsupported(t *testing.T) {
+	for _, alg := range []tpm2.Algorithm{tpm2.AlgSHA1, tpm2.AlgSHA256, tpm2.AlgSHA384, tpm2.AlgSHA512} {
+		_, ok := cryptoHashForPCRBank(alg)
+		require.True(t, ok, "bank %v must be supported", alg)
+	}
+	_, ok := cryptoHashForPCRBank(tpm2.AlgNull)
+	require.False(t, ok, "unknown bank must report unsupported (fail closed)")
+}
+
+// TestMeasureVolumeKeyToPCR15FailsClosedWhenTPMUnavailable pins the fail-safe
+// contract (systemd #36705): if the PCR15 latch can't be applied, the measure
+// must return an error so the caller aborts the unlock rather than booting with
+// the re-unseal oracle left open. Here the TPM is unreachable (emulator dial to
+// :2321 with no swtpm running), standing in for any extend failure.
+func TestMeasureVolumeKeyToPCR15FailsClosedWhenTPMUnavailable(t *testing.T) {
+	enableSwEmulator = true // openTPM dials :2321; no swtpm is started
+	t.Cleanup(func() { enableSwEmulator = false })
+
+	err := measureVolumeKeyToPCR15(rawKeyHMACer([]byte("k")), "cryptroot", "uuid")
+	require.Error(t, err, "measure must fail closed when the latch cannot be applied")
+}
+
+// TestMeasureVolumeKeyToPCR15ExtendsAllActiveBanks verifies all-banks coverage: a
+// policy satisfiable via an un-extended bank is bypassable, so booster extends
+// PCR15 in EVERY active bank, each with that bank's own HMAC algorithm (systemd
+// does HMAC-SHA256 for the sha256 bank, HMAC-SHA1 for the sha1 bank, etc.).
+// swtpm activates both sha1 and sha256.
+func TestMeasureVolumeKeyToPCR15ExtendsAllActiveBanks(t *testing.T) {
+	startSwtpmTCPForTest(t)
+	enableSwEmulator = true
+	t.Cleanup(func() { enableSwEmulator = false })
+
+	const name = "cryptroot"
+	const uuid = "5cbc48ce-0e78-4c6b-ac90-a8a540514b90"
+	volumeKey := []byte("0123456789abcdef0123456789abcdef")
+	data := []byte("cryptsetup:" + name + ":" + uuid)
+
+	require.Equal(t, make([]byte, 32), readPCR15(t, tpm2.AlgSHA256), "sha256:15 must start zero")
+	require.Equal(t, make([]byte, 20), readPCR15(t, tpm2.AlgSHA1), "sha1:15 must start zero")
+
+	require.NoError(t, measureVolumeKeyToPCR15(rawKeyHMACer(volumeKey), name, uuid))
+
+	// sha256 bank: PCR15 = SHA256(zeros32 || HMAC-SHA256(key, data))
+	m256 := hmac.New(sha256.New, volumeKey)
+	m256.Write(data)
+	e256 := sha256.New()
+	e256.Write(make([]byte, 32))
+	e256.Write(m256.Sum(nil))
+	require.Equal(t, e256.Sum(nil), readPCR15(t, tpm2.AlgSHA256), "sha256 bank must be extended with HMAC-SHA256")
+
+	// sha1 bank: PCR15 = SHA1(zeros20 || HMAC-SHA1(key, data))
+	m1 := hmac.New(sha1.New, volumeKey)
+	m1.Write(data)
+	e1 := sha1.New()
+	e1.Write(make([]byte, 20))
+	e1.Write(m1.Sum(nil))
+	require.Equal(t, e1.Sum(nil), readPCR15(t, tpm2.AlgSHA1), "sha1 bank must be extended with HMAC-SHA1 (all active banks)")
+}
+
+// TestXescapeColon pins booster's reimplementation of systemd's
+// xescape(name, ":") used to build the volume-key measurement message, so the
+// HMAC stays byte-compatible for volume names containing ':', '\', control or
+// high bytes. systemd escapes c<0x20 || c>=0x7f || c=='\\' || c==':' as \xNN
+// (lowercase), copying everything else verbatim (src/basic/escape.c xescape_full).
+func TestXescapeColon(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"cryptroot", "cryptroot"}, // common case: unchanged
+		{"my:vol", `my\x3avol`},    // colon (the bad char) escaped
+		{"a\\b", `a\x5cb`},         // backslash escaped
+		{"a b", "a b"},             // space (0x20) kept
+		{"a\tb", `a\x09b`},         // tab (control) escaped
+		{"\x7f", `\x7f`},           // DEL escaped
+		{"é", `\xc3\xa9`},          // high bytes (UTF-8) escaped
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, xescapeColon(c.in), "xescapeColon(%q)", c.in)
+	}
+}

--- a/tests/assets.go
+++ b/tests/assets.go
@@ -77,6 +77,10 @@ var assetGenerators = map[string]assetGenerator{
 	// PCR selection still mutated the policy digest, causing auth failure.
 	"systemd-tpm2-nopcr-pin.img": {"systemd_tpm2.sh", []string{"LUKS_UUID=d9ef7bf3-b4f8-4271-9f3c-df63d457fcc6", "FS_UUID=6abcf123-4182-452b-9c87-a769dc344e3b", "LUKS_PASSWORD=567", "CRYPTENROLL_TPM2_PIN=foo654", "CRYPTENROLL_TPM2_PCRS="}},
 	"systemd-tpm2-srk.img":       {"systemd_tpm2.sh", []string{"LUKS_UUID=c09debc6-6a06-4317-94f5-0916bb9ea1c8", "FS_UUID=5a6daa83-ea51-47dd-a38b-2b66d5cc8428", "LUKS_PASSWORD=567"}},
+	// systemd-tpm2-pcr15.img: TPM2 token bound to PCR15 (+10+13) — exercises the
+	// PCR15 re-unseal latch. At enroll/boot PCR15 is uninitialized (0); booster
+	// must extend it after unseal so the key can't be re-unsealed.
+	"systemd-tpm2-pcr15.img": {"systemd_tpm2.sh", []string{"LUKS_UUID=7a9f3c21-5e84-4d16-b2c7-1f0a9e6d4b33", "FS_UUID=8b0a4d32-6f95-4e27-93d8-2a1baf7e5c44", "LUKS_PASSWORD=567", "CRYPTENROLL_TPM2_PCRS=10+13+15"}},
 	// systemd-tpm2-legacy-pin.img: v252-254 format token — tpm2_srk present but
 	// no tpm2_salt, PIN auth via SHA256(pin) without PBKDF2.  Generated with
 	// raw tpm2-tools rather than systemd-cryptenroll to be independent of the

--- a/tests/supplantation_premise_test.go
+++ b/tests/supplantation_premise_test.go
@@ -1,0 +1,380 @@
+package tests
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Decision-validation / characterization tests for the TPM2 filesystem-
+// supplantation hardening work. These do not exercise booster
+// itself; they pin the TPM-semantics premises the PCR15-latch design depends
+// on, so the rationale is executable and a future TPM/tooling change that
+// invalidates a premise trips a test instead of silently weakening the design.
+//
+// Pure swtpm + tpm2-tools — no qemu boot, no booster image. Skipped when the
+// tools are unavailable (same pattern as TestSystemdTPM2LegacyPin).
+
+const (
+	swtpmTCPDataPort = "2321"
+	swtpmTCPCtrlPort = "2322"
+)
+
+func requireTool(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("%s not installed; skipping TPM-premise characterization test", name)
+	}
+}
+
+// startSwtpmTCP starts swtpm in TCP server mode so tpm2-tools can drive it via
+// the swtpm TCTI. The integration harness' startSwtpm() uses a unixio control
+// socket for QEMU; tpm2-tools needs the TCP data/ctrl ports instead. Returns
+// the TPM2TOOLS_TCTI string; the swtpm process is killed on test cleanup.
+func startSwtpmTCP(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmd := exec.Command("swtpm", "socket", "--tpm2",
+		"--server", "type=tcp,port="+swtpmTCPDataPort,
+		"--ctrl", "type=tcp,port="+swtpmTCPCtrlPort,
+		"--tpmstate", "dir="+dir,
+		"--flags", "not-need-init,startup-clear")
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:"+swtpmTCPDataPort, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			break
+		}
+		require.False(t, time.Now().After(deadline), "swtpm TCP port did not open")
+	}
+	return "swtpm:host=127.0.0.1,port=" + swtpmTCPDataPort
+}
+
+func tpm2Run(t *testing.T, tcti string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Env = append(os.Environ(), "TPM2TOOLS_TCTI="+tcti)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// restartableSwtpm is a swtpm TCP instance over a fixed state directory that can
+// be power-cycled: reboot() kills and restarts the process so the PCRs reset
+// (Startup CLEAR) while persistent hierarchy seeds and persistent handles in the
+// state dir survive — exactly the TPM behaviour across a real reboot. Used to
+// contrast a genuine boot with an attacker boot against the same enrolled key.
+type restartableSwtpm struct {
+	t    *testing.T
+	dir  string
+	port int
+	cmd  *exec.Cmd
+	tcti string
+}
+
+func newRestartableSwtpm(t *testing.T, port int) *restartableSwtpm {
+	s := &restartableSwtpm{t: t, dir: t.TempDir(), port: port}
+	s.start()
+	t.Cleanup(func() {
+		if s.cmd != nil {
+			_ = s.cmd.Process.Kill()
+		}
+	})
+	return s
+}
+
+func (s *restartableSwtpm) start() {
+	data := strconv.Itoa(s.port)
+	cmd := exec.Command("swtpm", "socket", "--tpm2",
+		"--server", "type=tcp,port="+data,
+		"--ctrl", "type=tcp,port="+strconv.Itoa(s.port+1),
+		"--tpmstate", "dir="+s.dir,
+		"--flags", "not-need-init,startup-clear")
+	require.NoError(s.t, cmd.Start())
+	s.cmd = cmd
+	s.tcti = "swtpm:host=127.0.0.1,port=" + data
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:"+data, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		require.False(s.t, time.Now().After(deadline), "swtpm TCP port did not open")
+	}
+}
+
+// reboot simulates a power cycle: kill (no graceful shutdown, so volatile state
+// is dropped and PCRs reset) and restart on a fresh port (avoids TIME_WAIT).
+func (s *restartableSwtpm) reboot() {
+	_ = s.cmd.Process.Kill()
+	_, _ = s.cmd.Process.Wait()
+	s.port += 2
+	s.start()
+}
+
+func tpm2Must(t *testing.T, tcti string, args ...string) string {
+	t.Helper()
+	out, err := tpm2Run(t, tcti, args...)
+	require.NoError(t, err, "%v failed: %s", args, out)
+	return out
+}
+
+const (
+	pcr15Zero256 = "0x0000000000000000000000000000000000000000000000000000000000000000"
+	pcr15Zero1   = "0x0000000000000000000000000000000000000000"
+)
+
+// TestSupplantationPCR15NonResettable validates the "the known all-zero value is
+// safe" premise: an attacker who knows PCR15's uninitialized value (all zeros)
+// still cannot make the register hold it again. PCRs 0-15 are non-resettable
+// SRTM registers (TCG PTP); only a full TPM reset (reboot) returns them to zero.
+// This is why sealing to an uninitialized PCR15 + extending it before pivot
+// closes the re-unseal oracle within a boot.
+func TestSupplantationPCR15NonResettable(t *testing.T) {
+	requireTool(t, "swtpm")
+	requireTool(t, "tpm2_pcrread")
+	requireTool(t, "tpm2_pcrextend")
+	requireTool(t, "tpm2_pcrreset")
+	tcti := startSwtpmTCP(t)
+
+	out, err := tpm2Run(t, tcti, "tpm2_pcrread", "sha256:15")
+	require.NoError(t, err)
+	require.Contains(t, out, pcr15Zero256, "PCR15 must start uninitialized (all zeros)")
+
+	_, err = tpm2Run(t, tcti, "tpm2_pcrextend",
+		"15:sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	require.NoError(t, err)
+
+	out, err = tpm2Run(t, tcti, "tpm2_pcrread", "sha256:15")
+	require.NoError(t, err)
+	require.NotContains(t, out, pcr15Zero256, "PCR15 must change after extend")
+
+	// The core assertion: PCR15 cannot be reset back to zero.
+	out, err = tpm2Run(t, tcti, "tpm2_pcrreset", "15")
+	require.Error(t, err, "PCR15 must NOT be resettable (would defeat the latch); got output: %s", out)
+
+	out, err = tpm2Run(t, tcti, "tpm2_pcrread", "sha256:15")
+	require.NoError(t, err)
+	require.NotContains(t, out, pcr15Zero256, "PCR15 must remain extended after a refused reset")
+}
+
+// TestSupplantationPCRBankIsolation validates the "extend ALL active banks"
+// premise: extending PCR15 in one bank leaves the other bank untouched, so
+// a policy that can be satisfied via the un-extended bank is bypassable. Booster
+// must extend PCR15 across every active bank, not just the token's recorded one.
+func TestSupplantationPCRBankIsolation(t *testing.T) {
+	requireTool(t, "swtpm")
+	requireTool(t, "tpm2_pcrread")
+	requireTool(t, "tpm2_pcrextend")
+	tcti := startSwtpmTCP(t)
+
+	out, err := tpm2Run(t, tcti, "tpm2_pcrread", "sha256:15+sha1:15")
+	require.NoError(t, err)
+	require.Contains(t, out, pcr15Zero256, "sha256:15 must start zero")
+	require.Contains(t, out, pcr15Zero1, "sha1:15 must start zero")
+
+	// Extend only the sha256 bank.
+	_, err = tpm2Run(t, tcti, "tpm2_pcrextend",
+		"15:sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	require.NoError(t, err)
+
+	out, err = tpm2Run(t, tcti, "tpm2_pcrread", "sha256:15+sha1:15")
+	require.NoError(t, err)
+	require.NotContains(t, out, pcr15Zero256, "sha256:15 must be extended")
+	require.Contains(t, out, pcr15Zero1,
+		"sha1:15 must still be zero => extending one bank leaves others exploitable; booster must extend ALL active banks")
+}
+
+// TestSupplantationPCR15WithoutPCR11Leaks validates the central premise: PCR15
+// contamination ALONE is not a defense. Co-binding to a PCR covering the
+// kernel+initrd (PCR11, via the UKI) is load-bearing — PCR15 is only a
+// single-use latch, not the thing that forces the real initrd to run.
+//
+// The test seals the same secret under two PCR policies captured at the same
+// "real boot" state, then simulates a supplanted initrd by changing PCR11:
+//
+//	A) PCR15 only      -> still unseals (the changed PCR11 is invisible) = LEAK
+//	B) PCR11 + PCR15   -> refuses (the changed PCR11 breaks the policy)  = SAFE
+//
+// The B branch is the internal control: if a misconfigured seal unsealed
+// unconditionally, B would fail too, so a green test genuinely shows that PCR11
+// — not PCR15 — is what catches the supplantation.
+func TestSupplantationPCR15WithoutPCR11Leaks(t *testing.T) {
+	requireTool(t, "swtpm")
+	for _, tool := range []string{
+		"tpm2_pcrextend", "tpm2_createprimary", "tpm2_createpolicy", "tpm2_create",
+		"tpm2_load", "tpm2_startauthsession", "tpm2_policypcr", "tpm2_unseal", "tpm2_flushcontext",
+	} {
+		requireTool(t, tool)
+	}
+	tcti := startSwtpmTCP(t)
+	dir := t.TempDir()
+	p := func(name string) string { return filepath.Join(dir, name) }
+	// swtpm has only a few transient object slots; each create/load reloads the
+	// parent, so flush transients between steps to avoid TPM_RC_OBJECT_MEMORY.
+	flushT := func() { _, _ = tpm2Run(t, tcti, "tpm2_flushcontext", "-t") }
+
+	// "Real boot": stamp a representative kernel+initrd measurement into PCR11.
+	tpm2Must(t, tcti, "tpm2_pcrextend", "11:sha256="+strings.Repeat("11", 32))
+
+	// One primary shared by both sealed objects.
+	tpm2Must(t, tcti, "tpm2_createprimary", "-C", "o", "-g", "sha256", "-G", "ecc", "-c", p("primary.ctx"))
+	flushT()
+
+	// Two policies captured at the same real state (PCR15==0, PCR11==real):
+	//   A) PCR15 only    -- the reporter's "PCR15 contamination" approach
+	//   B) PCR11 + PCR15 -- our co-binding
+	tpm2Must(t, tcti, "tpm2_createpolicy", "--policy-pcr", "-l", "sha256:15", "-L", p("polA.dat"))
+	tpm2Must(t, tcti, "tpm2_createpolicy", "--policy-pcr", "-l", "sha256:11,15", "-L", p("polB.dat"))
+
+	const secret = "super-secret-volume-key"
+	require.NoError(t, os.WriteFile(p("secret.txt"), []byte(secret), 0o600))
+
+	seal := func(pol, pub, priv, ctx string) {
+		tpm2Must(t, tcti, "tpm2_create", "-C", p("primary.ctx"), "-L", p(pol),
+			"-i", p("secret.txt"), "-u", p(pub), "-r", p(priv))
+		flushT()
+		tpm2Must(t, tcti, "tpm2_load", "-C", p("primary.ctx"), "-u", p(pub), "-r", p(priv), "-c", p(ctx))
+		flushT()
+	}
+	seal("polA.dat", "a.pub", "a.priv", "a.ctx")
+	seal("polB.dat", "b.pub", "b.priv", "b.ctx")
+
+	// Supplantation: a different initrd runs -> PCR11 changes. PCR15 stays 0 (the
+	// attacker simply never runs booster's extend, or has just rebooted).
+	tpm2Must(t, tcti, "tpm2_pcrextend", "11:sha256="+strings.Repeat("ee", 32))
+
+	unseal := func(ctx, pcrs string) (string, error) {
+		sess := p("sess.ctx")
+		defer func() { _, _ = tpm2Run(t, tcti, "tpm2_flushcontext", sess); flushT() }()
+		if out, err := tpm2Run(t, tcti, "tpm2_startauthsession", "--policy-session", "-S", sess); err != nil {
+			return out, err
+		}
+		if out, err := tpm2Run(t, tcti, "tpm2_policypcr", "-S", sess, "-l", pcrs); err != nil {
+			return out, err
+		}
+		return tpm2Run(t, tcti, "tpm2_unseal", "-c", p(ctx), "-p", "session:"+sess)
+	}
+
+	// A) PCR15-only: the changed PCR11 is invisible -> the key still falls out.
+	outA, errA := unseal("a.ctx", "sha256:15")
+	require.NoError(t, errA,
+		"PCR15-only seal should STILL unseal after PCR11 changed (the bypass); output: %s", outA)
+	require.Contains(t, outA, secret,
+		"PCR15-only policy leaked the volume key despite a supplanted initrd => PCR15 alone is not a defense")
+
+	// B) PCR11+PCR15: the changed PCR11 breaks the policy -> the key is protected.
+	outB, errB := unseal("b.ctx", "sha256:11,15")
+	require.Error(t, errB,
+		"PCR11-co-bound seal MUST refuse after PCR11 changed; it unsealed instead: %s", outB)
+	require.NotContains(t, outB, secret,
+		"PCR11 co-binding must not release the key for a supplanted initrd")
+}
+
+// TestSupplantationCrossBootDenied is the positive counterpart to
+// TestSupplantationPCR15WithoutPCR11Leaks: with the key co-bound to
+// PCR 7+11+15, an attacker who power-cycles the machine and boots a DIFFERENT
+// image is denied the key — even though they trivially reproduce PCR7 (same
+// firmware / Secure Boot state) and a fresh, uninitialised PCR15==0. Only PCR11,
+// the UKI/initrd measurement they cannot forge without the genuine image,
+// withholds it. This is exactly the supplantation attack run end to end against
+// the defended enrollment.
+//
+// It uses a real swtpm power-cycle (PCRs reset, persistent SRK survives), not a
+// full booster+UKI+OVMF in-guest boot — that broader integration harness does
+// not exist yet — but the cryptographic claim (PCR11 blocks, PCR7+15 do not) is
+// the same one booster's enrollment guidance and Phase-1b warning rely on.
+func TestSupplantationCrossBootDenied(t *testing.T) {
+	requireTool(t, "swtpm")
+	for _, tool := range []string{
+		"tpm2_pcrextend", "tpm2_createprimary", "tpm2_evictcontrol", "tpm2_createpolicy",
+		"tpm2_create", "tpm2_load", "tpm2_startauthsession", "tpm2_policypcr",
+		"tpm2_unseal", "tpm2_flushcontext",
+	} {
+		requireTool(t, tool)
+	}
+	s := newRestartableSwtpm(t, 2323)
+	dir := t.TempDir()
+	p := func(n string) string { return filepath.Join(dir, n) }
+	flushT := func() { _, _ = tpm2Run(t, s.tcti, "tpm2_flushcontext", "-t") }
+
+	const (
+		parent = "0x81000001"
+		secret = "super-secret-volume-key"
+	)
+	var (
+		fw       = strings.Repeat("77", 32) // PCR7:  firmware / Secure Boot state (reproducible)
+		realInit = strings.Repeat("be", 32) // PCR11: the genuine UKI/initrd
+		evilInit = strings.Repeat("ad", 32) // PCR11: the attacker's image
+	)
+	require.NoError(t, os.WriteFile(p("secret.txt"), []byte(secret), 0o600))
+
+	// measure replays a boot's measurements into PCR7 and PCR11. PCR15 is left at
+	// its fresh, uninitialised 0 — the "system-identity" value the token seals to.
+	measure := func(pcr7, pcr11 string) {
+		tpm2Must(t, s.tcti, "tpm2_pcrextend", "7:sha256="+pcr7)
+		tpm2Must(t, s.tcti, "tpm2_pcrextend", "11:sha256="+pcr11)
+	}
+	unseal := func() (string, error) {
+		sess := p("sess.ctx")
+		defer func() { _, _ = tpm2Run(t, s.tcti, "tpm2_flushcontext", sess); flushT() }()
+		if out, err := tpm2Run(t, s.tcti, "tpm2_load", "-C", parent,
+			"-u", p("seal.pub"), "-r", p("seal.priv"), "-c", p("seal.ctx")); err != nil {
+			return out, err
+		}
+		if out, err := tpm2Run(t, s.tcti, "tpm2_startauthsession", "--policy-session", "-S", sess); err != nil {
+			return out, err
+		}
+		if out, err := tpm2Run(t, s.tcti, "tpm2_policypcr", "-S", sess, "-l", "sha256:7,11,15"); err != nil {
+			return out, err
+		}
+		return tpm2Run(t, s.tcti, "tpm2_unseal", "-c", p("seal.ctx"), "-p", "session:"+sess)
+	}
+
+	// Enrollment during the genuine boot's measured state. The primary is made
+	// persistent so it survives the simulated reboots, like a real SRK.
+	tpm2Must(t, s.tcti, "tpm2_createprimary", "-C", "o", "-g", "sha256", "-G", "ecc", "-c", p("primary.ctx"))
+	tpm2Must(t, s.tcti, "tpm2_evictcontrol", "-C", "o", "-c", p("primary.ctx"), parent)
+	flushT()
+	measure(fw, realInit)
+	tpm2Must(t, s.tcti, "tpm2_createpolicy", "--policy-pcr", "-l", "sha256:7,11,15", "-L", p("pol.dat"))
+	tpm2Must(t, s.tcti, "tpm2_create", "-C", parent, "-L", p("pol.dat"),
+		"-i", p("secret.txt"), "-u", p("seal.pub"), "-r", p("seal.priv"))
+	flushT()
+
+	// Sanity: the genuine boot unseals.
+	out, err := unseal()
+	require.NoError(t, err, "genuine boot must unseal; output: %s", out)
+	require.Contains(t, out, secret)
+
+	// Attacker boot: power-cycle, reproduce PCR7 and a fresh PCR15==0, but run a
+	// different initrd (PCR11 differs). The key must be withheld.
+	s.reboot()
+	flushT()
+	measure(fw, evilInit)
+	out, err = unseal()
+	require.Error(t, err, "attacker boot (different PCR11) MUST be denied; it unsealed: %s", out)
+	require.NotContains(t, out, secret,
+		"PCR11 co-binding must withhold the key from a supplanted initrd, despite a reproduced PCR7 and a fresh PCR15==0")
+
+	// Control: a genuine re-boot (same PCR7+PCR11) still unseals, proving the
+	// denial above was the PCR11 difference and not a broken reload after reboot.
+	s.reboot()
+	flushT()
+	measure(fw, realInit)
+	out, err = unseal()
+	require.NoError(t, err, "genuine re-boot must still unseal; output: %s", out)
+	require.Contains(t, out, secret)
+}

--- a/tests/supplantation_test.go
+++ b/tests/supplantation_test.go
@@ -1,0 +1,41 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSupplantationPCR15Latch is the end-to-end proof for the TPM2 filesystem-
+// supplantation hardening. A volume whose systemd-tpm2 token binds PCR15
+// auto-unseals at the uninitialized PCR15 (==0); booster must then extend PCR15
+// with the volume-key measurement *before* pivot, so the key can no longer be
+// re-unsealed for the rest of the boot — closing the TPM re-unseal oracle.
+//
+// Observable: booster logs "PCR15 re-unseal latch engaged" once it extends the
+// PCR. The init-package unit tests separately prove the extend value is the
+// correct systemd-compatible HMAC across all active banks, and that PCR15 cannot
+// be reset without a reboot — so the log line firing on a real boot, combined
+// with those, demonstrates the oracle is closed. Pre-fix booster has zero
+// PCR-extend calls, so the line never appears and this test fails.
+//
+// The disk asset auto-generates on first run via checkAsset (systemd_tpm2.sh,
+// which uses sudo for losetup/cryptsetup/mkfs); no qemu-claude bootstrap needed.
+// Its token binds PCR 10+13+15 — including PCR15, so the latch engages.
+func TestSupplantationPCR15Latch(t *testing.T) {
+	swtpm, params, err := startSwtpm()
+	require.NoError(t, err)
+	defer swtpm.Kill()
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:       "assets/systemd-tpm2-pcr15.img",
+		kernelArgs: []string{"rd.luks.uuid=7a9f3c21-5e84-4d16-b2c7-1f0a9e6d4b33", "root=UUID=8b0a4d32-6f95-4e27-93d8-2a1baf7e5c44", "booster.log=debug"},
+		params:     params,
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	// The token unseals while PCR15 is still 0, then booster extends PCR15.
+	require.NoError(t, vm.ConsoleExpect("PCR15 re-unseal latch engaged"))
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}


### PR DESCRIPTION
## Summary
Implements the runtime half of the TPM2 filesystem-supplantation hardening from #379. After a `systemd-tpm2` token is unsealed, booster extends PCR 15 with the systemd-compatible "system-identity" measurement before pivot, so the volume key cannot be re-unsealed for the rest of the boot — closing the TPM re-unseal oracle. Adds a `tpm2-measure-pcr=` control (crypttab and `rd.luks.options=`) and a manpage section documenting the secure-enrollment recipe.

## Background
A TPM attests the boot *path*, not the data it releases: with a passphrase-less, PCR-only enrollment a physical attacker can present a substituted root (or boot their own image) and have the TPM hand back the real key (oddlama, "Bypassing disk encryption with TPM2 unlock"; IncusOS CVE-2026-32606, fixed by binding the key to an uninitialized PCR 15).

## What it does
- `measureVolumeKeyToPCR15` extends PCR 15 with `HMAC(volume_key, "cryptsetup:" + name + ":" + uuid)` in every active PCR bank, byte-compatible with systemd-cryptsetup's `tpm2-measure-pcr=yes`, before `SetupMapper`/pivot.
- Engages automatically when the token's policy binds PCR 15 (the enrollment is the signal); `tpm2-measure-pcr=yes|no` overrides per device; a measurement failure aborts the unlock (fail closed).
- Extends **all** active banks — a policy satisfiable through an un-extended bank would otherwise be bypassable.
- The volume key is consumed via `luks.Volume.HMAC` (anatol/luks.go#17, merged) so the key never leaves the LUKS library — only the non-secret digest crosses into booster.

## What the testing settled — PCR 15 alone vs. co-binding
The thread's open question was whether PCR 15 contamination alone suffices (@thePrivacyFanatic) or whether PCR 11 co-binding is required. The characterization tests answer it empirically:
- PCR 15 alone closes the *within-boot* re-unseal oracle but is **not** a supplantation defense by itself — PCR 15 resets to zero on power-cycle, so an attacker who reboots into a malicious initrd re-unseals. `TestSupplantationPCR15WithoutPCR11Leaks` seals one secret to a PCR15-only policy and another to PCR 11+15, changes PCR 11 (a supplanted initrd), and shows the PCR15-only seal still unseals (leak) while PCR 11+15 refuses.
- `TestSupplantationCrossBootDenied` runs the real attack at the TPM level with an actual power-cycle: sealed to 7+11+15, an attacker boot that reproduces PCR 7 and a fresh PCR 15 but a different PCR 11 is denied, while the control boot (genuine PCR 11) succeeds — so **PCR 11 (the UKI measurement) is the load-bearing barrier and PCR 15 is the single-use latch.**

So the latch ships as @thePrivacyFanatic proposed (and composes with keyfile-cascaded secondary volumes as they noted), but the docs are explicit that PCR 11 co-binding is what actually resists supplantation.

## Tests
- e2e: `TestSupplantationPCR15Latch` — real boot, unseal at PCR 15 == 0, asserts the latch extends before pivot.
- premise/characterization (swtpm + tpm2-tools, executable threat-model): `…WithoutPCR11Leaks` (co-binding load-bearing), `…CrossBootDenied` (positive cross-boot), `…PCRBankIsolation` (all-banks mandatory), `…PCR15NonResettable`.
- unit: exact systemd HMAC formula + `xescape`, all-active-banks extend, fail-closed on TPM/bank errors, and the gating decision.

## On the PCR 11 enrollment pain (@thePrivacyFanatic, @invokekitty)
Literal PCR 11 binding already unseals on booster today (the token's PCR set is honored). The painful part raised in the thread — refreshing the PCR 11 value on every kernel update — is the literal-policy fragility documented in the new manpage section. Signed (authorized) PCR policy, which lets ukify re-sign the new PCR 11 each build instead of re-enrolling by hand, is the immediate follow-up PR.

## Scope
Runtime latch + control + docs only. The other #379 targets — TPM bus session encryption, post-unlock key cleanup/keyring/zeroing, header-embed, clevis, and signed PCR policy — are separate follow-ups (clevis has no upstream measurement mechanism; signed policy is next).

Addresses #379
