### PR TITLE
generator: resolve a library by architecture, not by name alone

### DIFF
--- a/generator/image.go
+++ b/generator/image.go
@@ -325,7 +325,9 @@ func elfSectionContent(s *elf.Section) (string, error) {
 var elfLibDir = []string{"/usr/lib", "/lib", "/usr/lib64", "/usr/lib/x86_64-linux-gnu"}
 
 // for a given library (e.g. libc.so.6) finds absolute path to the library file
-func elfPath(lib string) string {
+// loadable by an object of this class and machine. A multilib host carries the
+// same soname once per architecture, so the name alone does not identify a file.
+func elfPath(lib string, class elf.Class, machine elf.Machine) string {
 	if filepath.IsAbs(lib) {
 		return lib
 	}
@@ -333,11 +335,16 @@ func elfPath(lib string) string {
 	// TODO: use ef.DynString(elf.DT_RPATH) to calculate path to the loaded library
 	// or maybe we can parse /etc/ld.so.cache to get location for all libs?
 	for _, elfDir := range elfLibDir {
-		elfPath := filepath.Join(elfDir, lib)
-		if _, err := os.Stat(elfPath); err != nil {
+		p := filepath.Join(elfDir, lib)
+		candidate, err := elf.Open(p)
+		if err != nil {
 			continue
 		}
-		return elfPath
+		matches := candidate.Class == class && candidate.Machine == machine
+		candidate.Close()
+		if matches {
+			return p
+		}
 	}
 
 	return ""
@@ -359,7 +366,7 @@ func (img *Image) AppendElfDependencies(ef *elf.File) error {
 	}
 
 	for _, lib := range libs {
-		p := elfPath(lib)
+		p := elfPath(lib, ef.Class, ef.Machine)
 		if p == "" {
 			return fmt.Errorf("unable to find path to library %v", lib)
 		}

--- a/generator/image_test.go
+++ b/generator/image_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"debug/elf"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeElfStub emits a header-only ELF file. Dependency resolution reads
+// nothing past the header, so a stub of the right class and machine stands in
+// for a real shared library of that architecture.
+func writeElfStub(t *testing.T, path string, class elf.Class, machine elf.Machine) {
+	t.Helper()
+
+	var size, ehsize, phentsize, shentsize int
+	if class == elf.ELFCLASS64 {
+		size, ehsize, phentsize, shentsize = 64, 64, 56, 64
+	} else {
+		size, ehsize, phentsize, shentsize = 52, 52, 32, 40
+	}
+
+	b := make([]byte, size)
+	copy(b, "\x7fELF")
+	b[elf.EI_CLASS] = byte(class)
+	b[elf.EI_DATA] = byte(elf.ELFDATA2LSB)
+	b[elf.EI_VERSION] = byte(elf.EV_CURRENT)
+
+	binary.LittleEndian.PutUint16(b[16:], uint16(elf.ET_DYN))
+	binary.LittleEndian.PutUint16(b[18:], uint16(machine))
+	binary.LittleEndian.PutUint32(b[20:], uint32(elf.EV_CURRENT))
+	binary.LittleEndian.PutUint16(b[ehsize-12:], uint16(ehsize))
+	binary.LittleEndian.PutUint16(b[ehsize-10:], uint16(phentsize))
+	binary.LittleEndian.PutUint16(b[ehsize-6:], uint16(shentsize))
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, b, 0o755))
+}
+
+// A soname does not identify a file: on a multilib host the same name exists
+// once per architecture. Resolving it by name alone packs a library the
+// image's own loader refuses, and the failure surfaces at boot as PID 1
+// exiting 127 rather than as a build error. Both directions are pinned so
+// that reordering the search path cannot pass for a fix.
+func TestElfPathSkipsMismatchedArchitecture(t *testing.T) {
+	dir := t.TempDir()
+	lib32 := filepath.Join(dir, "lib32")
+	lib64 := filepath.Join(dir, "lib64")
+	writeElfStub(t, filepath.Join(lib32, "libfoo.so.1"), elf.ELFCLASS32, elf.EM_386)
+	writeElfStub(t, filepath.Join(lib64, "libfoo.so.1"), elf.ELFCLASS64, elf.EM_X86_64)
+
+	defer func(saved []string) { elfLibDir = saved }(elfLibDir)
+	elfLibDir = []string{lib32, lib64}
+
+	require.Equal(t, filepath.Join(lib64, "libfoo.so.1"),
+		elfPath("libfoo.so.1", elf.ELFCLASS64, elf.EM_X86_64))
+	require.Equal(t, filepath.Join(lib32, "libfoo.so.1"),
+		elfPath("libfoo.so.1", elf.ELFCLASS32, elf.EM_386))
+}
+
+// A candidate of the wrong architecture is not a fallback. Reporting no match
+// lets AppendElfDependencies fail the build, which is where an unsatisfiable
+// dependency should surface; packing it instead defers the failure to boot,
+// where it costs a kernel panic to diagnose.
+func TestElfPathReportsNoMatchRatherThanWrongArchitecture(t *testing.T) {
+	lib32 := filepath.Join(t.TempDir(), "lib32")
+	writeElfStub(t, filepath.Join(lib32, "libfoo.so.1"), elf.ELFCLASS32, elf.EM_386)
+
+	defer func(saved []string) { elfLibDir = saved }(elfLibDir)
+	elfLibDir = []string{lib32}
+
+	require.Empty(t, elfPath("libfoo.so.1", elf.ELFCLASS64, elf.EM_X86_64))
+}


### PR DESCRIPTION
See #421 

DT_NEEDED entries are resolved against a fixed directory list and the first filename hit wins, with no check that what was found is loadable by the object that asked for it. A soname does not identify a file on a multilib host, where the same name exists once per architecture.

On Fedora /usr/lib holds the 32-bit libraries and is searched ahead of /usr/lib64, so an image built there for a 64-bit init receives a 32-bit libc and no 64-bit one at all. The dynamic loader then refuses to start init and exits 127, and because that process is PID 1 the kernel panics with "Attempted to kill init! exitcode=0x00007f00". Fedora is the distro exposed to this because its spec builds init with cgo for the FIDO2 plugin, so init is dynamically linked there and the image has to carry a working libc.

elfPath now takes the requesting object's ELF class and machine and skips candidates that do not match. Reordering the search list would fix x86-64 Fedora only: it inverts on a 32-bit host and does nothing for the per-architecture directories used by multiarch layouts. A library with no matching candidate now fails the build rather than producing an image that cannot boot.

Verified two ways. On a Fedora 44 container with glibc.i686 installed the dependency walk packed the 32-bit libc, the 32-bit loader and no 64-bit libc before the change, and the correct 64-bit set after, with the image's own loader resolving init cleanly. Under QEMU with the 32-bit directory forced ahead of the 64-bit one, the boot panicked with that exitcode before the change, and after it unlocks LUKS, mounts the root filesystem and reaches switch_root. A user who hit this on Fedora 44 rebuilt with the change and confirmed the image boots.