### PR TITLE
init/console: configurable password echo cycle (asterisks/silent/plaintext)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Booster - fast and secure initramfs generator
 
 Release 0.11 (TBD)
+  * Adds the `password_echo` config option: an ordered list of passphrase/PIN prompt echo modes
+    (`asterisks`, `silent`, `plaintext`). The prompt starts in the first listed mode and Tab
+    cycles through the list — a single entry pins the prompt, and omitting `plaintext` keeps the
+    typed characters unrevealable. This also implements the plaintext reveal the manpage
+    previously described but which was never wired up (#305)
   * FIDO2 unlock now uses native go-libfido2 via a plugin instead of the external `fido2-assert` binary.
     Add `enable_fido2: true` to `/etc/booster.yaml` to opt in. Users with `extra_files: fido2-assert`
     in their config will continue to work with a deprecation warning — update to `enable_fido2: true`

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -37,6 +37,7 @@ Booster advantages:
     enable_mdraid: true
     token_timeout: 30s
     pin_delay: 5s
+    password_echo: silent,asterisks,plaintext
     serialize_tokens:
       enabled: true
       clevis_timeout: 45s
@@ -105,6 +106,8 @@ Booster advantages:
     In serialize mode prefer leaving `token_timeout` unset so tier 3 applies: a fixed value shorter than the token chain can start the keyboard prompt before a token has had its turn.
 
  * `pin_delay` is the concurrent-mode counterpart to `serialize_tokens`: it holds the first interactive PIN prompt (TPM2-PIN, FIDO2-PIN) this long so a parallel non-interactive token can unlock first and the prompt is never drawn — cancelled before render if a token wins, shown as normal if the delay expires (no unlock path is lost; the delay only postpones the prompt). Go duration; unset (the default) means no delay. No effect in serialize mode, or when no parallel non-PIN token is enrolled (a PIN-only device prompts immediately). Set it longer than the racing token's real unlock time — TPM2/FIDO2 hardware bring-up, or for clevis the network/DHCP round-trip — but well below `token_timeout`; otherwise the prompt is still drawn. A few seconds suits a fast PCR-only TPM2 unseal; clevis-over-network or a universal image with slow module loading needs more.
+
+ * `password_echo` configures the password/PIN prompt feedback as an ordered, comma-separated list of echo modes: `asterisks` (one `*` per typed character), `silent` (no feedback at all, like `sudo`), and `plaintext` (the literal characters). The first entry is the mode the prompt starts in; **Tab** cycles through the listed modes in order, wrapping. Defaults to `asterisks,silent,plaintext`. A single entry pins the prompt to that mode (Tab is then ignored), and leaving `plaintext` out of the list (e.g. `silent,asterisks`) means the typed characters can never be shown at the prompt. Applies to every keyboard prompt — LUKS passphrase, TPM2 PIN, FIDO2 PIN. See **Password entry** in NOTES.
 
 Once you are done modifying your config file and want to regenerate booster images under `/boot` please use `/usr/lib/booster/regenerate_images`.
 It is a convenience script that performs the same type of image regeneration as if you installed `booster` with your package manager.
@@ -350,10 +353,12 @@ UUID parameter can optionally be enclosed with quote symbol `"` though it is not
 `rd.luks.uuid=ac8299a8-91ce-4bf6-a524-55a62844b787`, `rd.luks.uuid="ac8299a8-91ce-4bf6-a524-55a62844b787"` (not recommended).
 
 ### Password entry
+The prompt has three echo modes: **asterisks** (one `*` per typed character), **silent** (no feedback at all, like `sudo`), and **plaintext** (the literal characters, for hunting down a typo). The `password_echo` config option lists the modes as an ordered cycle: the prompt starts in the first listed mode and **Tab** advances through the list, wrapping. Switching modes repaints the feedback for everything typed so far. The default is `asterisks,silent,plaintext`, so plaintext is only ever reached deliberately — two presses past the default mode, never on the way to hiding. List a single mode to pin the prompt (Tab is then ignored), or leave `plaintext` out of the list — e.g. `password_echo: silent,asterisks` — to toggle between the hidden modes only, with no way to flash the typed characters on screen.
+
 Editing keys beyond the standard:
  * **Ctrl+W** — erase the previous word.
  * **Ctrl+U** — erase the entire entry.
- * **Tab** — toggle visibility of the typed characters (asterisks ↔ literal).
+ * **Tab** — cycle the echo mode through the configured `password_echo` list.
 
 ### LUKS unlock concurrency and prompt order
 Booster runs LUKS unlock paths concurrently per volume — multiple enrolled tokens dispatch in parallel where possible, and the keyboard passphrase prompt runs alongside them as a fallback. This subsection summarises the deterministic ordering and the cancel-on-win behaviour that ties them together.

--- a/generator/config.go
+++ b/generator/config.go
@@ -75,6 +75,7 @@ type UserConfig struct {
 	EnableFido2          bool   `yaml:"enable_fido2"`
 	TokenTimeout         string `yaml:"token_timeout,omitempty"` // device-level keyboard-fallback timer (e.g. 30s); applies in both modes; global default, overridable by crypttab/cmdline
 	PinDelay             string `yaml:"pin_delay,omitempty"`     // concurrent-mode only: hold an interactive PIN prompt (TPM2-PIN/FIDO2-PIN) this long (e.g. 3s) so a parallel non-interactive token can win first; default unset (off)
+	PasswordEcho         string `yaml:"password_echo,omitempty"` // ordered comma-separated list of prompt echo modes; first = startup mode, Tab cycles the list; default asterisks,silent,plaintext
 
 	// SerializeTokens opts out of booster's token concurrency: tokens are
 	// tried one at a time in ID order. The per-type timeouts are scoped here
@@ -97,6 +98,31 @@ func parseCommaList(raw string) []string {
 		values = append(values, value)
 	}
 	return values
+}
+
+// validatePasswordEcho checks a password_echo value: an ordered,
+// comma-separated list of unique prompt echo modes. The first entry is the
+// startup mode and Tab cycles through the list in order (a single entry pins
+// the prompt). Empty selects the default cycle asterisks,silent,plaintext.
+// init/console_input.go parses the same syntax at boot time.
+func validatePasswordEcho(val string) error {
+	if val == "" {
+		return nil
+	}
+	seen := make(map[string]bool)
+	for mode := range strings.SplitSeq(val, ",") {
+		mode = strings.TrimSpace(mode)
+		switch mode {
+		case "asterisks", "silent", "plaintext":
+		default:
+			return fmt.Errorf("config: invalid password_echo mode %q, expected a comma-separated list of: asterisks, silent, plaintext", mode)
+		}
+		if seen[mode] {
+			return fmt.Errorf("config: password_echo lists mode %q twice", mode)
+		}
+		seen[mode] = true
+	}
+	return nil
 }
 
 // read user config from the specified file. If file parameter is empty string then "empty" configuration is considered
@@ -246,6 +272,10 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 		conf.crypttabFile = u.CrypttabPath
 	}
 	conf.enableFido2 = u.EnableFido2
