### PR TITLE
docs/manpage: rd.luks.header takes the LUKS superblock UUID

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -147,7 +147,7 @@ Some parts of booster boot functionality can be modified with kernel boot parame
  * `rd.luks.uuid=$UUID` UUID of the LUKS partition where the root partition is enclosed. booster will try to unlock this LUKS device.
  * `rd.luks.name=$UUID=$NAME` similar to rd.luks.uuid parameter but also specifies the name used for the LUKS device opening.
  * `rd.luks.key=$UUID=$PATH` absolute path to a keyfile in the initrd/initramfs which can be used to unlock the device identified by UUID, if this file does not exist or fails to unlock it will fall back to a password request.
- * `rd.luks.header=$PARTUUID=$PATH` detached LUKS header for the device identified by `$PARTUUID` (notice that no filesystem UUID is shown when the header is detached as it is stored in the header. `$PATH` can take three forms:
+ * `rd.luks.header=$UUID=$PATH` detached LUKS header for the device identified by `$UUID` — the LUKS superblock UUID, the same value `rd.luks.uuid` takes and what `cryptsetup luksUUID --header $PATH` prints. Because that UUID lives *in the header*, a device with a detached header exposes no LUKS or filesystem UUID of its own; identify it by this header UUID, not by the data partition's `PARTUUID`. `$PATH` can take three forms:
     * **Initramfs file** — an absolute path (e.g. `/etc/luks/root.hdr`) to a header file bundled into the initramfs at build time via `extra_files`.
     * **Raw block device** — a device path (e.g. `/dev/sdb`) where the LUKS header begins at byte offset 0. Booster waits for the device to appear and passes it directly to cryptsetup without mounting.
     * **File on a separate device** — `$path:$deviceref` where `$deviceref` is `UUID=...`, `LABEL=...`, `PARTUUID=...`, or `PARTLABEL=...`. Booster mounts the device read-only, reads the header file, then unmounts before unlocking.
@@ -247,7 +247,14 @@ same device, the cmdline takes precedence for the device reference and
 mapper name, and for any security option (keyfile, header, tries,
 token-timeout, …) it sets explicitly; the crypttab entry supplies only
 the options the cmdline left unset. Crypttab entries for devices not
-covered by `rd.luks.*` are appended as new mappings.
+covered by `rd.luks.*` are appended as new mappings. Two entries "cover
+the same device" only when they name it the same way: a crypttab entry
+merges with a `rd.luks.*` parameter only if its device field is the same
+LUKS UUID (`UUID=<luksUUID>`). A crypttab entry that instead uses a
+partition identifier (`PARTUUID=`, `PARTLABEL=`, `LABEL=`, or a path) is
+treated as a distinct device and appended as its own mapping, so its
+options do **not** merge onto the cmdline entry — `systemd-cryptsetup`
+reconciles the two sources by LUKS UUID the same way.
 
 Booster-specific behaviour for selected options:
 


### PR DESCRIPTION
The rd.luks.header= manpage entry currently documents the left-hand value as a partition UUID. It is the LUKS superblock UUID. The same value rd.luks.uuid takes and what cryptsetup luksUUID --header prints. Booster parses it into a filesystem-UUID device reference and matches it against the UUID read out of the detached header; a PARTUUID there builds a reference that can never equal the header's UUID, so the device never unlocks. This restores the correct identifier while keeping the accurate observation that a detached-header data device exposes no UUID of its own.

Two related clarifications:

The cmdline/crypttab merge reconciles the two sources only by LUKS UUID, so a crypttab entry that names the same device by a partition identifier is treated as a distinct mapping and its options do not merge. This matches systemd-cryptsetup.

Multiple detached headers need each data device named explicitly in crypttab (PARTUUID/PARTLABEL/LABEL/path) with its own header=. rd.luks.header= supplies only the header, so with several headerless data devices present booster cannot tell which device pairs with which header and the pairing falls back to device arrival order.

Booster currently doesn't handle the systemd style for command-line detached-header. Systemd names the data device on the cmdline with rd.luks.data=$UUID=$DEV (the analogue of crypttab's encrypted-device field), whereas booster has no rd.luks.data= equivalent and accepts only the header on the command line. So crypttab is currently the only way to pin the data device for a multi-header setup. Adding rd.luks.data= would be a good addition.