### PR TITLE
init: password-gate the emergency shell

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -76,6 +76,10 @@ Booster advantages:
     * adding `busybox` to the image enables an emergency shell in case of a panic during the boot process.
     * adding `fsck` enables boot time filesystem check. It also requires filesystem specific binary called `fsck.$rootfstype` to be added to the image. Filesystems are corrected automatically and if it fails then boot stops and it is the responsibility of the user to fix the root filesystem.
 
+ * `emergency_shell_password` when set, booster prompts for passphrase before starting the emergency shell and reboots after three wrong attempts. The value is an argon2id PHC string. Generated with the `argon2` CLI:
+
+       printf 'your-password' | argon2 "$(head -c16 /dev/urandom)" -id -t 3 -m 16 -p 4 -e
+
  * `vconsole` is a flag that enables early-user console configuration. If it is set to `true` then booster reads configuration from `/etc/vconsole.conf` and `/etc/locale.conf` and adds required keymap and fonts to the generated image.
     The following config properties are taken into account: `KEYMAP`, `KEYMAP_TOGGLE`, `FONT`, `FONT_MAP`, `FONT_UNIMAP`. See also [man vconsole.conf](https://man.archlinux.org/man/vconsole.conf.5.en).
 

--- a/generator/config.go
+++ b/generator/config.go
@@ -55,27 +55,28 @@ type UserConfig struct {
 		SshAuthorizedKeys string `yaml:"ssh_authorized_keys,omitempty"` // path to authorized_keys file
 		SshListen         string `yaml:"ssh_listen,omitempty"`          // listen address, default :22
 	}
-	Universal            bool   `yaml:",omitempty"`
-	Modules              string `yaml:",omitempty"`                   // comma separated list of extra modules to add to initramfs
-	ModulesForceLoad     string `yaml:"modules_force_load,omitempty"` // comma separated list of extra modules to load at the boot time
-	AppendAllModAliases  bool   `yaml:"append_all_modaliases,omitempty"`
-	Compression          string `yaml:",omitempty"`              // output file compression
-	MountTimeout         string `yaml:"mount_timeout,omitempty"` // timeout for waiting for the rootfs mounted
-	ExtraFiles           string `yaml:"extra_files,omitempty"`   // comma-separated list of files to add to image
-	StripBinaries        bool   `yaml:"strip,omitempty"`         // if strip symbols from the binaries, shared libraries and kernel modules
-	EnableVirtualConsole bool   `yaml:"vconsole,omitempty"`      // configure virtual console at boot time using config from https://www.freedesktop.org/software/systemd/man/vconsole.conf.html
-	EnableLVM            bool   `yaml:"enable_lvm"`
-	EnableMdraid         bool   `yaml:"enable_mdraid"`
-	MdraidConfigPath     string `yaml:"mdraid_config_path"`
-	EnableZfs            bool   `yaml:"enable_zfs"`
-	ZfsImportParams      string `yaml:"zfs_import_params"`
-	ZfsCachePath         string `yaml:"zfs_cache_path"`
-	EnablePlymouth       bool   `yaml:"enable_plymouth"`
-	CrypttabPath         string `yaml:"crypttab_path,omitempty"` // path to crypttab file, defaults to /etc/crypttab
-	EnableFido2          bool   `yaml:"enable_fido2"`
-	TokenTimeout         string `yaml:"token_timeout,omitempty"` // device-level keyboard-fallback timer (e.g. 30s); applies in both modes; global default, overridable by crypttab/cmdline
-	PinDelay             string `yaml:"pin_delay,omitempty"`     // concurrent-mode only: hold an interactive PIN prompt (TPM2-PIN/FIDO2-PIN) this long (e.g. 3s) so a parallel non-interactive token can win first; default unset (off)
-	PasswordEcho         string `yaml:"password_echo,omitempty"` // ordered comma-separated list of prompt echo modes; first = startup mode, Tab cycles the list; default asterisks,silent,plaintext
+	Universal              bool   `yaml:",omitempty"`
+	Modules                string `yaml:",omitempty"`                   // comma separated list of extra modules to add to initramfs
+	ModulesForceLoad       string `yaml:"modules_force_load,omitempty"` // comma separated list of extra modules to load at the boot time
+	AppendAllModAliases    bool   `yaml:"append_all_modaliases,omitempty"`
+	Compression            string `yaml:",omitempty"`                         // output file compression
+	MountTimeout           string `yaml:"mount_timeout,omitempty"`            // timeout for waiting for the rootfs mounted
+	ExtraFiles             string `yaml:"extra_files,omitempty"`              // comma-separated list of files to add to image
+	EmergencyShellPassword string `yaml:"emergency_shell_password,omitempty"` // argon2id PHC; gates the emergency shell
+	StripBinaries          bool   `yaml:"strip,omitempty"`                    // if strip symbols from the binaries, shared libraries and kernel modules
+	EnableVirtualConsole   bool   `yaml:"vconsole,omitempty"`                 // configure virtual console at boot time using config from https://www.freedesktop.org/software/systemd/man/vconsole.conf.html
+	EnableLVM              bool   `yaml:"enable_lvm"`
+	EnableMdraid           bool   `yaml:"enable_mdraid"`
+	MdraidConfigPath       string `yaml:"mdraid_config_path"`
+	EnableZfs              bool   `yaml:"enable_zfs"`
+	ZfsImportParams        string `yaml:"zfs_import_params"`
+	ZfsCachePath           string `yaml:"zfs_cache_path"`
+	EnablePlymouth         bool   `yaml:"enable_plymouth"`
+	CrypttabPath           string `yaml:"crypttab_path,omitempty"` // path to crypttab file, defaults to /etc/crypttab
+	EnableFido2            bool   `yaml:"enable_fido2"`
+	TokenTimeout           string `yaml:"token_timeout,omitempty"` // device-level keyboard-fallback timer (e.g. 30s); applies in both modes; global default, overridable by crypttab/cmdline
+	PinDelay               string `yaml:"pin_delay,omitempty"`     // concurrent-mode only: hold an interactive PIN prompt (TPM2-PIN/FIDO2-PIN) this long (e.g. 3s) so a parallel non-interactive token can win first; default unset (off)
+	PasswordEcho           string `yaml:"password_echo,omitempty"` // ordered comma-separated list of prompt echo modes; first = startup mode, Tab cycles the list; default asterisks,silent,plaintext
 
 	// SerializeTokens opts out of booster's token concurrency: tokens are
 	// tried one at a time in ID order. The per-type timeouts are scoped here
@@ -256,6 +257,7 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 	conf.appendAllModAliases = u.AppendAllModAliases
 	conf.stripBinaries = u.StripBinaries || opts.BuildCommand.Strip
 	conf.enableLVM = u.EnableLVM
+	conf.emergencyShellPassword = u.EmergencyShellPassword
 	conf.enableMdraid = u.EnableMdraid
 	conf.mdraidConfigPath = u.MdraidConfigPath
 	conf.enableZfs = u.EnableZfs

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -27,6 +27,7 @@ type generatorConfig struct {
 	compression             string
 	timeout                 time.Duration
 	extraFiles              []string
+	emergencyShellPassword  string
 	output                  string
 	forceOverwrite          bool // overwrite output file
 	initBinary              string
@@ -518,6 +519,7 @@ func (img *Image) appendInitConfig(conf *generatorConfig, kmod *Kmod, vconsole *
 	initConfig.Tpm2Timeout = conf.tpm2Timeout
 	initConfig.Fido2Timeout = conf.fido2Timeout
 	initConfig.PasswordEcho = conf.passwordEcho
+	initConfig.EmergencyShellPassword = conf.emergencyShellPassword
 
 	if conf.networkConfigType == netDhcp {
 		initConfig.Network = &InitNetworkConfig{}

--- a/init/config.go
+++ b/init/config.go
@@ -43,13 +43,14 @@ type InitConfig struct {
 	EnableZfs              bool                `yaml:",omitempty"`
 	ZfsImportParams        string              `yaml:",omitempty"` // TODO: remove it
 	EnablePlymouth         bool                `yaml:",omitempty"`
-	SerializeTokens        bool                `yaml:",omitempty"`              // dispatch LUKS tokens serially instead of concurrently; default false
-	TokenTimeout           int                 `yaml:",omitempty"`              // device-level keyboard-fallback timer in seconds; 0 = unset (crypttab/cmdline or derived default applies)
-	PinDelay               int                 `yaml:",omitempty"`              // concurrent-mode PIN-prompt pre-delay in seconds so a parallel non-interactive token can win first; 0 = off
-	ClevisTimeout          int                 `yaml:",omitempty"`              // serialize-mode per-token bound for clevis tokens in seconds; 0 = default 45
-	Tpm2Timeout            int                 `yaml:",omitempty"`              // serialize-mode per-token bound for non-PIN systemd-tpm2 tokens in seconds; 0 = default 15
-	Fido2Timeout           int                 `yaml:",omitempty"`              // serialize-mode per-token bound for non-PIN systemd-fido2 tokens in seconds; 0 = default 30
-	PasswordEcho           string              `yaml:"password_echo,omitempty"` // ordered comma-separated echo-mode cycle; first entry = startup mode; validated by the generator
+	SerializeTokens        bool                `yaml:",omitempty"`                         // dispatch LUKS tokens serially instead of concurrently; default false
+	TokenTimeout           int                 `yaml:",omitempty"`                         // device-level keyboard-fallback timer in seconds; 0 = unset (crypttab/cmdline or derived default applies)
+	PinDelay               int                 `yaml:",omitempty"`                         // concurrent-mode PIN-prompt pre-delay in seconds so a parallel non-interactive token can win first; 0 = off
+	ClevisTimeout          int                 `yaml:",omitempty"`                         // serialize-mode per-token bound for clevis tokens in seconds; 0 = default 45
+	Tpm2Timeout            int                 `yaml:",omitempty"`                         // serialize-mode per-token bound for non-PIN systemd-tpm2 tokens in seconds; 0 = default 15
+	Fido2Timeout           int                 `yaml:",omitempty"`                         // serialize-mode per-token bound for non-PIN systemd-fido2 tokens in seconds; 0 = default 30
+	PasswordEcho           string              `yaml:"password_echo,omitempty"`            // ordered comma-separated echo-mode cycle; first entry = startup mode; validated by the generator
+	EmergencyShellPassword string              `yaml:"emergency_shell_password,omitempty"` // argon2id PHC; gates the emergency shell
 }
 
 const initConfigPath = "/etc/booster.init.yaml"

--- a/init/config_test.go
+++ b/init/config_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestInitConfigEmergencyShellPasswordRoundTrip(t *testing.T) {
+	in := InitConfig{EmergencyShellPassword: goldenPHC}
+	data, err := yaml.Marshal(&in)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "emergency_shell_password")
+
+	var out InitConfig
+	require.NoError(t, yaml.Unmarshal(data, &out))
+	require.Equal(t, goldenPHC, out.EmergencyShellPassword)
+}

--- a/init/main.go
+++ b/init/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -1351,15 +1352,21 @@ func enableLocalEcho() error {
 }
 
 func emergencyShell() {
-	if _, err := os.Stat("/usr/bin/busybox"); !os.IsNotExist(err) {
-		// Force local echo (might have been disabled by readPassword).
-		if err := enableLocalEcho(); err != nil {
-			warning("Failed to enable local echo: %v", err)
-		}
-
-		if err := unix.Exec("/usr/bin/busybox", []string{"sh", "-I"}, nil); err != nil {
-			severe("Unable to start an emergency shell: %v", err)
-		}
+	if _, err := os.Stat("/usr/bin/busybox"); os.IsNotExist(err) {
+		return
+	}
+	authFn := func() ([]byte, error) {
+		return readPassword(context.Background(), "Emergency shell password: ", "")
+	}
+	if ok := authorizeEmergencyShell(config.EmergencyShellPassword, authFn, 3); !ok {
+		return
+	}
+	// Force local echo (might have been disabled by readPassword).
+	if err := enableLocalEcho(); err != nil {
+		warning("Failed to enable local echo: %v", err)
+	}
+	if err := unix.Exec("/usr/bin/busybox", []string{"sh", "-I"}, nil); err != nil {
+		severe("Unable to start an emergency shell: %v", err)
 	}
 }
 

--- a/init/password.go
+++ b/init/password.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// verifyPassword reports whether pw matches a systemd/argon2-CLI style argon2id
+// PHC string: $argon2id$v=19$m=<KiB>,t=<iter>,p=<lanes>$<b64salt>$<b64hash>.
+// The params are read from the hash itself; base64 is unpadded (argon2 CLI).
+func verifyPassword(phc string, pw []byte) (bool, error) {
+	parts := strings.Split(phc, "$")
+	if len(parts) != 6 || parts[1] != "argon2id" {
+		return false, fmt.Errorf("not an argon2id PHC string")
+	}
+	var version int
+	if _, err := fmt.Sscanf(parts[2], "v=%d", &version); err != nil || version != argon2.Version {
+		return false, fmt.Errorf("unsupported argon2 version %q", parts[2])
+	}
+	var mem, iter, par int
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &mem, &iter, &par); err != nil {
+		return false, fmt.Errorf("bad argon2 params %q: %v", parts[3], err)
+	}
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return false, fmt.Errorf("bad salt: %v", err)
+	}
+	want, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return false, fmt.Errorf("bad hash: %v", err)
+	}
+	got := argon2.IDKey(pw, salt, uint32(iter), uint32(mem), uint8(par), uint32(len(want)))
+	return subtle.ConstantTimeCompare(got, want) == 1, nil
+}
+
+// authorizeEmergencyShell decides whether the emergency shell may start. An empty
+// hash keeps the historical behaviour (no gate). Otherwise it prompts up to tries
+// times and reports success; a read error or a malformed hash denies access
+// (fail closed — a broken hash must not grant a root shell).
+func authorizeEmergencyShell(hash string, prompt func() ([]byte, error), tries int) bool {
+	if hash == "" {
+		return true
+	}
+	for i := 0; i < tries; i++ {
+		pw, err := prompt()
+		if err != nil {
+			return false
+		}
+		ok, err := verifyPassword(hash, pw)
+		if err != nil {
+			return false // malformed configured hash
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}

--- a/init/password_test.go
+++ b/init/password_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// goldenPHC was produced by the real argon2 CLI the manpage tells users to run:
+//   printf 'hunter2-correct' | argon2 'boostersalt12345' -id -t 3 -m 16 -p 4 -e
+// It pins interop with that tool (unpadded base64, m=64MiB t=3 p=4).
+const goldenPHC = "$argon2id$v=19$m=65536,t=3,p=4$Ym9vc3RlcnNhbHQxMjM0NQ$YVOIENbv5h37WfbpMl6VgxCWPe7oOTlc0bJDgJhjUS4"
+
+func TestVerifyPassword(t *testing.T) {
+	ok, err := verifyPassword(goldenPHC, []byte("hunter2-correct"))
+	require.NoError(t, err)
+	require.True(t, ok, "the correct password must verify against an argon2-CLI hash")
+
+	ok, err = verifyPassword(goldenPHC, []byte("wrong"))
+	require.NoError(t, err)
+	require.False(t, ok, "a wrong password must not verify")
+
+	for _, bad := range []string{
+		"", "notaphc", "$argon2id$v=19$m=65536,t=3,p=4$onlyfourfields",
+		"$bcrypt$v=19$m=1,t=1,p=1$YWJj$YWJj", // wrong algorithm
+	} {
+		_, err := verifyPassword(bad, []byte("x"))
+		require.Error(t, err, "malformed PHC %q must error", bad)
+	}
+}
+
+func TestAuthorizeEmergencyShell(t *testing.T) {
+	const correct = "hunter2-correct"
+
+	// Empty hash: backward-compatible, always allowed (no prompt).
+	require.True(t, authorizeEmergencyShell("", func() ([]byte, error) {
+		t.Fatal("must not prompt when no password is configured")
+		return nil, nil
+	}, 3))
+
+	// Correct on first try.
+	require.True(t, authorizeEmergencyShell(goldenPHC,
+		func() ([]byte, error) { return []byte(correct), nil }, 3))
+
+	// Wrong every time -> denied after tries.
+	calls := 0
+	require.False(t, authorizeEmergencyShell(goldenPHC, func() ([]byte, error) {
+		calls++
+		return []byte("nope"), nil
+	}, 3))
+	require.Equal(t, 3, calls, "must use all attempts")
+
+	// Read error -> denied.
+	require.False(t, authorizeEmergencyShell(goldenPHC,
+		func() ([]byte, error) { return nil, errors.New("no tty") }, 3))
+
+	// Malformed configured hash -> denied (fail closed).
+	require.False(t, authorizeEmergencyShell("garbage",
+		func() ([]byte, error) { return []byte(correct), nil }, 3))
+}


### PR DESCRIPTION
booster's emergencyShell() execs `busybox sh -I` as root in the initramfs on the boot-failure path whenever busybox has been added via extra_files, with no authentication. An attacker who can force boost() to fail (withhold or present an unmountable root) reaches an unauthenticated root shell in the trusted, pre-pivot boot phase.

Add an opt-in emergency_shell_password config holding an argon2id PHC string. When set, booster prompts for the password before starting the shell and reboots after three wrong attempts; when unset, the shell starts unauthenticated as before, so existing images are unchanged.

verifyPassword parses the systemd/argon2-CLI PHC format (unpadded base64) and compares in constant time. authorizeEmergencyShell fails closed: a read error or a malformed configured hash denies the shell rather than granting it. The hash is minted externally with the argon2 CLI, so there is no new dependency (x/crypto/argon2 is already vendored) and no new subcommand. Documented in the manpage.