### PR TITLE
init/luks: pair a crypttab entry with a command line parameter that names the same device

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -262,9 +262,14 @@ the file by either being ran as root, or by being passed
 > this warning is irrelevant with x-initrd.attach
 
 
-Crypttab entries and `rd.luks.*` parameters with the same LUKS UUID are
+Crypttab entries and `rd.luks.*` parameters describing the same device are
 merged, with cmdline parameters taking precedence and unspecified options
-being added from crypttab.
+being added from crypttab. The two sources need not name the device the
+same way: an entry written `LABEL=`, `WWID=` or as a path is matched to a
+`rd.luks.*` parameter written `$UUID` once the device appears and both
+spellings are known to resolve to it. The volume name and device
+reference then come from the command line, the key file and options from
+whichever source outranks the other for that field.
 
 A per-device `rd.luks.options=$UUID=` is the exception: it *replaces* that
 entry's options instead of adding to them, so the command line can remove

--- a/init/crypttab.go
+++ b/init/crypttab.go
@@ -287,6 +287,7 @@ func resolveLuksOptions(ctMappings []*luksMapping) {
 			// a device nothing else names: its own entry is its only source,
 			// and it is composed below like any other
 			cm.crypttabOptions = &opts
+			cm.fromCrypttab = true
 			luksMappings = append(luksMappings, cm)
 			continue
 		}
@@ -304,29 +305,36 @@ func resolveLuksOptions(ctMappings []*luksMapping) {
 	}
 
 	for _, m := range luksMappings {
-		merged := newLuksOptions()
-
-		if ct := m.crypttabOptions; ct != nil {
-			if m.cmdlineOptions != nil {
-				// A per-device rd.luks.options= replaces the entry's option
-				// field, so the entry contributes none of it.
-				if len(ct.appliedOptions) > 0 {
-					warning("crypttab: entry %q: options %q dropped. A per-device rd.luks.options= replaces a crypttab entry's options rather than adding to them. Repeat on the command line any that are still needed.", m.name, joinOptions(ct.appliedOptions))
-				}
-			} else {
-				overlay(&merged, ct)
-			}
-		}
-		applyGlobalOptions(&merged)
-		if h := m.deprecatedHeader; h != nil {
-			overlay(&merged, h)
-		}
-		if pd := m.cmdlineOptions; pd != nil {
-			overlay(&merged, pd)
-		}
-
-		m.luksOptions = merged
+		composeMapping(m)
 	}
+}
+
+// composeMapping folds a device's sources into its options, lowest priority
+// first. Kept separate from resolveLuksOptions because a device that turns out
+// to be described twice is composed again once that is known.
+func composeMapping(m *luksMapping) {
+	merged := newLuksOptions()
+
+	if ct := m.crypttabOptions; ct != nil {
+		if m.cmdlineOptions != nil {
+			// A per-device rd.luks.options= replaces the entry's option
+			// field, so the entry contributes none of it.
+			if len(ct.appliedOptions) > 0 {
+				warning("crypttab: entry %q: options %q dropped. A per-device rd.luks.options= replaces a crypttab entry's options rather than adding to them. Repeat on the command line any that are still needed.", m.name, joinOptions(ct.appliedOptions))
+			}
+		} else {
+			overlay(&merged, ct)
+		}
+	}
+	applyGlobalOptions(&merged)
+	if h := m.deprecatedHeader; h != nil {
+		overlay(&merged, h)
+	}
+	if pd := m.cmdlineOptions; pd != nil {
+		overlay(&merged, pd)
+	}
+
+	m.luksOptions = merged
 }
 
 // deviceRefEqual reports whether two deviceRefs refer to the same device.

