### PR TITLE
init: zero LUKS passphrases and TPM2 PINs from memory after use

### DIFF
--- a/init/luks.go
+++ b/init/luks.go
@@ -1013,6 +1013,22 @@ func unmarshalTPM2Field(raw json.RawMessage) (value string, sharded bool, err er
 	return s, false, nil
 }
 
+// readTPM2PINAuthValue prompts for a TPM2 PIN, derives the systemd-compatible
+// auth value, and wipes the PIN bytes before returning. An empty PIN yields
+// errTPM2Skipped so the caller falls through to the passphrase prompt.
+func readTPM2PINAuthValue(ctx context.Context, prompt string, salt []byte) ([]byte, error) {
+	pin, err := askKeyboardPassword(ctx, prompt, "")
+	if err != nil {
+		return nil, err
+	}
+	if len(pin) == 0 {
+		return nil, errTPM2Skipped
+	}
+	authValue := tpm2PINAuthValue(pin, salt)
+	wipe(pin)
+	return authValue, nil
+}
+
 func recoverSystemdTPM2Password(ctx context.Context, t luks.Token, mappingName string, tpm2Signature string) ([]byte, error) {
 	var node struct {
 		Blob       json.RawMessage `json:"tpm2-blob"` // base64 string, or array of strings when sharded
@@ -1111,14 +1127,10 @@ func recoverSystemdTPM2Password(ctx context.Context, t luks.Token, mappingName s
 		var authValue []byte
 		if node.Pin {
 			prompt := promptPrefix + "Enter TPM2 PIN for " + mappingName + ":"
-			pin, err := askPasswordWithFallback(ctx, prompt, "")
+			authValue, err = readTPM2PINAuthValue(ctx, prompt, salt)
 			if err != nil {
 				return nil, err
 			}
-			if len(pin) == 0 {
-				return nil, errTPM2Skipped // passphrase prompt is self-explanatory
-			}
-			authValue = tpm2PINAuthValue(pin, salt)
 		}
 
 		var password []byte

--- a/init/luks.go
+++ b/init/luks.go
@@ -84,6 +84,11 @@ func tryPassphraseAgainstSlots(ctx context.Context, volumes chan *luks.Volume, d
 // passphraseCache holds passwords that successfully unlocked a LUKS volume during
 // this boot, so subsequent volumes (e.g. btrfs RAID1 members) can be tried
 // automatically without prompting the user again.
+//
+// Ownership/wipe rule: a successful passphrase is appended here BY REFERENCE and
+// is thereafter owned by the cache — read sites must not wipe it. The cache is
+// scrubbed once, at the boot exits, by wipeSecretCache(). Only unowned secrets
+// (failed attempts, consumed PINs) are wiped at their read site.
 var passphraseCache struct {
 	sync.Mutex
 	passwords [][]byte
@@ -1406,6 +1411,10 @@ func tryCachedPassphrases(ctx context.Context, volumes chan *luks.Volume, d luks
 	return false
 }
 
+// askKeyboardPassword is the console/plymouth passphrase reader, indirected
+// through a var so tests can stub keyboard input. Mirrors askFido2Pin.
+var askKeyboardPassword = askPasswordWithFallback
+
 func requestKeyboardPassword(ctx context.Context, volumes chan *luks.Volume, d luks.Device, checkSlots []int, mappingName string, maxTries int) {
 	// Wait for plymouth initialization to complete before attempting to use
 	// it. Without this, udev events can trigger LUKS password prompts while
@@ -1450,7 +1459,7 @@ func requestKeyboardPassword(ctx context.Context, volumes chan *luks.Volume, d l
 
 		prompt := promptPrefix + fmt.Sprintf("Enter passphrase for %s:", mappingName)
 
-		password, err := askPasswordWithFallback(ctx, prompt, "   Unlocking...")
+		password, err := askKeyboardPassword(ctx, prompt, "   Unlocking...")
 		if err != nil {
 			warning("reading password: %v", err)
 			return
@@ -1465,6 +1474,7 @@ func requestKeyboardPassword(ctx context.Context, volumes chan *luks.Volume, d l
 			return
 		}
 
+		wipe(password) // failed attempt: no one owns it, scrub it
 		promptPrefix = "Incorrect passphrase — "
 		if !plymouthEnabled {
 			console("   Incorrect passphrase, please try again\n")

--- a/init/luks.go
+++ b/init/luks.go
@@ -1139,8 +1139,14 @@ func recoverSystemdTPM2Password(ctx context.Context, t luks.Token, mappingName s
 		} else {
 			password, err = tpm2Unseal(public, private, node.PCRs, bank, policyHash, authValue, srkHandle)
 		}
+		// The TPM call has consumed authValue; scrub it on every path (a
+		// wrong-PIN retry redeclares a fresh one next iteration). nil is a no-op.
+		wipe(authValue)
 		if err == nil {
-			return []byte(base64.StdEncoding.EncodeToString(password)), nil
+			// Keep only the base64 form the caller uses; scrub the raw key.
+			encoded := []byte(base64.StdEncoding.EncodeToString(password))
+			wipe(password)
+			return encoded, nil
 		}
 		if node.Pin && attempt < maxAttempts-1 {
 			promptPrefix = "TPM2 PIN incorrect — "

--- a/init/main.go
+++ b/init/main.go
@@ -970,6 +970,7 @@ func cleanup() {
 	udevConn.Close()
 	sshShutdown()
 	shutdownNetwork()
+	wipeSecretCache() // scrub cached passphrases before exec-to-systemd
 }
 
 func scanSysBlock() error {
@@ -1352,6 +1353,9 @@ func enableLocalEcho() error {
 }
 
 func emergencyShell() {
+	// The failure path bypasses cleanup(); scrub any cached passphrase before
+	// dropping to an interactive root shell (or the subsequent reboot).
+	wipeSecretCache()
 	if _, err := os.Stat("/usr/bin/busybox"); os.IsNotExist(err) {
 		return
 	}

--- a/init/main.go
+++ b/init/main.go
@@ -1369,6 +1369,9 @@ func emergencyShell() {
 	if err := enableLocalEcho(); err != nil {
 		warning("Failed to enable local echo: %v", err)
 	}
+	// Re-wipe as late as possible: on the failure path cleanup() never ran, so
+	// an unlock goroutine may have repopulated the cache after the entry wipe.
+	wipeSecretCache()
 	if err := unix.Exec("/usr/bin/busybox", []string{"sh", "-I"}, nil); err != nil {
 		severe("Unable to start an emergency shell: %v", err)
 	}

--- a/init/secret.go
+++ b/init/secret.go
@@ -12,3 +12,15 @@ func wipe(b []byte) {
 	}
 	runtime.KeepAlive(b)
 }
+
+// wipeSecretCache zeroes every cached passphrase and drops the slice. Called at
+// the two boot exits (the switchRoot handoff via cleanup(), and emergencyShell)
+// so the root passphrase does not linger in RAM. Idempotent.
+func wipeSecretCache() {
+	passphraseCache.Lock()
+	defer passphraseCache.Unlock()
+	for _, p := range passphraseCache.passwords {
+		wipe(p)
+	}
+	passphraseCache.passwords = nil
+}

--- a/init/secret.go
+++ b/init/secret.go
@@ -1,0 +1,14 @@
+package main
+
+import "runtime"
+
+// wipe zeroes b in place. It scrubs secret material (LUKS passphrases, TPM2
+// PINs) from memory once it is no longer needed, reducing cold-boot exposure.
+// runtime.KeepAlive keeps the final stores from being treated as dead once b is
+// otherwise unreachable.
+func wipe(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+	runtime.KeepAlive(b)
+}

--- a/init/secret_test.go
+++ b/init/secret_test.go
@@ -25,3 +25,30 @@ func TestWipeEmpty(t *testing.T) {
 	require.NotPanics(t, func() { wipe(nil) })
 	require.NotPanics(t, func() { wipe([]byte{}) })
 }
+
+func TestWipeSecretCache(t *testing.T) {
+	p1 := []byte("hunter2")
+	p2 := []byte("correct horse battery")
+
+	passphraseCache.Lock()
+	passphraseCache.passwords = [][]byte{p1, p2}
+	passphraseCache.Unlock()
+
+	wipeSecretCache()
+
+	// p1/p2 are the retained slice headers; assert their backing arrays were
+	// zeroed (proves the bytes were cleared, not just the cache header dropped).
+	require.True(t, allZero(p1), "p1 backing not zeroed")
+	require.True(t, allZero(p2), "p2 backing not zeroed")
+
+	passphraseCache.Lock()
+	require.Nil(t, passphraseCache.passwords)
+	passphraseCache.Unlock()
+}
+
+func TestWipeSecretCacheIdempotent(t *testing.T) {
+	passphraseCache.Lock()
+	passphraseCache.passwords = nil
+	passphraseCache.Unlock()
+	require.NotPanics(t, wipeSecretCache)
+}

--- a/init/secret_test.go
+++ b/init/secret_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"testing"
 
+	"github.com/anatol/luks.go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,4 +53,71 @@ func TestWipeSecretCacheIdempotent(t *testing.T) {
 	passphraseCache.passwords = nil
 	passphraseCache.Unlock()
 	require.NotPanics(t, wipeSecretCache)
+}
+
+// resetKeyboardHarness puts the package into a state where requestKeyboardPassword
+// runs without real plymouth/terminal I/O.
+func resetKeyboardHarness(t *testing.T) {
+	t.Helper()
+	plymouthEnabled = false
+	plymouthInitDone = make(chan struct{})
+	close(plymouthInitDone) // waitForPlymouthInit returns immediately
+	passphraseCache.Lock()
+	passphraseCache.passwords = nil
+	passphraseCache.Unlock()
+}
+
+func TestRequestKeyboardPasswordWipesFailedAttempts(t *testing.T) {
+	resetKeyboardHarness(t)
+
+	var handed [][]byte
+	askKeyboardPassword = func(ctx context.Context, prompt, postPrompt string) ([]byte, error) {
+		p := []byte("wrongpass")
+		handed = append(handed, p)
+		return p, nil
+	}
+	t.Cleanup(func() { askKeyboardPassword = askPasswordWithFallback })
+
+	dev := &fenceFakeLuksDevice{
+		unseal: func(int, []byte) (*luks.Volume, error) {
+			return nil, luks.ErrPassphraseDoesNotMatch
+		},
+	}
+	volumes := make(chan *luks.Volume, 1)
+
+	requestKeyboardPassword(context.Background(), volumes, dev, []int{0}, "root", 2)
+
+	require.Len(t, handed, 2, "expected maxTries=2 attempts")
+	for i, p := range handed {
+		require.Truef(t, allZero(p), "failed attempt %d not wiped", i)
+	}
+}
+
+func TestRequestKeyboardPasswordKeepsCachedPassphrase(t *testing.T) {
+	resetKeyboardHarness(t)
+
+	secret := []byte("goodpass")
+	askKeyboardPassword = func(ctx context.Context, prompt, postPrompt string) ([]byte, error) {
+		return secret, nil
+	}
+	t.Cleanup(func() { askKeyboardPassword = askPasswordWithFallback })
+
+	dev := &fenceFakeLuksDevice{
+		unseal: func(int, []byte) (*luks.Volume, error) {
+			return &luks.Volume{}, nil // success on first try
+		},
+	}
+	volumes := make(chan *luks.Volume, 1)
+
+	requestKeyboardPassword(context.Background(), volumes, dev, []int{0}, "root", 3)
+
+	// The success branch caches by reference and must NOT wipe.
+	passphraseCache.Lock()
+	require.Len(t, passphraseCache.passwords, 1)
+	require.False(t, allZero(passphraseCache.passwords[0]), "cached passphrase wrongly wiped")
+	passphraseCache.Unlock()
+
+	// And the handoff wipe clears it.
+	wipeSecretCache()
+	require.True(t, allZero(secret), "cached passphrase not wiped at handoff")
 }

--- a/init/secret_test.go
+++ b/init/secret_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func allZero(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func TestWipe(t *testing.T) {
+	b := []byte{1, 2, 3, 4, 5}
+	wipe(b)
+	require.Equal(t, []byte{0, 0, 0, 0, 0}, b)
+}
+
+func TestWipeEmpty(t *testing.T) {
+	require.NotPanics(t, func() { wipe(nil) })
+	require.NotPanics(t, func() { wipe([]byte{}) })
+}

--- a/init/secret_test.go
+++ b/init/secret_test.go
@@ -57,6 +57,7 @@ func TestWipeSecretCacheIdempotent(t *testing.T) {
 
 // resetKeyboardHarness puts the package into a state where requestKeyboardPassword
 // runs without real plymouth/terminal I/O.
+// Mutates package globals; tests using it must not call t.Parallel().
 func resetKeyboardHarness(t *testing.T) {
 	t.Helper()
 	plymouthEnabled = false

--- a/init/secret_test.go
+++ b/init/secret_test.go
@@ -121,3 +121,30 @@ func TestRequestKeyboardPasswordKeepsCachedPassphrase(t *testing.T) {
 	wipeSecretCache()
 	require.True(t, allZero(secret), "cached passphrase not wiped at handoff")
 }
+
+func TestReadTPM2PINAuthValueWipesPIN(t *testing.T) {
+	var handed []byte
+	askKeyboardPassword = func(ctx context.Context, prompt, postPrompt string) ([]byte, error) {
+		handed = []byte("1234")
+		return handed, nil
+	}
+	t.Cleanup(func() { askKeyboardPassword = askPasswordWithFallback })
+
+	salt := []byte("saltsalt")
+	want := tpm2PINAuthValue([]byte("1234"), salt)
+
+	got, err := readTPM2PINAuthValue(context.Background(), "PIN:", salt)
+	require.NoError(t, err)
+	require.Equal(t, want, got) // auth value derived correctly
+	require.True(t, allZero(handed), "PIN bytes not wiped after derivation")
+}
+
+func TestReadTPM2PINAuthValueEmptySkips(t *testing.T) {
+	askKeyboardPassword = func(ctx context.Context, prompt, postPrompt string) ([]byte, error) {
+		return []byte{}, nil
+	}
+	t.Cleanup(func() { askKeyboardPassword = askPasswordWithFallback })
+
+	_, err := readTPM2PINAuthValue(context.Background(), "PIN:", []byte("salt"))
+	require.ErrorIs(t, err, errTPM2Skipped)
+}


### PR DESCRIPTION
## Summary

Secret material (LUKS passphrases, TPM2 PINs, unsealed volume keys) currently lingers in the initramfs's memory after it has served its purpose. Go does not scrub freed slices, and unless the kernel is built with `CONFIG_INIT_ON_FREE_DEFAULT_ON=y` those pages keep the plaintext until they happen to be reused — a cold-boot / RAM-remanence exposure that outlives the unlock. 

No real functional changes...This adds a small `wipe()` primitive and scrubs in-process `[]byte` secrets at the point they stop being needed.

## What gets wiped

- The passphrase cache, at both boot exits — the `switchRoot` handoff (via `cleanup()`) and the emergency shell. The root passphrase no longer survives into the pivoted system or an interactive rescue shell.
- Failed keyboard passphrase attempts, scrubbed at the retry site (no one owns them).
- TPM2 PINs, wiped immediately after the auth value is derived.
- The derived TPM2 auth value and the raw unsealed volume key, wiped after the TPM consumes them / after the base64 form the caller needs is produced.

## Ownership rule 

A passphrase that successfully unlocks a volume is appended to `passphraseCache` **by reference** so later volumes (e.g. btrfs RAID1 members) unlock without re-prompting. That slice is thereafter owned by the cache and is scrubbed exactly once, at the boot exits. Only unowned secrets — failed attempts and consumed PINs — are wiped at their read site. This invariant is documented on the cache and is what keeps the shared-passphrase RAID1 path intact.

## Out of scope

Two secret copies remain because they are handed to an external API as a Go `string`, which is immutable and cannot be zeroed in place.

- TPM2 auth value, the residual string copy. `tpm2Unseal` uses the legacy `go-tpm/legacy/tpm2` API, whose auth argument is a `string` (`UnsealWithSession`). A `[]byte` auth requires porting the unseal path onto the newer `go-tpm/tpm2` transport API which is a possible bigger future project.
- FIDO2 PIN. `go-libfido2` accepts the PIN only as a `string` and copies it to the C heap via `C.CString`; it exposes no `[]byte` variant, and libfido2 itself buffers the PIN internally. Scrubbing it would need upstream changes to go-libfido2 and libfido2. 

## Testing

- New unit tests (`init/secret_test.go`) cover `wipe`, `wipeSecretCache` (incl. idempotency), the failed-attempt wipe, the cache-retention-on-success path, and the TPM2 PIN read/wipe.
- QEMU integration suite, unlock-relevant groups: LUKS1/2 (name/UUID/detached-header), all `Crypttab*` including `CrypttabTPM2` (swtpm), Clevis Tang + Tpm2, `PassphraseCache`, and `LuksBtrfsRaid1` — 27/27 pass. `PassphraseCache` and `LuksBtrfsRaid1` specifically exercise the by-reference cache path the ownership rule protects.
