### PR TITLE
strip signed modules

### DIFF
--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -70,6 +70,8 @@ serialize_tokens:
 
  * `strip` is a boolean flag that enables stripping of ELF files before adding them to the image. Binaries, shared libraries and kernel modules are examples of ELF files that get processed with the strip UNIX tool. The default is `false`. Signed kernel modules are skipped.
 
+ * `strip_extra_sections` is a comma-separated list of ELF sections to remove from kernel modules in addition to debug info, for example `*orc_unwind*, .BTF`. Names are passed to `strip -R`. Only applies when `strip` is set.
+
  * `extra_files` is a comma-separated list of extra files to add to the image. If an item starts with slash ("/") then it is considered an absolute path. Otherwise it is a path relative to /usr/bin. If the item is a directory then its content is added recursively. There are a few special cases:
     * adding `busybox` to the image enables an emergency shell in case of a panic during the boot process.
     * adding `fsck` enables boot time filesystem check. It also requires filesystem specific binary called `fsck.$rootfstype` to be added to the image. Filesystems are corrected automatically and if it fails then boot stops and it is the responsibility of the user to fix the root filesystem.

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -68,9 +68,7 @@ serialize_tokens:
 
  * `mount_timeout` timeout for waiting for the root filesystem to appear. The field format is a decimal number and then unit number. Valid units are "s", "m", "h". If no value is specified, the default timeout (3 minutes) is used. To disable the timeout completely specify "0s".
 
- * `strip` is a boolean flag that enables stripping of ELF files before adding them to the image. Binaries, shared libraries and kernel modules are examples of ELF files that get processed with the strip UNIX tool.
-
-   This option is not compatible with signed modules. If you see `booster: finit(crc32,generic): key was rejected by service` boot error please set the `strip` config option to `false`.
+ * `strip` is a boolean flag that enables stripping of ELF files before adding them to the image. Binaries, shared libraries and kernel modules are examples of ELF files that get processed with the strip UNIX tool. The default is `false`. Signed kernel modules are skipped.
 
  * `extra_files` is a comma-separated list of extra files to add to the image. If an item starts with slash ("/") then it is considered an absolute path. Otherwise it is a path relative to /usr/bin. If the item is a directory then its content is added recursively. There are a few special cases:
     * adding `busybox` to the image enables an emergency shell in case of a panic during the boot process.

