### PR TITLE
generator: Fix consolefonts on Alpine Linux

### DIFF
--- a/generator/console.go
+++ b/generator/console.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 )
 
-// kbdBaseDir is the root of the kbd data tree. Arch/Debian/openSUSE/Alpine use
-// /usr/share/kbd; Fedora/RHEL use /usr/lib/kbd. Probe at startup so the generator
-// works on any distro without configuration.
+// kbdBaseDir is the root of the kbd data tree. Arch/Debian/openSUSE use
+// /usr/share/kbd, Fedora/RHEL use /usr/lib/kbd, Alpine uses /usr/share.
+// Probe at startup so the generator works on any distro without configuration.
 var kbdBaseDir = func() string {
-	for _, d := range []string{"/usr/share/kbd", "/usr/lib/kbd"} {
+	for _, d := range []string{"/usr/share/kbd", "/usr/lib/kbd", "/usr/share"} {
 		if _, err := os.Stat(filepath.Join(d, "consolefonts")); err == nil {
 			return d
 		}


### PR DESCRIPTION
On Alpine, consolefonts are stored in /usr/share/consolefonts. Alpine doesn't use a kbd directory in /usr/share. Therefore, the current code does not work on Alpine and fails to find consolefonts.

Prior to 6d3a307f6a257cd64347e45604b3b346fa7796d6, the Alpine package would simply override the main.consolefontsDir variable using a linker flag in the APKBUILD. However, since main.consolefontsDir is now calculated dynamically this approach no longer works.

See <https://github.com/golang/go/issues/64246>.