### PR TITLE
init: five fixes found while stress testing the integration tests

### DIFF
--- a/init/btrfs.go
+++ b/init/btrfs.go
@@ -57,30 +57,36 @@ func btrfsScanDevice(dev string) error {
 	return ioctl(controlFile.Fd(), BTRFS_IOC_SCAN_DEV, uintptr(unsafe.Pointer(args)))
 }
 
-// Wait until all devices of a multiple-device filesystem are scanned and registered within the kernel module
-func waitForBtrfsDevicesReady(dev string) error {
+// A variable so a test can shorten it.
+var btrfsTimeout = 10 * time.Minute
+
+// btrfsDevicesReady reports whether every member of dev's volume has been
+// registered.  Not-ready and error mean different things: the ioctl answers 1
+// while the volume is still assembling, but returns an errno when it cannot
+// scan dev at all, which waiting will not fix.
+var btrfsDevicesReady = func(dev string) (bool, error) {
 	controlFile, args, err := openBtrfsControl(dev)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer controlFile.Close()
 
-	/* these three should all be uintptr */
-	ioctlFd := controlFile.Fd()
-	BTRFS_IOC_DEVICES_READY := ior(BTRFS_IOCTL_MAGIC, BTRFS_IOCTL_NR_DEVICES_READY, unsafe.Sizeof(*args))
-	ptrBtrfsIoctlVolArgs := uintptr(unsafe.Pointer(args))
+	cmd := ior(BTRFS_IOCTL_MAGIC, BTRFS_IOCTL_NR_DEVICES_READY, unsafe.Sizeof(*args))
+	return ioctlCheckZero(controlFile.Fd(), cmd, uintptr(unsafe.Pointer(args)))
+}
 
+// Wait until all devices of a multiple-device filesystem are scanned and registered within the kernel module
+func waitForBtrfsDevicesReady(dev string) error {
 	/* prepare to wait */
-	const btrfsTimeout time.Duration = 10 * time.Minute
 	timeNow := time.Now()
 	timeStart := timeNow
 	timeEnd := timeStart.Add(btrfsTimeout)
 
 	/* actually wait */
 	for timeNow.Before(timeEnd) {
-		ready, err := ioctlCheckZero(ioctlFd, BTRFS_IOC_DEVICES_READY, ptrBtrfsIoctlVolArgs)
+		ready, err := btrfsDevicesReady(dev)
 		if err != nil {
-			return err
+			return fmt.Errorf("btrfs: cannot scan %v to see whether its volume is complete: %w", dev, err)
 		}
 		timeElapsed := timeNow.Sub(timeStart)
 		if ready {

--- a/init/btrfs_test.go
+++ b/init/btrfs_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestWaitForBtrfsDevicesReady(t *testing.T) {
+	orig := btrfsDevicesReady
+	t.Cleanup(func() { btrfsDevicesReady = orig })
+
+	// Short enough that a case which wrongly keeps polling fails the test
+	// rather than running for the real ten minutes.
+	origTimeout := btrfsTimeout
+	btrfsTimeout = 5 * time.Second
+	t.Cleanup(func() { btrfsTimeout = origTimeout })
+
+	t.Run("ready at once", func(t *testing.T) {
+		calls := 0
+		btrfsDevicesReady = func(string) (bool, error) { calls++; return true, nil }
+		require.NoError(t, waitForBtrfsDevicesReady("/dev/dm-0"))
+		require.Equal(t, 1, calls, "a ready volume must not be polled twice")
+	})
+
+	t.Run("assembling then ready", func(t *testing.T) {
+		calls := 0
+		btrfsDevicesReady = func(string) (bool, error) {
+			calls++
+			return calls > 2, nil
+		}
+		require.NoError(t, waitForBtrfsDevicesReady("/dev/dm-0"))
+		require.Equal(t, 3, calls)
+	})
+
+	t.Run("a scan failure is not waited out", func(t *testing.T) {
+		calls := 0
+		btrfsDevicesReady = func(string) (bool, error) {
+			calls++
+			return false, unix.ENOENT
+		}
+		err := waitForBtrfsDevicesReady("/dev/dm-0")
+		require.Error(t, err)
+		require.Equal(t, 1, calls, "the volume will not assemble by polling a device that cannot be scanned")
+		require.ErrorIs(t, err, unix.ENOENT)
+		require.Contains(t, err.Error(), "/dev/dm-0", "the message must name the device")
+	})
+
+	t.Run("errors is unwrappable through the wrapper", func(t *testing.T) {
+		btrfsDevicesReady = func(string) (bool, error) { return false, unix.ENXIO }
+		err := waitForBtrfsDevicesReady("/dev/dm-0")
+		require.True(t, errors.Is(err, unix.ENXIO))
+	})
+}

--- a/init/ioctl.go
+++ b/init/ioctl.go
@@ -51,7 +51,7 @@ func iowr(t, nr, size uintptr) uintptr {
 func ioctl(fd, cmd, ptr uintptr) error {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, cmd, ptr)
 	if errno != 0 {
-		return fmt.Errorf("ioctl(0x%x): %v", cmd, errno)
+		return fmt.Errorf("ioctl(0x%x): %w", cmd, errno)
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func ioctl(fd, cmd, ptr uintptr) error {
 func ioctlCheckZero(fd, cmd, ptr uintptr) (bool, error) {
 	ret, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, cmd, ptr)
 	if errno != 0 {
-		return false, fmt.Errorf("ioctl(0x%x): %v", cmd, errno)
+		return false, fmt.Errorf("ioctl(0x%x): %w", cmd, errno)
 	}
 	return ret == 0, nil
 }

--- a/init/luks.go
+++ b/init/luks.go
@@ -745,6 +745,9 @@ func recoverSystemdFido2Password(ctx context.Context, t luks.Token, mappingName 
 		case <-ctx.Done():
 			// serialize-mode per-token timeout (or cancel-on-win) fired
 			// while waiting for a FIDO2 device to appear — stop waiting.
+			// Logged because it is the only outward sign the goroutine
+			// honoured cancellation rather than leaking.
+			info("FIDO2 unlock for %s cancelled while waiting for a device: %v", mappingName, ctx.Err())
 			return nil, ctx.Err()
 		case <-noDeviceC:
 			// Dedup across goroutines for the same mapping (multi-FIDO2-token

--- a/init/main.go
+++ b/init/main.go
@@ -432,9 +432,12 @@ func retryPendingDevices() {
 }
 
 func setupDiskSymlinks(devpath string, blk *blkInfo, err error) error {
-	blk.wwid, err = wwid(devpath)
-	if err != nil {
-		return fmt.Errorf("%s: %v", devpath, err)
+	// hwPath below needs only sysfs, so a device whose INQUIRY fails can still
+	// be addressed by HWPATH=.  Report and carry on rather than returning.
+	var wwidErr error
+	blk.wwid, wwidErr = wwid(devpath)
+	if wwidErr != nil {
+		info("wwid %s: %v", devpath, wwidErr)
 	}
 	for _, wwid := range blk.wwid {
 		if err := diskSymlink("id", devpath, wwid); err != nil {

--- a/init/wwid.go
+++ b/init/wwid.go
@@ -79,9 +79,13 @@ func wwid(device string) ([]string, error) {
 				return nil, err
 			}
 
+			// systemd's scsi_id treats an absent unit-serial page as an empty
+			// serial rather than an error; match it so the vendor/product WWID
+			// is still emitted.
 			serial, err := dev.SerialNumber()
 			if err != nil {
-				return nil, err
+				debug("wwid %s: serial number unavailable: %v", device, err)
+				serial = ""
 			}
 
 			bus := "scsi"


### PR DESCRIPTION
Five independent init changes, all surfaced by stress testing the integration suite. They are carved out of that test-suite work so the production changes can be reviewed on their own. None alter behaviour a currently-working boot depends on: they add symlinks and logs where there were none, or recover from a condition that was being treated as fatal.

The first two are real boot failures on any device that answers a SCSI INQUIRY with a check condition, which is what qemu's scsi-hd does.

`init: keep hwpath symlinks when WWID probing fails`. A device whose SCSI identity could not be read got no /dev/disk/by-path entries either, so a root= given as HWPATH= never matched and the boot timed out. hwPath is derived purely from sysfs and cannot fail for the same reason, so the early return threw away working identifiers along with the broken one.

`init: tolerate a missing SCSI unit serial number`. An absent unit-serial VPD page was fatal for the whole device, so it produced no /dev/disk/by-id entries at all, including the vendor/product form that needs no serial. systemd's scsi_id leaves the serial empty when the page is absent, and this matches that.

The remaining three are diagnostics.

`init/luks: log when the FIDO2 wait is cancelled`. The hidraw wait returned ctx.Err() silently. That branch is where every FIDO2 unlock ends on a machine with no security key attached, so nothing outside the process could tell whether the goroutine had honoured the cancellation or simply leaked.

`init: wrap the ioctl errno so a caller can tell them apart`. Failures were formatted with %v, which renders the errno and throws it away, so no caller could distinguish one cause from another.

`init/btrfs: say which device could not be scanned, and cover both answers`. BTRFS_IOC_DEVICES_READY answers two conditions differently: a volume still assembling comes back as 1 with no error, and waiting is correct; a device the module cannot scan comes back as an errno, and no amount of waiting will change it. The second case reported "ioctl(0x90009427): no such file or directory", which names neither btrfs nor the device and reads like a missing file when the scan is what failed.

That last commit adds a unit test covering both answers. It fakes the ioctl, so it needs no VM, no root and no btrfs, and it makes the ten-minute assembly budget a variable so a case that wrongly keeps polling fails in seconds.

Verified with the integration suite, which covers the by-id and HWPATH paths directly. The HWPATH failure reproduced on every boot before the first commit and stopped after it.