+	if err := validatePasswordEcho(u.PasswordEcho); err != nil {
+		return nil, err
+	}
+	conf.passwordEcho = u.PasswordEcho
 	var clevisT, tpm2T, fido2T string
 	if st := u.SerializeTokens; st != nil {
 		conf.serializeTokens = st.Enabled

--- a/generator/config_test.go
+++ b/generator/config_test.go
@@ -256,3 +256,45 @@ network:
 	require.NoError(t, err)
 	require.NotEmpty(t, c.sshHostKey)
 }
+
+func TestReadConfigPasswordEcho(t *testing.T) {
+	t.Parallel()
+
+	// A single mode (pinned prompt), a two-mode cycle, and a full explicit
+	// order with surrounding spaces must all pass through verbatim.
+	for _, val := range []string{"silent", "silent,asterisks", "plaintext, silent, asterisks"} {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "booster.yaml")
+		require.NoError(t, os.WriteFile(cfgPath, []byte("password_echo: "+val+"\n"), 0o644))
+
+		c, err := readGeneratorConfig(cfgPath)
+		require.NoError(t, err, "value %q", val)
+		require.Equal(t, val, c.passwordEcho, "value %q", val)
+	}
+}
+
+func TestReadConfigPasswordEchoDefaults(t *testing.T) {
+	t.Parallel()
+
+	c, err := readGeneratorConfig("")
+	require.NoError(t, err)
+	require.Equal(t, "", c.passwordEcho)
+}
+
+func TestReadConfigRejectsInvalidPasswordEcho(t *testing.T) {
+	t.Parallel()
+
+	for _, val := range []string{
+		"hidden",            // unknown mode
+		"silent,hidden",     // unknown mode inside a list
+		"silent,silent",     // duplicate mode
+		"silent,,asterisks", // empty element
+	} {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "booster.yaml")
+		require.NoError(t, os.WriteFile(cfgPath, []byte("password_echo: "+val+"\n"), 0o644))
+
+		_, err := readGeneratorConfig(cfgPath)
+		require.ErrorContains(t, err, "password_echo", "value %q must be rejected", val)
+	}
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -64,6 +64,8 @@ type generatorConfig struct {
 	clevisTimeout   int  // serialize-mode per-token bound for clevis (seconds); 0 = default
 	tpm2Timeout     int  // serialize-mode per-token bound for non-PIN systemd-tpm2 (seconds); 0 = default
 	fido2Timeout    int  // serialize-mode per-token bound for non-PIN systemd-fido2 (seconds); 0 = default
+
+	passwordEcho string // ordered comma-separated echo-mode cycle for the prompt; "" = default asterisks,silent,plaintext
 }
 
 type networkStaticConfig struct {
@@ -515,6 +517,7 @@ func (img *Image) appendInitConfig(conf *generatorConfig, kmod *Kmod, vconsole *
 	initConfig.ClevisTimeout = conf.clevisTimeout
 	initConfig.Tpm2Timeout = conf.tpm2Timeout
 	initConfig.Fido2Timeout = conf.fido2Timeout
+	initConfig.PasswordEcho = conf.passwordEcho
 
 	if conf.networkConfigType == netDhcp {
 		initConfig.Network = &InitNetworkConfig{}

--- a/init/config.go
+++ b/init/config.go
@@ -43,12 +43,13 @@ type InitConfig struct {
 	EnableZfs              bool                `yaml:",omitempty"`
 	ZfsImportParams        string              `yaml:",omitempty"` // TODO: remove it
 	EnablePlymouth         bool                `yaml:",omitempty"`
-	SerializeTokens        bool                `yaml:",omitempty"` // dispatch LUKS tokens serially instead of concurrently; default false
-	TokenTimeout           int                 `yaml:",omitempty"` // device-level keyboard-fallback timer in seconds; 0 = unset (crypttab/cmdline or derived default applies)
-	PinDelay               int                 `yaml:",omitempty"` // concurrent-mode PIN-prompt pre-delay in seconds so a parallel non-interactive token can win first; 0 = off
-	ClevisTimeout          int                 `yaml:",omitempty"` // serialize-mode per-token bound for clevis tokens in seconds; 0 = default 45
-	Tpm2Timeout            int                 `yaml:",omitempty"` // serialize-mode per-token bound for non-PIN systemd-tpm2 tokens in seconds; 0 = default 15
-	Fido2Timeout           int                 `yaml:",omitempty"` // serialize-mode per-token bound for non-PIN systemd-fido2 tokens in seconds; 0 = default 30
+	SerializeTokens        bool                `yaml:",omitempty"`              // dispatch LUKS tokens serially instead of concurrently; default false
+	TokenTimeout           int                 `yaml:",omitempty"`              // device-level keyboard-fallback timer in seconds; 0 = unset (crypttab/cmdline or derived default applies)
+	PinDelay               int                 `yaml:",omitempty"`              // concurrent-mode PIN-prompt pre-delay in seconds so a parallel non-interactive token can win first; 0 = off
+	ClevisTimeout          int                 `yaml:",omitempty"`              // serialize-mode per-token bound for clevis tokens in seconds; 0 = default 45
+	Tpm2Timeout            int                 `yaml:",omitempty"`              // serialize-mode per-token bound for non-PIN systemd-tpm2 tokens in seconds; 0 = default 15
+	Fido2Timeout           int                 `yaml:",omitempty"`              // serialize-mode per-token bound for non-PIN systemd-fido2 tokens in seconds; 0 = default 30
+	PasswordEcho           string              `yaml:"password_echo,omitempty"` // ordered comma-separated echo-mode cycle; first entry = startup mode; validated by the generator
 }
 
 const initConfigPath = "/etc/booster.init.yaml"

--- a/init/console_input.go
+++ b/init/console_input.go
@@ -89,6 +89,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -106,7 +107,7 @@ const (
 	keyEnter                     // CR / LF — end of input
 	keyEOF                       // Ctrl+D (0x04) — end-of-input on empty buffer; no-op otherwise
 	keyBackspace                 // BS (0x08) or DEL (0x7f) — erase last char
-	keyTab                       // Tab (0x09) — toggle masking
+	keyTab                       // Tab (0x09) — cycle the password echo mode
 	keyKillLine                  // Ctrl+U (0x15) — erase entire line
 	keyKillWord                  // Ctrl+W (0x17) — erase back to last whitespace
 )
@@ -473,32 +474,101 @@ func (s *inputScanner) Feed(b byte) (event keyEvent, chars []byte) {
 	return keyNone, nil
 }
 
+// passwordEchoMode selects what the password prompt paints per typed
+// character: one asterisk, nothing at all, or the literal character.
+type passwordEchoMode int
+
+const (
+	echoAsterisks passwordEchoMode = iota // one "*" per codepoint; the default
+	echoSilent                            // no visual feedback (sudo-style)
+	echoPlaintext                         // literal characters, for typo hunting
+)
+
+// defaultPasswordEchoCycle is the Tab order when password_echo is unset:
+// asterisks → silent → plaintext. Plaintext last keeps the historical
+// first-press behavior (hide the feedback) and makes the reveal mode
+// reachable only deliberately, never on the way to hiding.
+var defaultPasswordEchoCycle = []passwordEchoMode{echoAsterisks, echoSilent, echoPlaintext}
+
+// parsePasswordEcho maps a password_echo config value — an ordered,
+// comma-separated list of unique modes — to the prompt's Tab cycle. The first
+// entry is the startup mode; Tab advances through the list in order, wrapping.
+// A single entry pins the prompt (Tab is a no-op). Empty selects the default
+// cycle. The generator validates the same syntax at image build time; the
+// boolean here guards against a hand-edited image config.
+func parsePasswordEcho(val string) ([]passwordEchoMode, bool) {
+	if val == "" {
+		return defaultPasswordEchoCycle, true
+	}
+	parts := strings.Split(val, ",")
+	cycle := make([]passwordEchoMode, 0, len(parts))
+	for _, p := range parts {
+		var m passwordEchoMode
+		switch strings.TrimSpace(p) {
+		case "asterisks":
+			m = echoAsterisks
+		case "silent":
+			m = echoSilent
+		case "plaintext":
+			m = echoPlaintext
+		default:
+			return defaultPasswordEchoCycle, false
+		}
+		if slices.Contains(cycle, m) {
+			return defaultPasswordEchoCycle, false
+		}
+		cycle = append(cycle, m)
+	}
+	return cycle, true
+}
+
+// Prompt echo policy from the init config (password_echo). Set once in
+// readConfig before any prompt is shown; read-only afterwards. The first
+// entry is the prompt's startup mode; Tab advances through the cycle,
+// wrapping. A single-entry cycle pins the prompt.
+var passwordEchoCycle = defaultPasswordEchoCycle
+
+// echoFor renders the visible form of password under mode: one asterisk per
+// codepoint, nothing, or the literal bytes. Erase paths assume one terminal
+// cell per codepoint; a double-width glyph echoed in plaintext mode leaves
+// half a cell behind on backspace (cosmetic only — the buffer stays correct).
+func echoFor(password []byte, mode passwordEchoMode) string {
+	switch mode {
+	case echoAsterisks:
+		return strings.Repeat("*", countCodepoints(password))
+	case echoPlaintext:
+		return string(password)
+	}
+	return ""
+}
+
 // consoleMu serializes all stdout writes so that concurrent status message
-// reprints and raw-mode asterisk echoes never interleave. Held briefly during
+// reprints and raw-mode keystroke echoes never interleave. Held briefly during
 // every consolePrint call.
 var consoleMu sync.Mutex
 
 // consolePrompt tracks the active password prompt so statusMessage (declared
 // in plymouth.go) can erase the current line, print the status, and reprint
-// the prompt beneath it without losing the user's typed-asterisks state.
+// the prompt beneath it without losing the user's typed-echo state.
 //
 // Invariants (must hold while consoleMu is held):
 //   - active == true iff a readPasswordOn is running and has finished its
 //     initial prompt print
 //   - text is the prompt string passed to readPasswordOn; statusMessage uses
 //     it to redraw after writing a status line
-//   - asterisks is the number of asterisks currently visible on the console;
-//     readPasswordOn maintains this with consoleMu held to keep statusMessage
-//     in sync. Tracked as a count (not the password length) so toggling
-//     masking via Tab can erase exactly the right number of "\b \b" sequences
+//   - echoed is exactly the feedback currently painted after the prompt text
+//     ("" in silent mode, asterisks, or the literal password in plaintext
+//     mode); readPasswordOn maintains it with consoleMu held so redraw paths
+//     can repaint prompt + feedback verbatim, and erase paths can remove
+//     exactly countCodepoints(echoed) cells
 //   - done mirrors the active prompt's ctx.Done(); statusMessage selects on
 //     it to skip a redraw once the volume is unlocked by another method
 //     (avoids redrawing a prompt that's about to be dismissed)
 var consolePrompt struct {
-	active    bool
-	text      string
-	asterisks int
-	done      <-chan struct{}
+	active bool
+	text   string
+	echoed string
+	done   <-chan struct{}
 }
 
 // consolePrint writes msg without acquiring consoleMu. Callers must hold consoleMu.
@@ -514,14 +584,33 @@ func consolePrint(msg string) {
 // re-painting any active password prompt below so the user's cursor stays
 // at the bottom. Used by log levels (info, warning, severe) which would
 // otherwise overwrite the prompt line mid-input.
+//
+// The live prompt line is erased in place before msg scrolls it away:
+// otherwise the terminal archives it intact in scrollback, which in plaintext
+// echo mode preserves the literal passphrase in history (and in the capture
+// buffer of serial/IPMI consoles).
 func consolePrintWithPromptRedraw(msg string) {
 	consoleMu.Lock()
 	defer consoleMu.Unlock()
 	if consolePrompt.active && !promptVolumeUnlocked() {
-		consolePrint(msg + "\n" + consolePrompt.text + strings.Repeat("*", consolePrompt.asterisks))
+		consoleEcho(eraseLine)
+		consolePrint(msg + "\n" + consolePrompt.text + promptEchoedForPrint())
 	} else {
 		consolePrint(msg + "\n")
 	}
+}
+
+// promptEchoedForPrint returns the prompt feedback to repaint after a status
+// or log message. In qemu integration builds (-tags test) consolePrint writes
+// to /dev/kmsg, where repainting the feedback would log the literal passphrase
+// whenever the prompt is in plaintext mode — repaint nothing there (the
+// per-keystroke echo is already suppressed by consoleEcho for the same
+// reason). Callers must hold consoleMu.
+func promptEchoedForPrint() string {
+	if quirk.TestEnabled {
+		return ""
+	}
+	return consolePrompt.echoed
 }
 
 // consoleEcho writes terminal-only decoration (asterisks, backspace, line-erase
@@ -539,15 +628,16 @@ func consoleEcho(msg string) {
 
 // Terminal byte sequences written via consoleEcho.
 const (
-	eraseChar           = "\b \b"      // erase the character at the cursor
-	eraseLineAndAdvance = "\r\x1b[K\n" // wipe current line and move to next
+	eraseChar           = "\b \b"          // erase the character at the cursor
+	eraseLine           = "\r\x1b[K"       // wipe the current line in place
+	eraseLineAndAdvance = eraseLine + "\n" // wipe current line and move to next
 )
 
 var inputMutex sync.Mutex
 
 // readPasswordLocked reads a password from stdin in raw terminal mode, echoing
-// asterisks for each character typed. Cancels cleanly when ctx is done.
-// The caller must hold inputMutex.
+// keystroke feedback per the configured password echo mode (asterisks by
+// default). Cancels cleanly when ctx is done. The caller must hold inputMutex.
 func readPasswordLocked(ctx context.Context, prompt, postPrompt string) ([]byte, error) {
 	return readPasswordOn(ctx, os.Stdin, prompt, postPrompt)
 }
@@ -620,7 +710,7 @@ func readPasswordOn(ctx context.Context, tty *os.File, prompt, postPrompt string
 	consolePrint(prompt)
 	consolePrompt.active = true
 	consolePrompt.text = prompt
-	consolePrompt.asterisks = 0
+	consolePrompt.echoed = ""
 	consolePrompt.done = ctx.Done()
 	consoleMu.Unlock()
 
@@ -646,7 +736,9 @@ func readPasswordOn(ctx context.Context, tty *os.File, prompt, postPrompt string
 	}
 
 	var password []byte
-	var masked bool
+	cycle := passwordEchoCycle
+	modeIdx := 0
+	mode := cycle[modeIdx]
 	var b [1]byte
 	var scanner inputScanner
 	fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
@@ -685,50 +777,47 @@ loop:
 				break loop
 			}
 		case keyChar:
-			// ch holds one complete codepoint (1–4 bytes); one asterisk.
+			// ch holds one complete codepoint (1–4 bytes).
 			password = append(password, ch...)
-			if !masked {
+			if add := echoFor(ch, mode); add != "" {
 				consoleMu.Lock()
-				consolePrompt.asterisks++
-				consoleEcho("*")
+				consolePrompt.echoed += add
+				consoleEcho(add)
 				consoleMu.Unlock()
 			}
 		case keyBackspace:
 			if len(password) > 0 {
 				// Remove the last UTF-8 codepoint from the buffer.
 				password = trimLastCodepoint(password)
-				if !masked {
+				if mode != echoSilent {
 					consoleMu.Lock()
-					consolePrompt.asterisks--
+					consolePrompt.echoed = string(trimLastCodepoint([]byte(consolePrompt.echoed)))
 					consoleEcho(eraseChar)
 					consoleMu.Unlock()
 				}
 			}
-		case keyTab: // toggle asterisk masking
-			consoleMu.Lock()
-			if masked {
-				cp := countCodepoints(password)
-				for range cp {
-					consoleEcho("*")
-				}
-				consolePrompt.asterisks = cp
-			} else {
-				for range consolePrompt.asterisks {
-					consoleEcho(eraseChar)
-				}
-				consolePrompt.asterisks = 0
+		case keyTab: // advance the echo mode through the configured cycle
+			if len(cycle) < 2 {
+				// Single-mode cycle: the prompt is pinned; Tab is ignored (and
+				// never lands in the password — the scanner ate the byte).
+				continue
 			}
-			masked = !masked
+			consoleMu.Lock()
+			for range countCodepoints([]byte(consolePrompt.echoed)) {
+				consoleEcho(eraseChar)
+			}
+			modeIdx = (modeIdx + 1) % len(cycle)
+			mode = cycle[modeIdx]
+			consolePrompt.echoed = echoFor(password, mode)
+			consoleEcho(consolePrompt.echoed)
 			consoleMu.Unlock()
 		case keyKillLine: // Ctrl+U — erase entire password
 			if len(password) > 0 {
 				consoleMu.Lock()
-				if !masked {
-					for range consolePrompt.asterisks {
-						consoleEcho(eraseChar)
-					}
+				for range countCodepoints([]byte(consolePrompt.echoed)) {
+					consoleEcho(eraseChar)
 				}
-				consolePrompt.asterisks = 0
+				consolePrompt.echoed = ""
 				consoleMu.Unlock()
 				password = password[:0]
 			}
@@ -736,14 +825,14 @@ loop:
 			if len(password) > 0 {
 				newPwd, removed := killWord(password)
 				if removed > 0 {
-					consoleMu.Lock()
-					if !masked {
+					if mode != echoSilent {
+						consoleMu.Lock()
 						for range removed {
+							consolePrompt.echoed = string(trimLastCodepoint([]byte(consolePrompt.echoed)))
 							consoleEcho(eraseChar)
 						}
+						consoleMu.Unlock()
 					}
-					consolePrompt.asterisks -= removed
-					consoleMu.Unlock()
 					password = newPwd
 				}
 			}

--- a/init/console_input_pty_test.go
+++ b/init/console_input_pty_test.go
@@ -15,7 +15,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -289,4 +291,172 @@ func TestReadPasswordOnCancelAfterPartialInput(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("reader did not return within 2s of cancellation")
 	}
+}
+
+// ── Echo-mode behavior ───────────────────────────────────────────────────────
+//
+// The reader echoes feedback to the process stdout (the boot console), not to
+// the tty it reads from, so these tests capture os.Stdout to observe what a
+// user would see. The echo-cycle global is swapped per test and restored via
+// t.Cleanup; the package's tests run sequentially so this does not race.
+
+// captureStdout redirects os.Stdout to a pipe for the duration of fn and
+// returns everything written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	old := os.Stdout
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+		_ = w.Close()
+		_ = r.Close()
+	}()
+	fn()
+	os.Stdout = old
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+// setEchoCycle overrides the echo-cycle global for one test. The first mode
+// is the startup mode; a single mode pins the prompt.
+func setEchoCycle(t *testing.T, cycle ...passwordEchoMode) {
+	t.Helper()
+	old := passwordEchoCycle
+	passwordEchoCycle = cycle
+	t.Cleanup(func() { passwordEchoCycle = old })
+}
+
+// runPromptSession runs readPasswordOn against a fresh pty, types input on the
+// master, and returns the produced password plus everything the reader printed
+// to stdout (prompt, echo, erase sequences).
+func runPromptSession(t *testing.T, prompt string, input []byte) (password []byte, output string) {
+	t.Helper()
+	master, slave := openPTY(t)
+	output = captureStdout(t, func() {
+		type result struct {
+			password []byte
+			err      error
+		}
+		done := make(chan result, 1)
+		go func() {
+			pw, err := readPasswordOn(t.Context(), slave, prompt, "")
+			done <- result{pw, err}
+		}()
+		time.Sleep(50 * time.Millisecond)
+		_, err := master.Write(input)
+		require.NoError(t, err)
+		select {
+		case res := <-done:
+			require.NoError(t, res.err)
+			password = res.password
+		case <-time.After(2 * time.Second):
+			t.Fatal("reader did not return after typing input")
+		}
+	})
+	return password, output
+}
+
+func TestReadPasswordOnAsterisksModeEchoesStars(t *testing.T) {
+	setEchoCycle(t, echoAsterisks)
+	password, out := runPromptSession(t, "> ", []byte("abc\n"))
+	require.Equal(t, []byte("abc"), password)
+	require.Contains(t, out, "***")
+	require.NotContains(t, out, "abc", "asterisks mode must not leak the typed characters")
+}
+
+func TestReadPasswordOnSilentModeEchoesNothing(t *testing.T) {
+	setEchoCycle(t, echoSilent)
+	password, out := runPromptSession(t, "> ", []byte("secret\n"))
+	require.Equal(t, []byte("secret"), password)
+	require.NotContains(t, out, "*")
+	require.NotContains(t, out, "secret", "silent mode must not leak the typed characters")
+}
+
+func TestReadPasswordOnPlaintextModeEchoesLiteral(t *testing.T) {
+	setEchoCycle(t, echoPlaintext)
+	// Type "secrex", erase the x, type "t".
+	password, out := runPromptSession(t, "> ", []byte("secrex\bt\n"))
+	require.Equal(t, []byte("secret"), password)
+	require.Contains(t, out, "secrex", "plaintext mode must echo the typed characters")
+	require.Contains(t, out, eraseChar, "backspace must erase the echoed character")
+}
+
+func TestReadPasswordOnTabCyclesModes(t *testing.T) {
+	setEchoCycle(t, echoAsterisks, echoSilent, echoPlaintext)
+	// Type "zq", Tab (→ silent: both cells erased), Tab (→ plaintext: repaint
+	// the buffer literally), Enter. Tab must never land in the password.
+	password, out := runPromptSession(t, "> ", []byte("zq\t\t\n"))
+	require.Equal(t, []byte("zq"), password)
+	require.Contains(t, out, "**", "asterisks painted before the first Tab")
+	require.Contains(t, out, "zq", "second Tab must repaint the buffer in plaintext")
+	require.Equal(t, 2, strings.Count(out, eraseChar),
+		"the asterisks→silent transition must erase exactly the two painted cells")
+}
+
+func TestReadPasswordOnHiddenOnlyCycleNeverRevealsPlaintext(t *testing.T) {
+	setEchoCycle(t, echoSilent, echoAsterisks)
+	// Type "zq" (silent), Tab (→ asterisks: repaint two stars), Tab (wraps
+	// back to silent: erase them), Enter. Plaintext is not in the cycle, so
+	// the typed characters must never be painted.
+	password, out := runPromptSession(t, "> ", []byte("zq\t\t\n"))
+	require.Equal(t, []byte("zq"), password)
+	require.Contains(t, out, "**", "first Tab must repaint the buffer as asterisks")
+	require.NotContains(t, out, "zq", "plaintext is not in the cycle and must never be painted")
+	require.Equal(t, 2, strings.Count(out, eraseChar),
+		"the wrap back to silent must erase exactly the two painted cells")
+}
+
+func TestReadPasswordOnSingleModeCycleIgnoresTab(t *testing.T) {
+	setEchoCycle(t, echoSilent)
+	password, out := runPromptSession(t, "> ", []byte("z\tq\n"))
+	require.Equal(t, []byte("zq"), password, "Tab must be swallowed, not typed into the password")
+	require.NotContains(t, out, "*", "pinned silent mode must never start echoing")
+	require.NotContains(t, out, "z")
+	require.NotContains(t, out, "q")
+}
+
+// setActivePrompt marks a fake prompt active with the given painted feedback
+// for the duration of one test.
+func setActivePrompt(t *testing.T, text, echoed string) {
+	t.Helper()
+	consoleMu.Lock()
+	consolePrompt.active = true
+	consolePrompt.text = text
+	consolePrompt.echoed = echoed
+	consolePrompt.done = nil
+	consoleMu.Unlock()
+	t.Cleanup(func() {
+		consoleMu.Lock()
+		consolePrompt.active = false
+		consolePrompt.text = ""
+		consolePrompt.echoed = ""
+		consoleMu.Unlock()
+	})
+}
+
+// TestConsolePrintWithPromptRedrawRepaintsEchoed verifies the log-over-prompt
+// redraw path repaints whatever feedback is currently on screen — asterisks or
+// plaintext — rather than assuming asterisks, and erases the live prompt line
+// in place first so it never scrolls into terminal scrollback (in plaintext
+// mode that line holds the literal passphrase).
+func TestConsolePrintWithPromptRedrawRepaintsEchoed(t *testing.T) {
+	setActivePrompt(t, "> ", "zq")
+
+	out := captureStdout(t, func() { consolePrintWithPromptRedraw("status line") })
+	require.Equal(t, eraseLine+"status line\n> zq", out,
+		"the live prompt line must be erased before the message scrolls it away")
+}
+
+// TestStatusMessageErasesLivePromptLine verifies the unlock-status redraw path
+// (statusMessage, plymouth.go) has the same erase-before-scroll behavior.
+func TestStatusMessageErasesLivePromptLine(t *testing.T) {
+	setActivePrompt(t, "> ", "zq")
+
+	out := captureStdout(t, func() { statusMessage("volume unlocked") })
+	require.Equal(t, eraseLine+"\n\nvolume unlocked\n\n> zq", out,
+		"the live prompt line must be erased before the message scrolls it away")
 }

--- a/init/console_input_test.go
+++ b/init/console_input_test.go
@@ -454,3 +454,36 @@ func TestKillWord(t *testing.T) {
 		})
 	}
 }
+
+// ── Password echo mode ──────────────────────────────────────────────────────
+
+func TestParsePasswordEcho(t *testing.T) {
+	for _, tc := range []struct {
+		val   string
+		cycle []passwordEchoMode
+		ok    bool
+	}{
+		{"", defaultPasswordEchoCycle, true},
+		{"asterisks,silent,plaintext", []passwordEchoMode{echoAsterisks, echoSilent, echoPlaintext}, true},
+		{"silent,asterisks,plaintext", []passwordEchoMode{echoSilent, echoAsterisks, echoPlaintext}, true},
+		{"silent,asterisks", []passwordEchoMode{echoSilent, echoAsterisks}, true},
+		{"silent", []passwordEchoMode{echoSilent}, true},
+		{" plaintext , silent ", []passwordEchoMode{echoPlaintext, echoSilent}, true},
+		// Invalid values fall back to the default cycle with ok=false.
+		{"Silent", defaultPasswordEchoCycle, false},
+		{"garbage", defaultPasswordEchoCycle, false},
+		{"silent,silent", defaultPasswordEchoCycle, false},
+		{"silent,", defaultPasswordEchoCycle, false},
+	} {
+		cycle, ok := parsePasswordEcho(tc.val)
+		require.Equal(t, tc.cycle, cycle, "value %q", tc.val)
+		require.Equal(t, tc.ok, ok, "value %q", tc.val)
+	}
+}
+
+func TestEchoFor(t *testing.T) {
+	pw := []byte("héllo") // 6 bytes, 5 codepoints
+	require.Equal(t, "*****", echoFor(pw, echoAsterisks), "one asterisk per codepoint, not per byte")
+	require.Equal(t, "", echoFor(pw, echoSilent))
+	require.Equal(t, "héllo", echoFor(pw, echoPlaintext))
+}

--- a/init/main.go
+++ b/init/main.go
@@ -1263,8 +1263,18 @@ func readConfig() error {
 	if err != nil {
 		return err
 	}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return err
+	}
 
-	return yaml.Unmarshal(data, &config)
+	// The generator validated password_echo at build time, so a bad value here
+	// means a hand-edited image config. Cosmetic setting — warn, never fail.
+	cycle, ok := parsePasswordEcho(config.PasswordEcho)
+	if !ok {
+		warning("invalid password_echo value %q, using the default cycle", config.PasswordEcho)
+	}
+	passwordEchoCycle = cycle
+	return nil
 }
 
 func mount(source, target, fstype string, flags uintptr, options string) error {

--- a/init/plymouth.go
+++ b/init/plymouth.go
@@ -207,18 +207,20 @@ func askPasswordWithFallback(ctx context.Context, prompt, postPrompt string) ([]
 // is disabled. Passing an empty string clears the Plymouth message (no-op on console).
 //
 // On the console, if a password prompt is active and its volume hasn't been
-// unlocked yet, the current line is erased and the prompt is reprinted beneath
-// the message so the cursor stays at the bottom. Once the prompt's done channel
-// closes (volume unlocked by another token), the redraw is skipped — otherwise
-// the unlock status message would reprint a stale prompt that ctx-cancel hasn't
-// torn down yet.
+// unlocked yet, the current line is erased in place (so the typed feedback —
+// the literal passphrase in plaintext echo mode — never scrolls into terminal
+// history) and the prompt is reprinted beneath the message so the cursor stays
+// at the bottom. Once the prompt's done channel closes (volume unlocked by
+// another token), the redraw is skipped — otherwise the unlock status message
+// would reprint a stale prompt that ctx-cancel hasn't torn down yet.
 func statusMessage(msg string) {
 	if plymouthEnabled {
 		plymouthMessage(msg)
 	} else if msg != "" {
 		consoleMu.Lock()
 		if consolePrompt.active && !promptVolumeUnlocked() {
-			consolePrint("\n\n" + msg + "\n\n" + consolePrompt.text + strings.Repeat("*", consolePrompt.asterisks))
+			consoleEcho(eraseLine)
+			consolePrint("\n\n" + msg + "\n\n" + consolePrompt.text + promptEchoedForPrint())
 		} else {
 			consolePrint("\n\n" + msg + "\n\n")
 		}


### PR DESCRIPTION
### What this PR does

Makes the password prompt's keystroke feedback configurable, and implements the plaintext reveal the manpage already describes.

Since the raw-mode reader landed (#355), the manpage has said:

> **Tab** — toggle visibility of the typed characters (asterisks ↔ literal).

but the literal mode was never wired up — the `masked` bool actually toggles asterisks ↔ *hidden*. This PR turns that two-state bool into a configurable mode cycle and closes the doc/code gap:

- **Three echo modes**: `asterisks` (one `*` per codepoint; the default), `silent` (no feedback at all, sudo-style), `plaintext` (literal characters, for hunting down a typo).
- **`password_echo`** is an ordered, comma-separated list of modes (same syntax as `modules`/`extra_files`): the prompt starts in the first listed mode and **Tab cycles through the list in order, wrapping**. The default `asterisks,silent,plaintext` keeps the historical first-press behavior (asterisks → hidden) and makes plaintext reachable only deliberately — never on the way to hiding.
- **A single entry** (`password_echo: silent`) pins the prompt to one mode — Tab becomes a no-op (some users prefer the prompt to have exactly one behavior).
- **Omitting `plaintext`** (`password_echo: silent,asterisks`) allows toggling between the hidden modes while making the typed password unrevealable at the prompt.
- Applies to every prompt that goes through the shared reader: LUKS passphrase, TPM2 PIN, FIDO2 PIN.

**Defaults are unchanged**: with no config, the prompt echoes asterisks and Tab's first press hides them, exactly as today.

### Motivation

The asterisk echo added in #355 (requested in #305) is a regression for users who preferred the old sudo-style silent prompt — there is currently no way to get it back except pressing Tab on every boot. Listing `silent` first restores it persistently, while keeping the #305 behavior as the default. Expressing the cycle as an ordered list (rather than a fixed cycle plus a toggle flag) also covers what a fixed order can't: whatever mode you start in, you can order the list so plaintext is never one accidental Tab away — or leave it out entirely.

### Implementation notes

- `consolePrompt` now tracks the exact painted feedback (`echoed string`) instead of an asterisk count, so the log-over-prompt redraw paths (`consolePrintWithPromptRedraw`, `statusMessage`) repaint silent and plaintext prompts correctly instead of assuming asterisks.
- The generator validates `password_echo` at build time (known modes only, no duplicates, no empty elements) and fails loudly on a bad value; init re-parses the same syntax defensively and falls back to the default cycle with a warning — a cosmetic setting must never fail a boot.
- One config key covers startup mode, cycle order, membership, and pinning — there is no second flag to keep consistent with it.
- Erase paths assume one terminal cell per codepoint; a double-width glyph echoed in plaintext leaves half a cell behind on backspace (cosmetic only, buffer stays correct — same assumption the asterisk path has always made, noted in a comment).

### Tests

New PTY-harness tests capture `os.Stdout` (where the reader echoes; the pty slave is input-only) and assert on what a user would actually see: silent emits nothing, plaintext echoes literally and erases on backspace, Tab repaints the buffer across mode transitions, a hidden-only cycle (`silent,asterisks`) never paints the typed characters, a single-mode cycle swallows Tab without typing it into the password, and the redraw path repaints the painted feedback verbatim. Plus table tests for the list parser (ordering, whitespace trimming, rejection of unknown/duplicate/empty modes) and generator-side validation.

`go test ./init/ ./generator/` — all reader/scanner/config tests pass (the environment-dependent blkinfo/image tests fail identically on pristine master).

### Docs

`docs/manpage.md` — `password_echo` documented, the example config updated, and the Password entry section now describes the real behavior; `CHANGES.md` entry added.