--- a/init/luks.go
+++ b/init/luks.go
@@ -94,6 +94,11 @@ type luksMapping struct {
 	crypttabOptions *luksOptions
 	cmdlineOptions  *luksOptions // a per-device rd.luks.options=$UUID=
 
+	// fromCrypttab marks a mapping an /etc/crypttab entry produced on its own,
+	// which decides whose name and device reference survive if it turns out to
+	// describe a device the command line also named.
+	fromCrypttab bool
+
 	// deprecatedHeader carries rd.luks.header=, booster's own spelling for a
 	// detached header. systemd has no such parameter -- it is only ever the
 	// header= option -- so this slot exists to be deleted with it.
@@ -1995,16 +2000,15 @@ func unreachableMapperName() (string, bool) {
 }
 
 func matchLuksMapping(blk *blkInfo) *luksMapping {
-	for _, m := range luksMappings {
-		if blk.matchesRef(m.ref) {
-			// Mirror the synthesis-fallback remap so root=UUID=<luks-uuid>
-			// keeps working after a crypttab/rd.luks.* entry adds the mapping.
-			if blk.matchesRef(cmdRoot) {
-				info("LUKS device %s matches root=, re-pointing root to /dev/mapper/%s", blk.path, m.name)
-				cmdRoot = &deviceRef{format: refPath, data: "/dev/mapper/" + m.name}
-			}
-			return m
+	if matched := matchingLuksMappings(blk); len(matched) > 0 {
+		m := foldLuksMappings(matched)
+		// Mirror the synthesis-fallback remap so root=UUID=<luks-uuid>
+		// keeps working after a crypttab/rd.luks.* entry adds the mapping.
+		if blk.matchesRef(cmdRoot) {
+			info("LUKS device %s matches root=, re-pointing root to /dev/mapper/%s", blk.path, m.name)
+			cmdRoot = &deviceRef{format: refPath, data: "/dev/mapper/" + m.name}
 		}
+		return m
 	}
 
 	// a special case coming from autodiscoverable partitions https://systemd.io/DISCOVERABLE_PARTITIONS/
@@ -2020,6 +2024,52 @@ func matchLuksMapping(blk *blkInfo) *luksMapping {
 	}
 
 	return nil
+}
+
+// matchingLuksMappings returns every mapping this device answers to. There can
+// be more than one: the sources name a device however the user wrote it, and
+// two spellings are only known to mean one disk once the disk is here.
+func matchingLuksMappings(blk *blkInfo) []*luksMapping {
+	var matched []*luksMapping
+	for _, m := range luksMappings {
+		if blk.matchesRef(m.ref) {
+			matched = append(matched, m)
+		}
+	}
+	return matched
+}
+
+// foldLuksMappings folds several records of one device into the one booster
+// unlocks. The command line keeps the volume name and device reference, an
+// entry contributes the fourth crypttab field and the key file it named, and
+// the result is composed again now that every source for the device is known.
+func foldLuksMappings(matched []*luksMapping) *luksMapping {
+	primary := matched[0]
+	for _, m := range matched {
+		if !m.fromCrypttab {
+			primary = m
+			break
+		}
+	}
+	if len(matched) == 1 {
+		return primary
+	}
+
+	for _, m := range matched {
+		if m == primary {
+			continue
+		}
+		info("LUKS device is described twice, as %q and %q; folding into %q", primary.name, m.name, primary.name)
+		if primary.crypttabOptions == nil {
+			primary.crypttabOptions = m.crypttabOptions
+		}
+		if primary.keyfile == "" {
+			primary.keyfile, primary.keyfileDeviceRef = m.keyfile, m.keyfileDeviceRef
+		}
+		luksMappings = slices.DeleteFunc(luksMappings, func(x *luksMapping) bool { return x == m })
+	}
+	composeMapping(primary)
+	return primary
 }
 
 func handleLuksBlockDevice(blk *blkInfo) error {

--- a/init/luks_test.go
+++ b/init/luks_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -759,4 +760,69 @@ func TestAutodiscoveredRootGetsGlobalOptions(t *testing.T) {
 	require.Equal(t, []string{luks.FlagAllowDiscards}, m.options)
 	require.Equal(t, 5, m.tries)
 	require.Empty(t, m.header, "a global header= must not reach a device")
+}
+
+// A crypttab entry and a command-line parameter can name one disk differently.
+// Which spelling was used is not something either source can resolve: only the
+// device itself knows it answers to both. Until it appears they are two
+// records, and folding them is what makes the entry take effect.
+func TestMappingsForOneDeviceAreFolded(t *testing.T) {
+	withLuksGlobals(t)
+	origGlobal := globalLuksOptions
+	t.Cleanup(func() { globalLuksOptions = origGlobal })
+
+	const u = "ab6d7d78-b816-4495-928d-766d6607035e"
+	uuid, err := parseUUID(u)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name     string
+		ctDevice string
+		blk      *blkInfo
+	}{
+		{"label", "LABEL=crypt", &blkInfo{path: "/dev/sda2", format: "luks", uuid: uuid, label: "crypt"}},
+		{"path", "/dev/sda2", &blkInfo{path: "/dev/sda2", format: "luks", uuid: uuid}},
+		{"wwid", "WWID=scsi-360", &blkInfo{path: "/dev/sda2", format: "luks", uuid: uuid, wwid: []string{"scsi-360"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			luksMappings = nil
+			globalLuksOptions = newLuksOptions()
+			require.NoError(t, parseParams("rd.luks.name="+u+"=root"))
+			ct, err := parseCrypttabReader(strings.NewReader(
+				"cryptroot " + tc.ctDevice + " /entry.key luks,tries=7\n"))
+			require.NoError(t, err)
+			resolveLuksOptions(ct)
+			require.Len(t, luksMappings, 2, "two records until the device resolves them")
+
+			m := matchLuksMapping(tc.blk)
+			require.NotNil(t, m)
+			require.Equal(t, "root", m.name, "the command line names the volume")
+			require.Equal(t, "/entry.key", m.keyfile, "the entry's key file takes effect")
+			require.Equal(t, 7, m.tries, "and its options do too")
+			require.Len(t, luksMappings, 1, "the absorbed record must not be unlocked separately")
+		})
+	}
+}
+
+// Folding must not let a crypttab entry outrank the command line.
+func TestFoldedMappingKeepsCmdlinePrecedence(t *testing.T) {
+	withLuksGlobals(t)
+	origGlobal := globalLuksOptions
+	t.Cleanup(func() { globalLuksOptions = origGlobal })
+
+	const u = "ab6d7d78-b816-4495-928d-766d6607035e"
+	uuid, err := parseUUID(u)
+	require.NoError(t, err)
+
+	luksMappings = nil
+	globalLuksOptions = newLuksOptions()
+	require.NoError(t, parseParams("rd.luks.name="+u+"=root rd.luks.key="+u+"=/cmdline.key rd.luks.options="+u+"=tries=2"))
+	ct, err := parseCrypttabReader(strings.NewReader("cryptroot LABEL=crypt /entry.key luks,tries=7,discard\n"))
+	require.NoError(t, err)
+	resolveLuksOptions(ct)
+
+	m := matchLuksMapping(&blkInfo{path: "/dev/sda2", format: "luks", uuid: uuid, label: "crypt"})
+	require.Equal(t, "/cmdline.key", m.keyfile, "rd.luks.key= wins field 3")
+	require.Equal(t, 2, m.tries, "the per-device list wins field 4")
+	require.Empty(t, m.options, "and it replaces the entry's options rather than adding to them")
 }


### PR DESCRIPTION
A crypttab entry and a kernel parameter can describe the same disk in different words. The entry says `LABEL=crypt`, the command line says `rd.luks.name=$UUID=root`. Booster treats those as two different devices today, because it compares how a device was written before what it resolves to.

Only one of the two then does anything. The command line is parsed before crypttab is read, so its mapping is the one that matches, and the entry's key file, its `tries=`, its `header=` are dropped without a message. The entry's mapping stays in the list matching nothing.

This is a follow-on to the per-device option work that just landed: that change made the option sources compose in one place, and this makes them compose for a device the two sources spell differently.

## What changes

Pairing now happens when the device appears, which is the first moment it can. Whether `LABEL=crypt` and a given UUID are the same disk is not knowable while parsing, which is why matching identical spellings was as far as the old code could go.

When more than one mapping answers for a device, they are folded into one. The command line keeps the volume name and the device reference. The crypttab entry contributes its options field and the key file it named. The result then goes through the same composition every other source goes through, so precedence is unchanged: `rd.luks.key=` still outranks the entry's key file, and a per-device `rd.luks.options=` still replaces the entry's options rather than adding to them. The absorbed mapping is removed, so nothing attempts to unlock the device twice.

## What it means

If your crypttab names a device by label, path or WWID while your bootloader names it by UUID, the crypttab entry's settings now apply instead of being silently ignored. Setups where both sources already used the same spelling behave exactly as before.

## Tests

Unit tests cover an entry naming the device by label, by path and by WWID, and a second pinning that command line precedence survives the fold.