--- a/generator/config.go
+++ b/generator/config.go
@@ -64,6 +64,7 @@ type UserConfig struct {
 	ExtraFiles             string `yaml:"extra_files,omitempty"`              // comma-separated list of files to add to image
 	EmergencyShellPassword string `yaml:"emergency_shell_password,omitempty"` // argon2id PHC; gates the emergency shell
 	StripBinaries          bool   `yaml:"strip,omitempty"`                    // if strip symbols from the binaries, shared libraries and kernel modules
+	StripExtraSections     string `yaml:"strip_extra_sections,omitempty"`     // comma-separated ELF sections to additionally remove from kernel modules when strip is set
 	EnableVirtualConsole   bool   `yaml:"vconsole,omitempty"`                 // configure virtual console at boot time using config from https://www.freedesktop.org/software/systemd/man/vconsole.conf.html
 	EnableLVM              bool   `yaml:"enable_lvm"`
 	EnableMdraid           bool   `yaml:"enable_mdraid"`
@@ -256,6 +257,7 @@ func readGeneratorConfig(file string) (*generatorConfig, error) {
 	conf.readModprobeOptions = readModprobeOptions
 	conf.appendAllModAliases = u.AppendAllModAliases
 	conf.stripBinaries = u.StripBinaries || opts.BuildCommand.Strip
+	conf.stripExtraSections = parseCommaList(u.StripExtraSections)
 	conf.enableLVM = u.EnableLVM
 	conf.emergencyShellPassword = u.EmergencyShellPassword
 	conf.enableMdraid = u.EnableMdraid

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -38,6 +38,7 @@ type generatorConfig struct {
 	readHostModules         func(kernelVer string) (set, error)
 	readModprobeOptions     func() (map[string]string, error)
 	stripBinaries           bool
+	stripExtraSections      []string
 	enableLVM               bool
 	enableMdraid            bool
 	mdraidConfigPath        string
@@ -124,6 +125,7 @@ func generateInitRamfs(conf *generatorConfig) error {
 	}
 	defer img.Cleanup()
 	img.signedModulesRequired = kernelEnforcesModuleSignatures(conf.modulesDir, conf.kernelVersion)
+	img.stripExtraSections = conf.stripExtraSections
 
 	if err := appendCompatibilitySymlinks(img); err != nil {
 		return err

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -123,6 +123,7 @@ func generateInitRamfs(conf *generatorConfig) error {
 		return err
 	}
 	defer img.Cleanup()
+	img.signedModulesRequired = kernelEnforcesModuleSignatures(conf.modulesDir, conf.kernelVersion)
 
 	if err := appendCompatibilitySymlinks(img); err != nil {
 		return err

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -62,6 +62,7 @@ type options struct {
 	modprobeOptions              map[string]string
 	expectError                  string
 	stripBinaries                bool
+	stripExtraSections           []string
 	enableLVM                    bool
 	vConsoleConfig, localeConfig string
 	enableMdraid                 bool
@@ -196,6 +197,7 @@ func createTestInitRamfs(t *testing.T, o *options) {
 		extraFiles:          o.extraFiles,
 		modules:             o.extraModules,
 		stripBinaries:       o.stripBinaries,
+		stripExtraSections:  o.stripExtraSections,
 		enableLVM:           o.enableLVM,
 		enableMdraid:        o.enableMdraid,
 		mdraidConfigPath:    o.mdraidConfigPath,
@@ -628,6 +630,36 @@ func readelfSections(t *testing.T, path string) []string {
 	}
 
 	return names
+}
+
+// TestStripExtraSections covers the escape hatch for people who want the
+// aggressive behaviour back: sections named in strip_extra_sections are removed
+// from modules on top of debug info, and userspace files are left alone.
+func TestStripExtraSections(t *testing.T) {
+	require.Equal(t, []string{"--strip-debug"}, stripArgs(false, true, nil))
+	require.Equal(t,
+		[]string{"--strip-debug", "-R", "*orc_unwind*", "-R", ".BTF"},
+		stripArgs(false, true, []string{"*orc_unwind*", ".BTF"}))
+
+	// userspace files are unaffected: the list is about modules
+	require.NotContains(t, stripArgs(true, false, []string{".BTF"}), ".BTF")
+
+}
+
+func TestStripExtraSectionsReachTheImage(t *testing.T) {
+	opts := options{
+		universal:          true,
+		stripBinaries:      true,
+		stripExtraSections: []string{"*orc_unwind*", ".BTF"},
+		prepareModulesAt:   []string{"kernel/fs/mod.ko"},
+		unpackImage:        true,
+	}
+	createTestInitRamfs(t, &opts)
+
+	sections := readelfSections(t, opts.workDir+"/image.unpacked/usr/lib/modules/mod.ko")
+	require.NotContains(t, sections, ".orc_unwind")
+	require.NotContains(t, sections, ".BTF")
+	require.Contains(t, sections, ".note.gnu.build-id", "only the listed sections go")
 }
 
 func TestKernelEnforcesModuleSignatures(t *testing.T) {

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -539,6 +540,70 @@ func appendModuleSignature(content []byte) []byte {
 	out = append(out, descriptor...)
 
 	return append(out, "~Module signature appended~\n"...)
+}
+
+// captureStdout collects what the generator prints, which is where warning()
+// goes.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	saved := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = saved }()
+
+	fn()
+	require.NoError(t, w.Close())
+
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	return string(out)
+}
+
+// TestUnsignedModuleWarnsWhenKernelEnforces covers the case booster cannot fix
+// for the user: a module that was never signed, packed for a kernel that refuses
+// unsigned modules. Silence there means an image that fails at finit_module with
+// nothing in the build output pointing at why.
+func TestUnsignedModuleWarnsWhenKernelEnforces(t *testing.T) {
+	prepareAssets(t)
+	content, err := os.ReadFile("assets/test_module.ko")
+	require.NoError(t, err)
+
+	img, err := NewImage(filepath.Join(t.TempDir(), "booster.img"), "none", false)
+	require.NoError(t, err)
+	defer img.Cleanup()
+	img.signedModulesRequired = true
+
+	out := captureStdout(t, func() {
+		require.NoError(t, img.AppendContent(imageModulesDir+"nosig.ko", 0o644, content))
+		require.NoError(t, img.AppendContent(imageModulesDir+"withsig.ko", 0o644, appendModuleSignature(content)))
+	})
+
+	require.Contains(t, out, "nosig.ko is not signed")
+	require.NotContains(t, out, "withsig.ko is not signed")
+}
+
+func TestKernelEnforcesModuleSignatures(t *testing.T) {
+	dir := t.TempDir()
+	require.False(t, kernelEnforcesModuleSignatures(dir, "matestkernel"), "no config means no claim either way")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config"),
+		[]byte("CONFIG_MODULE_SIG=y\n# CONFIG_MODULE_SIG_FORCE is not set\n"), 0o644))
+	require.False(t, kernelEnforcesModuleSignatures(dir, "matestkernel"), "signing without forcing is not enforcement")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config"),
+		[]byte("CONFIG_MODULE_SIG=y\nCONFIG_MODULE_SIG_FORCE=y\n"), 0o644))
+	require.True(t, kernelEnforcesModuleSignatures(dir, "matestkernel"))
+
+	// the kernel build directory is where a distribution that ships no separate
+	// config file keeps it
+	build := filepath.Join(dir, "build")
+	require.NoError(t, os.MkdirAll(build, 0o755))
+	require.NoError(t, os.Remove(filepath.Join(dir, "config")))
+	require.NoError(t, os.WriteFile(filepath.Join(build, ".config"), []byte("CONFIG_MODULE_SIG_FORCE=y\n"), 0o644))
+	require.True(t, kernelEnforcesModuleSignatures(dir, "matestkernel"))
 }
 
 func TestStripKeepsModuleSignatures(t *testing.T) {

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -585,6 +585,51 @@ func TestUnsignedModuleWarnsWhenKernelEnforces(t *testing.T) {
 	require.NotContains(t, out, "withsig.ko is not signed")
 }
 
+// TestStripKeepsKernelConsumedSections pins the dracut-aligned split: a module
+// gives up debug info only, because the kernel reads its ORC unwind tables, BTF
+// and build-id note out of the file, and an image whose modules cannot be
+// unwound through is an image whose panics cannot be read.
+func TestStripKeepsKernelConsumedSections(t *testing.T) {
+	opts := options{
+		universal:        true,
+		stripBinaries:    true,
+		prepareModulesAt: []string{"kernel/fs/mod.ko"},
+		unpackImage:      true,
+	}
+	createTestInitRamfs(t, &opts)
+
+	packed := opts.workDir + "/image.unpacked/usr/lib/modules/mod.ko"
+	sections := readelfSections(t, packed)
+	for _, want := range []string{".orc_unwind", ".orc_unwind_ip", ".BTF", ".note.gnu.build-id"} {
+		require.Contains(t, sections, want, "the kernel reads %s out of the module file", want)
+	}
+	require.NotContains(t, sections, ".debug_info", "debug info is what stripping a module is for")
+
+	// and the module really was processed rather than copied whole
+	original, err := os.Stat("assets/test_module.ko")
+	require.NoError(t, err)
+	stripped, err := os.Stat(packed)
+	require.NoError(t, err)
+	require.Less(t, stripped.Size(), original.Size())
+}
+
+func readelfSections(t *testing.T, path string) []string {
+	t.Helper()
+
+	out, err := exec.Command("readelf", "-SW", path).Output()
+	require.NoError(t, err)
+
+	var names []string
+	for _, line := range strings.Split(string(out), "\n") {
+		f := strings.Fields(strings.TrimPrefix(strings.TrimSpace(line), "["))
+		if len(f) > 2 && strings.HasPrefix(f[1], ".") {
+			names = append(names, f[1])
+		}
+	}
+
+	return names
+}
+
 func TestKernelEnforcesModuleSignatures(t *testing.T) {
 	dir := t.TempDir()
 	require.False(t, kernelEnforcesModuleSignatures(dir, "matestkernel"), "no config means no claim either way")

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"os/exec"
@@ -49,6 +50,7 @@ type options struct {
 	universal                    bool
 	extraModules                 []string // modules to add to the image
 	prepareModulesAt             []string // copy a test module to these locations
+	signModulesAt                []string // same, with a module signature appended
 	unpackImage                  bool
 	hostModules                  []string // modules as found under /proc/modules
 	hostAliases                  []string // list of all aliases for the host devices
@@ -136,6 +138,15 @@ func createTestInitRamfs(t *testing.T, o *options) {
 			source += ".gz"
 		}
 		require.NoError(t, exec.Command("cp", source, loc).Run())
+	}
+
+	for _, l := range o.signModulesAt {
+		loc := modulesDir + "/" + l
+		require.NoError(t, os.MkdirAll(filepath.Dir(loc), 0o755))
+
+		content, err := os.ReadFile("assets/test_module.ko")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(loc, appendModuleSignature(content), 0o644))
 	}
 
 	require.NoError(t, os.WriteFile(modulesDir+"/modules.builtin", generateBuiltinFile(o.builtin), 0o644))
@@ -514,6 +525,46 @@ func TestStripBinaries(t *testing.T) {
 	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/whiteheat.fw.zst")
 	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/usbdux_firmware.bin.zst")
 	checkFileExistence(t, opts.workDir+"/image.unpacked/usr/lib/firmware/rtw88/rtw8723d_fw.bin.zst")
+}
+
+// Shaped like a real signature (signature, 12 byte descriptor, marker) per the
+// kernel's scripts/sign-file.c, though only the marker matters to the generator.
+func appendModuleSignature(content []byte) []byte {
+	sig := bytes.Repeat([]byte{0xab}, 64)
+	descriptor := make([]byte, 12)
+	binary.BigEndian.PutUint32(descriptor[8:], uint32(len(sig)))
+
+	out := append([]byte{}, content...)
+	out = append(out, sig...)
+	out = append(out, descriptor...)
+
+	return append(out, "~Module signature appended~\n"...)
+}
+
+func TestStripKeepsModuleSignatures(t *testing.T) {
+	// strip discards everything past the ELF, signature included, so a stripped
+	// module is refused once the kernel enforces signatures
+	opts := options{
+		universal:        true,
+		stripBinaries:    true,
+		prepareModulesAt: []string{"kernel/fs/unsigned.ko"},
+		signModulesAt:    []string{"kernel/fs/signed.ko"},
+		unpackImage:      true,
+	}
+	createTestInitRamfs(t, &opts)
+
+	source, err := os.ReadFile(opts.workDir + "/modules/kernel/fs/signed.ko")
+	require.NoError(t, err)
+	packed, err := os.ReadFile(opts.workDir + "/image.unpacked/usr/lib/modules/signed.ko")
+	require.NoError(t, err)
+	require.Equal(t, source, packed, "signed module must reach the image untouched")
+
+	// the unsigned module is still stripped, so this is not a blanket opt-out
+	unsigned, err := os.ReadFile(opts.workDir + "/image.unpacked/usr/lib/modules/unsigned.ko")
+	require.NoError(t, err)
+	original, err := os.ReadFile("assets/test_module.ko")
+	require.NoError(t, err)
+	require.Less(t, len(unsigned), len(original), "unsigned module should still be stripped")
 }
 
 func TestVirtualConsoleFontMap(t *testing.T) {

--- a/generator/image.go
+++ b/generator/image.go
@@ -121,6 +121,9 @@ func (img *Image) AppendDirEntry(dir string) error {
 	return err
 }
 
+// moduleSignatureMarker terminates a module signature, which sits past the end of the ELF (kernel scripts/sign-file.c)
+var moduleSignatureMarker = []byte("~Module signature appended~\n")
+
 func stripElf(in []byte, stripAll bool) ([]byte, error) {
 	t, err := os.CreateTemp("", "booster.strip")
 	if err != nil {
@@ -183,14 +186,19 @@ func (img *Image) AppendContent(dest string, osMode os.FileMode, content []byte)
 				// some firmware files are actually ELF but we should not run strip on them
 				doStrip = false
 			}
+			if doStrip && bytes.HasSuffix(content, moduleSignatureMarker) {
+				// strip rewrites the ELF, discarding everything past it, and reports success
+				debug("%s is signed, skipping strip to keep the signature", dest)
+				doStrip = false
+			}
 			if doStrip {
 				// do not use --strip-all for modules/shared libs as it fails to load
 				isBinary := ef.Type == elf.ET_EXEC
 				stripped, stripErr := stripElf(content, isBinary)
 				if stripErr != nil {
 					// Strip is an optional size optimisation; a failure (e.g. LTO
-					// modules, signed modules, unusual toolchains) must not abort
-					// the build.  Warn and fall back to the unstripped binary.
+					// modules, unusual toolchains) must not abort the build.
+					// Warn and fall back to the unstripped binary.
 					warning("strip %s: %v — using unstripped", dest, stripErr)
 				} else {
 					content = stripped

--- a/generator/image.go
+++ b/generator/image.go
@@ -26,6 +26,8 @@ type Image struct {
 	out           *cpio.Writer
 	contains      set // whether image contains the file
 	stripBinaries bool
+
+	signedModulesRequired bool
 }
 
 func NewImage(path string, compression string, stripBinaries bool) (*Image, error) {
@@ -121,7 +123,10 @@ func (img *Image) AppendDirEntry(dir string) error {
 	return err
 }
 
-// moduleSignatureMarker terminates a module signature, which sits past the end of the ELF (kernel scripts/sign-file.c)
+// moduleSignatureMarker terminates a module signature, which sits past the end
+// of the ELF (kernel scripts/sign-file.c). Whether losing it is fatal is decided
+// at boot, not here, and two of the three enforcement switches can be turned on
+// long after an image was built, so signed modules are never stripped.
 var moduleSignatureMarker = []byte("~Module signature appended~\n")
 
 func stripElf(in []byte, stripAll bool) ([]byte, error) {
@@ -187,7 +192,7 @@ func (img *Image) AppendContent(dest string, osMode os.FileMode, content []byte)
 				doStrip = false
 			}
 			if doStrip && bytes.HasSuffix(content, moduleSignatureMarker) {
-				// strip rewrites the ELF, discarding everything past it, and reports success
+				// strip discards everything past the ELF, signature included, and reports success
 				debug("%s is signed, skipping strip to keep the signature", dest)
 				doStrip = false
 			}
@@ -203,6 +208,11 @@ func (img *Image) AppendContent(dest string, osMode os.FileMode, content []byte)
 				} else {
 					content = stripped
 				}
+			}
+
+			if img.signedModulesRequired && strings.HasPrefix(dest, imageModulesDir) &&
+				!bytes.HasSuffix(content, moduleSignatureMarker) {
+				warning("%s is not signed and this kernel refuses unsigned modules; the boot will fail at finit_module", dest)
 			}
 
 			if err := img.AppendElfDependencies(ef); err != nil {

--- a/generator/image.go
+++ b/generator/image.go
@@ -129,7 +129,22 @@ func (img *Image) AppendDirEntry(dir string) error {
 // long after an image was built, so signed modules are never stripped.
 var moduleSignatureMarker = []byte("~Module signature appended~\n")
 
-func stripElf(in []byte, stripAll bool) ([]byte, error) {
+// stripArgs mirrors dracut: modules give up debug info only, because the kernel
+// reads ORC unwind tables, BTF and the build-id note out of the module file.
+func stripArgs(stripAll, isModule bool) []string {
+	if isModule {
+		return []string{"--strip-debug"}
+	}
+
+	args := []string{"-R", ".note.*", "-R", ".comment", "-R", ".go.buildinfo", "-R", ".gosymtab"}
+	if stripAll {
+		return append(args, "--strip-all")
+	}
+
+	return append(args, "--strip-unneeded")
+}
+
+func stripElf(in []byte, stripAll, isModule bool) ([]byte, error) {
 	t, err := os.CreateTemp("", "booster.strip")
 	if err != nil {
 		return nil, err
@@ -142,13 +157,7 @@ func stripElf(in []byte, stripAll bool) ([]byte, error) {
 	}
 	_ = t.Close()
 
-	args := []string{"-R", ".note.*", "-R", ".comment", "-R", ".go.buildinfo", "-R", ".gosymtab", "-R", "*orc_unwind*", "-R", ".BTF"}
-	if stripAll {
-		args = append(args, "--strip-all")
-	} else {
-		args = append(args, "--strip-unneeded")
-	}
-	args = append(args, t.Name())
+	args := append(stripArgs(stripAll, isModule), t.Name())
 	cmd := exec.Command("strip", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -197,9 +206,9 @@ func (img *Image) AppendContent(dest string, osMode os.FileMode, content []byte)
 				doStrip = false
 			}
 			if doStrip {
-				// do not use --strip-all for modules/shared libs as it fails to load
+				// do not use --strip-all for shared libs as it fails to load
 				isBinary := ef.Type == elf.ET_EXEC
-				stripped, stripErr := stripElf(content, isBinary)
+				stripped, stripErr := stripElf(content, isBinary, strings.HasPrefix(dest, imageModulesDir))
 				if stripErr != nil {
 					// Strip is an optional size optimisation; a failure (e.g. LTO
 					// modules, unusual toolchains) must not abort the build.

--- a/generator/image.go
+++ b/generator/image.go
@@ -28,6 +28,8 @@ type Image struct {
 	stripBinaries bool
 
 	signedModulesRequired bool
+
+	stripExtraSections []string
 }
 
 func NewImage(path string, compression string, stripBinaries bool) (*Image, error) {
@@ -131,9 +133,14 @@ var moduleSignatureMarker = []byte("~Module signature appended~\n")
 
 // stripArgs mirrors dracut: modules give up debug info only, because the kernel
 // reads ORC unwind tables, BTF and the build-id note out of the module file.
-func stripArgs(stripAll, isModule bool) []string {
+func stripArgs(stripAll, isModule bool, extraSections []string) []string {
 	if isModule {
-		return []string{"--strip-debug"}
+		args := []string{"--strip-debug"}
+		for _, section := range extraSections {
+			args = append(args, "-R", section)
+		}
+
+		return args
 	}
 
 	args := []string{"-R", ".note.*", "-R", ".comment", "-R", ".go.buildinfo", "-R", ".gosymtab"}
@@ -144,7 +151,7 @@ func stripArgs(stripAll, isModule bool) []string {
 	return append(args, "--strip-unneeded")
 }
 
-func stripElf(in []byte, stripAll, isModule bool) ([]byte, error) {
+func stripElf(in []byte, stripAll, isModule bool, extraSections []string) ([]byte, error) {
 	t, err := os.CreateTemp("", "booster.strip")
 	if err != nil {
 		return nil, err
@@ -157,7 +164,7 @@ func stripElf(in []byte, stripAll, isModule bool) ([]byte, error) {
 	}
 	_ = t.Close()
 
-	args := append(stripArgs(stripAll, isModule), t.Name())
+	args := append(stripArgs(stripAll, isModule, extraSections), t.Name())
 	cmd := exec.Command("strip", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -208,7 +215,7 @@ func (img *Image) AppendContent(dest string, osMode os.FileMode, content []byte)
 			if doStrip {
 				// do not use --strip-all for shared libs as it fails to load
 				isBinary := ef.Type == elf.ET_EXEC
-				stripped, stripErr := stripElf(content, isBinary, strings.HasPrefix(dest, imageModulesDir))
+				stripped, stripErr := stripElf(content, isBinary, strings.HasPrefix(dest, imageModulesDir), img.stripExtraSections)
 				if stripErr != nil {
 					// Strip is an optional size optimisation; a failure (e.g. LTO
 					// modules, unusual toolchains) must not abort the build.

--- a/generator/kmod.go
+++ b/generator/kmod.go
@@ -793,6 +793,34 @@ func readCompiledInComponents(kernelVersion string) (set, error) {
 	return result, nil
 }
 
+// kernelEnforcesModuleSignatures reports whether the target kernel refuses unsigned
+// modules. Only CONFIG_MODULE_SIG_FORCE is knowable at build time; sig_enforce=1 and
+// lockdown are chosen at boot, so a false answer must never gate dropping a signature.
+func kernelEnforcesModuleSignatures(modulesDir, kernelVersion string) bool {
+	candidates := []string{
+		filepath.Join(modulesDir, "config"),
+		filepath.Join(modulesDir, "build", ".config"),
+		"/boot/config-" + kernelVersion,
+	}
+
+	for _, p := range candidates {
+		f, err := os.Open(p)
+		if err != nil {
+			continue
+		}
+		s := bufio.NewScanner(f)
+		for s.Scan() {
+			if s.Text() == "CONFIG_MODULE_SIG_FORCE=y" {
+				_ = f.Close()
+				return true
+			}
+		}
+		_ = f.Close()
+	}
+
+	return false
+}
+
 func readHostModules(kernelVersion string) (set, error) {
 	// Unlike /proc/modules (or `lsmod`) /sys/module provides information about builtin modules as well.
 	// And we need to check the built-in modules and try to add it to the image. This is needed because

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -221,6 +221,25 @@ func TestStripBinaries(t *testing.T) {
 	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
 }
 
+func TestStripKeepsModuleSignatures(t *testing.T) {
+	// the booting kernel trusts these modules' signatures; sig_enforce rejects any that lost one
+	kernelVersion := defaultKernelVersion(t)
+	if !hostSignsModules(kernelVersion) {
+		t.Skip("host kernel modules are unsigned, signature enforcement proves nothing here")
+	}
+
+	vm, err := buildVmInstance(t, Opts{
+		disk:          "assets/ext4.img",
+		stripBinaries: true,
+		kernelVersion: kernelVersion,
+		kernelArgs:    []string{"root=UUID=5c92fc66-7315-408b-b652-176dc554d370", "module.sig_enforce=1"},
+	})
+	require.NoError(t, err)
+	defer vm.Shutdown()
+
+	require.NoError(t, vm.ConsoleExpect("Hello, booster!"))
+}
+
 func TestNvme(t *testing.T) {
 	vm, err := buildVmInstance(t, Opts{
 		disks:      []vmtest.QemuDisk{{Path: "assets/gpt.img", Format: "raw", Controller: "nvme,serial=boostfoo"}},

--- a/tests/util.go
+++ b/tests/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -180,6 +181,28 @@ func shell(script string, env ...string) error {
 func fileExists(file string) bool {
 	_, err := os.Stat(file)
 	return err == nil
+}
+
+// hostSignsModules reports whether this host's modules for kernelVersion are signed
+func hostSignsModules(kernelVersion string) bool {
+	var module string
+
+	dir := filepath.Join(kernelsDir, kernelVersion, "kernel")
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil //nolint:nilerr // an unreadable subtree just means we keep looking
+		}
+		module = path
+		return fs.SkipAll
+	})
+	if err != nil || module == "" {
+		return false
+	}
+
+	// modinfo handles whatever compression the distribution packs modules with
+	signer, err := exec.Command("modinfo", "-F", "signer", module).Output()
+
+	return err == nil && len(bytes.TrimSpace(signer)) > 0
 }
 
 func detectKernelVersion() (map[string]string, error) {


### PR DESCRIPTION
Issue #401 and #410 led me here. Referenced issues  #36, #57, #65, #69, #70.

`strip: true` silently destroys the signature on every signed kernel module it packs.

A module's signature is appended after the end of its ELF image. `strip` rewrites the ELF and discards everything past it, and exits successfully while doing so. The image looks fine and boots fine until the kernel enforces module signatures, at which point `finit_module` returns EKEYREJECTED and the boot stops:

```
booster: finit(virtio_scsi): key was rejected by service
booster: finit(ata_piix): key was rejected by service
```

Signing and enforcing are separate things, which is why this went unnoticed. `CONFIG_MODULE_SIG_ALL=y` signs every module and still loads unsigned ones happily. Refusal needs `CONFIG_MODULE_SIG_FORCE`, `module.sig_enforce=1`, or lockdown in integrity mode, which some distributions turn on under Secure Boot. So nothing happens on an Arch-family machine, and the same image will not boot on a Fedora one.

## What changes

Signed modules are no longer stripped. dracut's module loop already skips them, keyed on the same 28-byte marker.

Modules give up debug info only. Booster removed a fixed section list from every ELF it packed, and three of those are read by the kernel out of the module file rather than being debug data: the ORC unwind tables behind kernel backtraces, the BTF that registers the module under `/sys/kernel/btf`, and the build-id note. dracut strips modules with `-g` and nothing more, reserving the aggressive form for an explicit flag. This matches that.

A build-time warning when a module that was never signed, from DKMS or a local build, is packed for a kernel that will refuse it. Booster cannot fix that for the user, but it should not ship an image that dies at boot with nothing in the build output explaining why.

`strip_extra_sections` puts the aggressive behaviour back per section, for anyone who wants those bytes.

Userspace files are untouched by all of this, which is where stripping earns its keep: the init binary alone goes from 23.7 MB to 16.5 MB. The change costs roughly 200 KiB of module sections but makes the option safe to enable on machines that enforce signatures, which could not use it before.

## Testing

A unit test asserts a signed module reaches the image byte for byte, and that an unsigned one is still stripped, so the skip is not a blanket opt-out.

An integration test boots with `strip` enabled and `module.sig_enforce=1`, which makes the kernel refuse any module whose signature went missing, the same thing a Secure Boot machine does unasked. With the fix reverted the VM never reaches userspace and the console fills with the error above.
